### PR TITLE
docs: update documentation for semantic extraction pipeline

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -193,6 +193,6 @@ After each DM turn:
 1. Append the turn to `sessions/*/raw/full-transcript.md`
 2. Create a new `sessions/*/transcript/turn-NNN-dm.md`
 3. Run `python tools/update_state.py` or ask Copilot to update derived files
-4. If LLM is configured, run `python tools/ingest_turn.py --extract` to auto-populate catalogs (or `bootstrap_session.py` for batch)
+4. If LLM is configured, pass `--extract` when ingesting turns with `ingest_turn.py` to auto-populate catalogs (or use `bootstrap_session.py` for batch import)
 5. Run `python tools/analyze_next_move.py` or ask Copilot to generate analysis
 6. Review `derived/next-move-analysis.md` and `derived/prompt-candidates.json`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,6 +79,9 @@ When generating `derived/prompt-candidates.json`:
 | `framework/dm-profile/dm-profile.json` | Inferred DM behavior profile | Yes |
 | `framework/story/summary.md` | High-level story arc | Yes |
 | `schemas/*.schema.json` | JSON schemas | No |
+| `config/llm.json` | LLM provider/model configuration | Yes |
+| `templates/extraction/*.md` | LLM prompt templates for semantic extraction | Yes |
+| `requirements-llm.txt` | Optional LLM dependencies | Yes |
 
 ---
 
@@ -190,5 +193,6 @@ After each DM turn:
 1. Append the turn to `sessions/*/raw/full-transcript.md`
 2. Create a new `sessions/*/transcript/turn-NNN-dm.md`
 3. Run `python tools/update_state.py` or ask Copilot to update derived files
-4. Run `python tools/analyze_next_move.py` or ask Copilot to generate analysis
-5. Review `derived/next-move-analysis.md` and `derived/prompt-candidates.json`
+4. If LLM is configured, run `python tools/ingest_turn.py --extract` to auto-populate catalogs (or `bootstrap_session.py` for batch)
+5. Run `python tools/analyze_next_move.py` or ask Copilot to generate analysis
+6. Review `derived/next-move-analysis.md` and `derived/prompt-candidates.json`

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ examples/
 
 ### Prerequisites
 
-- Python 3.9+
+- Python 3.10+
 - No external dependencies required for core tools
 - **Optional** — for LLM-based semantic extraction: `pip install -r requirements-llm.txt`
   - Works with OpenAI API or any OpenAI-compatible endpoint (e.g. Ollama)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ docs/
   architecture.md
   usage.md
 
+config/
+  llm.json                     # LLM provider settings (model, endpoint)
+
 schemas/
   turn.schema.json
   entity.schema.json
@@ -76,12 +79,22 @@ sessions/
       next-move-analysis.md
       prompt-candidates.json
 
+templates/
+  extraction/
+    entity-discovery.md          # LLM prompt templates for semantic extraction
+    entity-detail.md
+    relationship-mapper.md
+    event-extractor.md
+
 tools/
   bootstrap_session.py
   ingest_turn.py
   update_state.py
   analyze_next_move.py
   validate.py
+  semantic_extraction.py         # LLM-based entity/relationship/event extraction
+  catalog_merger.py              # Merge extracted data into framework catalogs
+  llm_client.py                  # Provider-agnostic LLM client wrapper
 
 examples/
   demo-session/
@@ -95,6 +108,9 @@ examples/
 
 - Python 3.9+
 - No external dependencies required for core tools
+- **Optional** — for LLM-based semantic extraction: `pip install -r requirements-llm.txt`
+  - Works with OpenAI API or any OpenAI-compatible endpoint (e.g. Ollama)
+  - Configure provider/model in `config/llm.json`
 
 ### Ingesting a Turn
 
@@ -148,12 +164,21 @@ Current automated behavior:
 - Creates scaffold files if missing: `state.json`, `objectives.json`, `evidence.json`
 - Updates only `state.json.as_of_turn`
 
-Not automated yet:
-- Framework catalog updates (`framework/catalogs/*.json`)
-- Framework story updates (`framework/story/*`)
-- Framework DM profile updates (`framework/dm-profile/dm-profile.json`)
+### Semantic Extraction (Optional)
 
-Those updates are currently manual/Copilot-assisted.
+If an LLM is configured (`config/llm.json`), `bootstrap_session.py` automatically runs semantic extraction across all turns to populate `framework/catalogs/` with entities, relationships, and events.
+
+For incremental ingestion, pass `--extract` to `ingest_turn.py`:
+
+```bash
+python tools/ingest_turn.py \
+  --session sessions/session-001 \
+  --speaker dm \
+  --text "..." \
+  --extract
+```
+
+See [`docs/semantic-extraction-design.md`](docs/semantic-extraction-design.md) for pipeline details.
 
 ### Generating Next-Move Analysis
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,7 +127,7 @@ All data structures are defined in `schemas/`. See each schema file for field de
 |---|---|
 | `tools/bootstrap_session.py` | Import an existing transcript into a session |
 | `tools/ingest_turn.py` | Add a new turn to a session |
-| `tools/update_state.py` | Update catalogs, objectives, evidence, and summaries |
+| `tools/update_state.py` | Regenerate session-local derived scaffolds, turn summaries, and structured extraction outputs |
 | `tools/analyze_next_move.py` | Generate next-move analysis and prompt candidates |
 | `tools/validate.py` | Validate all JSON files against schemas |
 | `tools/semantic_extraction.py` | LLM-based entity/relationship/event extraction pipeline |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,16 +21,18 @@ DM response text
 sessions/*/raw/full-transcript.md        (immutable append)
 sessions/*/transcript/turn-NNN-dm.md     (immutable append)
       |
-      v
-tools/update_state.py
-      |
-      +---> framework/catalogs/           (characters, locations, factions, items, plot-threads)
-      +---> framework/objectives/         (objectives.json)
-      +---> framework/dm-profile/         (dm-profile.json)
-      +---> framework/story/              (summary.md, world-state.md)
-      +---> sessions/*/derived/state.json
-      +---> sessions/*/derived/objectives.json
-      +---> sessions/*/derived/evidence.json
+      +------------------------------------------+
+      |                                          |
+      v                                          v
+tools/update_state.py                  tools/semantic_extraction.py  (optional, LLM)
+      |                                          |
+      +---> sessions/*/derived/state.json        +---> framework/catalogs/characters.json
+      +---> sessions/*/derived/objectives.json   +---> framework/catalogs/locations.json
+      +---> sessions/*/derived/evidence.json     +---> framework/catalogs/factions.json
+      +---> sessions/*/derived/turn-summary.md   +---> framework/catalogs/items.json
+      |                                          +---> framework/catalogs/events.json
+      v                                          |
+      +------------------------------------------+
       |
       v
 tools/analyze_next_move.py
@@ -38,6 +40,10 @@ tools/analyze_next_move.py
       +---> sessions/*/derived/next-move-analysis.md
       +---> sessions/*/derived/prompt-candidates.json
 ```
+
+Semantic extraction is triggered automatically during `bootstrap_session.py` (batch)
+or via the `--extract` flag on `ingest_turn.py` (incremental). It requires an LLM
+endpoint configured in `config/llm.json` and gracefully degrades if unavailable.
 
 ---
 
@@ -82,6 +88,20 @@ A running profile of inferred DM behavior patterns.
 - Includes tone, structure, hint patterns, adversarial level, and formatting preferences
 - All entries include confidence scores
 
+### Semantic Extraction Layer (Optional, LLM-based)
+
+An automated pipeline that uses an LLM to extract structured data from transcript turns.
+
+- **Four-agent pipeline**: Entity Discovery → Entity Detail → Relationship Mapper → Event Extractor
+- Prompt templates in `templates/extraction/` define each agent's behavior
+- `tools/semantic_extraction.py` orchestrates the pipeline
+- `tools/catalog_merger.py` merges agent outputs into `framework/catalogs/`
+- `tools/llm_client.py` provides a provider-agnostic LLM wrapper (OpenAI, Ollama, etc.)
+- `config/llm.json` configures the LLM provider, model, and endpoint
+- All extracted entities are validated against `schemas/entity.schema.json` before merging
+- Entities below a confidence threshold are logged but not cataloged
+- Batch mode checkpoints progress every 50 turns for resume after interruption
+
 ---
 
 ## Schemas
@@ -105,10 +125,14 @@ All data structures are defined in `schemas/`. See each schema file for field de
 
 | Script | Purpose |
 |---|---|
+| `tools/bootstrap_session.py` | Import an existing transcript into a session |
 | `tools/ingest_turn.py` | Add a new turn to a session |
 | `tools/update_state.py` | Update catalogs, objectives, evidence, and summaries |
 | `tools/analyze_next_move.py` | Generate next-move analysis and prompt candidates |
 | `tools/validate.py` | Validate all JSON files against schemas |
+| `tools/semantic_extraction.py` | LLM-based entity/relationship/event extraction pipeline |
+| `tools/catalog_merger.py` | Merge extracted entities into framework catalog files |
+| `tools/llm_client.py` | Provider-agnostic LLM client (OpenAI, Ollama, etc.) |
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,8 @@ The primary workflow is a single user running the repo locally in VS Code with G
 - GitHub issues assignable to Copilot for async tasks
 
 **Limitations at this phase:**
-- State extraction (catalogs, evidence, objectives) requires Copilot assistance; it is not fully automated
+- State extraction (evidence, objectives, DM profile) requires Copilot assistance; it is not fully automated
+- Entity/relationship/event extraction is automated via LLM (see Phase 2 progress below) but other state updates remain manual
 - Single-user, single-session workflow
 - No automated pipeline between tool steps
 
@@ -28,14 +29,16 @@ The primary workflow is a single user running the repo locally in VS Code with G
 
 Divide session processing across multiple specialized agents, each with a focused scope:
 
-| Agent | Responsibility |
-|---|---|
-| Ingestion agent | Parse raw turns, write transcript files, update full-transcript.md |
-| Catalog agent | Extract and maintain entities, locations, factions, items |
-| Evidence agent | Tag and classify claims; maintain evidence.json |
-| Strategy agent | Generate next-move analysis; apply heuristics and risk model |
-| Prompt agent | Generate candidate player prompts optimized per mode |
-| DM profile agent | Infer and refine DM behavior from accumulated evidence |
+| Agent | Responsibility | Status |
+|---|---|---|
+| Ingestion agent | Parse raw turns, write transcript files, update full-transcript.md | — |
+| Catalog agent | Extract and maintain entities, locations, factions, items | **Implemented** (#43) |
+| Evidence agent | Tag and classify claims; maintain evidence.json | — |
+| Strategy agent | Generate next-move analysis; apply heuristics and risk model | — |
+| Prompt agent | Generate candidate player prompts optimized per mode | — |
+| DM profile agent | Infer and refine DM behavior from accumulated evidence | — |
+
+The **Catalog agent** is implemented as `tools/semantic_extraction.py` — a four-agent LLM pipeline (Entity Discovery → Entity Detail → Relationship Mapper → Event Extractor) that runs during bootstrap and incremental ingestion. It uses prompt templates in `templates/extraction/` and a provider-agnostic LLM client (`tools/llm_client.py`) supporting OpenAI and Ollama.
 
 Benefits:
 - Narrower per-agent context window → lower token cost
@@ -52,6 +55,8 @@ Goals:
 - Token-free (no cloud cost per session turn)
 - Offline-capable (no internet dependency during play)
 - Faster turnaround for frequent small-context tasks (catalog updates, summary refreshes)
+
+The semantic extraction pipeline (#43) already supports local models via Ollama (tested with `qwen2.5:3b`). The `config/llm.json` design decouples the pipeline from any specific provider.
 
 Design implications for earlier phases:
 - Keep context loading modular (catalog-first) so small local models can handle targeted tasks

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,7 +4,7 @@
 
 ### Prerequisites
 
-- Python 3.9+
+- Python 3.10+
 - No external Python packages required for core tools
 - **Optional** — for LLM-based semantic extraction:
   - `pip install -r requirements-llm.txt`
@@ -142,8 +142,7 @@ The semantic extraction pipeline uses an LLM to automatically extract entities, 
    {
      "provider": "ollama",
      "model": "qwen2.5:3b",
-     "base_url": "http://localhost:11434/v1",
-     "api_key_env": "OLLAMA_API_KEY"
+     "base_url": "http://localhost:11434/v1"
    }
    ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,6 +6,10 @@
 
 - Python 3.9+
 - No external Python packages required for core tools
+- **Optional** — for LLM-based semantic extraction:
+  - `pip install -r requirements-llm.txt`
+  - An OpenAI-compatible LLM endpoint (OpenAI API, Ollama, etc.)
+  - Configure `config/llm.json` with provider, model, and endpoint
 
 ### Creating a New Session
 
@@ -52,6 +56,16 @@ The script will:
 - Create `sessions/session-001/transcript/turn-NNN-{speaker}.md`
 - Append to `sessions/session-001/raw/full-transcript.md`
 
+To also run LLM-based semantic extraction on the new turn:
+
+```bash
+python tools/ingest_turn.py \
+  --session sessions/session-001 \
+  --speaker dm \
+  --text "..." \
+  --extract
+```
+
 ### Bootstrapping an Existing Transcript
 
 If you already have a large transcript file, bootstrap a session in one pass:
@@ -94,11 +108,76 @@ This regenerates:
 Current `update_state.py` behavior is intentionally limited to session-local derived files.
 
 It does **not** currently update:
-- `framework/catalogs/*.json`
 - `framework/story/*`
 - `framework/dm-profile/dm-profile.json`
 
 Those updates are currently manual/Copilot-assisted.
+
+For automated catalog updates, see Semantic Extraction below.
+
+---
+
+## Semantic Extraction (Optional)
+
+The semantic extraction pipeline uses an LLM to automatically extract entities, relationships, and events from transcript turns and merge them into `framework/catalogs/`.
+
+### Setup
+
+1. Install the optional LLM dependency:
+   ```bash
+   pip install -r requirements-llm.txt
+   ```
+
+2. Configure `config/llm.json`:
+   ```json
+   {
+     "provider": "openai",
+     "model": "gpt-4o",
+     "api_key_env": "OPENAI_API_KEY"
+   }
+   ```
+
+   For a local Ollama instance:
+   ```json
+   {
+     "provider": "ollama",
+     "model": "qwen2.5:3b",
+     "base_url": "http://localhost:11434/v1",
+     "api_key_env": "OLLAMA_API_KEY"
+   }
+   ```
+
+### Batch Mode (Bootstrap)
+
+When bootstrapping a session, semantic extraction runs automatically over all turns if the LLM is configured:
+
+```bash
+python tools/bootstrap_session.py \
+  --session sessions/session-001 \
+  --file sessions/_import/session-001-full-transcript.txt
+```
+
+The pipeline processes each turn through four agents:
+1. **Entity Discovery** — identify entities mentioned in the turn
+2. **Entity Detail Extractor** — extract/update attributes per entity
+3. **Relationship Mapper** — identify cross-entity relationships
+4. **Event Extractor** — identify narrative events
+
+Progress is checkpointed every 50 turns and can resume after interruption.
+
+### Incremental Mode (Ingest)
+
+Pass `--extract` to `ingest_turn.py` to run semantic extraction on a single new turn:
+
+```bash
+python tools/ingest_turn.py \
+  --session sessions/session-001 \
+  --speaker dm \
+  --text "The elder reveals that the crystal was shattered decades ago." \
+  --extract
+```
+
+See [`docs/semantic-extraction-design.md`](semantic-extraction-design.md) for full pipeline design.
 
 ---
 


### PR DESCRIPTION
## Summary

Updates all user-facing documentation to reflect the semantic extraction pipeline implemented in PR #45 (issue #43).

## Changes

### README.md
- Added `config/llm.json`, `templates/extraction/`, `tools/semantic_extraction.py`, `tools/catalog_merger.py`, `tools/llm_client.py` to repository structure
- Added optional LLM dependencies to prerequisites
- Added Semantic Extraction section with `--extract` flag usage
- Removed "not automated yet" for catalog updates (now automated via LLM)

### docs/usage.md
- Added LLM setup prerequisites (OpenAI/Ollama configuration)
- Added `--extract` flag to ingestion examples
- Added full Semantic Extraction section covering setup, batch mode, incremental mode, and the four-agent pipeline

### docs/architecture.md
- Updated data flow diagram to show the semantic extraction path alongside `update_state.py`
- Added Semantic Extraction Layer section describing the four-agent pipeline, validation, and checkpointing
- Updated tool scripts table with `semantic_extraction.py`, `catalog_merger.py`, `llm_client.py`

### docs/roadmap.md
- Updated Phase 1 limitations (catalogs now partially automated)
- Added Status column to Phase 2 agent table; marked Catalog agent as **Implemented** (#43)
- Updated Phase 3 to note Ollama/local model support already works

### .github/copilot-instructions.md
- Added `config/llm.json`, `templates/extraction/*.md`, `requirements-llm.txt` to File Conventions table
- Added semantic extraction step (step 4) to Workflow Reminder
