### PR TITLE
Add CODEOWNERS for repository owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default ownership for the repository.
+# GitHub uses the last matching pattern, so keep specific overrides below if added later.
+
+* @daviburg


### PR DESCRIPTION
## Summary\n\nAdds a repository-level CODEOWNERS file assigning default ownership to @daviburg.\n\n## Why\n\nThis enables code-owner-aware review workflows now that main branch protection/rulesets are in place.\n\n## Changes\n\n- Adds .github/CODEOWNERS\n- Sets default owner for all files to @daviburg\n\n## Follow-up\n\nIf your branch ruleset should require code owner review, enable Require review from Code Owners on the main branch ruleset.