### PR TITLE
docs: add real-session import folder guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Thumbs.db
 .vscode/settings.json
 *.swp
 *~
+
+# Local import source files (real session transcripts)
+sessions/_import/

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ mkdir -p sessions/_import
 ```
 
 ```bash
-python tools/bootstrap_session.py \\
-  --session sessions/session-001 \\
+python tools/bootstrap_session.py \
+  --session sessions/session-001 \
   --file sessions/_import/session-001-full-transcript.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,24 +107,33 @@ python tools/ingest_turn.py \
   --speaker dm \
   --text "The innkeeper leans forward and whispers: 'The old tower has been sealed for twenty years. Those who enter do not return.'"
 
-
-### Bootstrapping From an Existing Transcript
-
-If you already have a large transcript, import it in one step:
-
-```bash
-python tools/bootstrap_session.py \\
-  --session sessions/session-001 \\
-  --file path/to/full-transcript.txt
-```
-
-Use `--dry-run` first to preview parsed turns and writes.
 # Add a player prompt
 python tools/ingest_turn.py \
   --session sessions/session-001 \
   --speaker player \
   --text "I ask the innkeeper if anyone has tried to investigate the tower recently."
 ```
+
+
+### Bootstrapping From an Existing Transcript
+
+If you already have a large transcript, import it in one step:
+
+Put the source text in a local-only folder that is gitignored:
+
+```bash
+mkdir -p sessions/_import
+# Place your raw transcript text at:
+# sessions/_import/session-001-full-transcript.txt
+```
+
+```bash
+python tools/bootstrap_session.py \\
+  --session sessions/session-001 \\
+  --file sessions/_import/session-001-full-transcript.txt
+```
+
+Use `--dry-run` first to preview parsed turns and writes.
 
 ### Updating State
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -65,8 +65,8 @@ mkdir -p sessions/_import
 ```
 
 ```bash
-python tools/bootstrap_session.py \\
-  --session sessions/session-001 \\
+python tools/bootstrap_session.py \
+  --session sessions/session-001 \
   --file sessions/_import/session-001-full-transcript.txt
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,10 +56,18 @@ The script will:
 
 If you already have a large transcript file, bootstrap a session in one pass:
 
+Use a local-only import folder (gitignored) for raw source text:
+
+```bash
+mkdir -p sessions/_import
+# Place your transcript at:
+# sessions/_import/session-001-full-transcript.txt
+```
+
 ```bash
 python tools/bootstrap_session.py \\
   --session sessions/session-001 \\
-  --file path/to/full-transcript.txt
+  --file sessions/_import/session-001-full-transcript.txt
 ```
 
 Useful flags:


### PR DESCRIPTION
## Summary

This PR makes real-session import setup explicit and safe for public repos.

- Adds sessions/_import/ to .gitignore for local raw transcript source files.
- Updates README bootstrap section with an exact folder and file path:
  - sessions/_import/session-001-full-transcript.txt
- Updates docs/usage.md with the same explicit placement and bootstrap command.

## Why

Users now have a clearly documented place to put real transcript text before running bootstrap, without accidentally committing source transcripts.