### PR TITLE
feat: separate story content from engine to prevent leaks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Pre-commit hook: prevent accidental commits of private story content.
+#
+# Blocks commits that include files from private session directories or
+# framework catalog files that have grown beyond their empty-template state.
+#
+# Install: git config core.hooksPath .githooks
+
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+blocked=0
+
+# 1. Check for private session files being staged
+private_sessions=$(git diff --cached --name-only | grep -E '^sessions/(session-import|test-)/')
+if [ -n "$private_sessions" ]; then
+    echo "${RED}BLOCKED:${NC} Private session files staged for commit:"
+    echo "$private_sessions" | head -20
+    blocked=1
+fi
+
+# 2. Check for framework catalog files that are no longer empty templates
+for f in framework/catalogs/characters.json \
+         framework/catalogs/locations.json \
+         framework/catalogs/factions.json \
+         framework/catalogs/items.json \
+         framework/catalogs/events.json \
+         framework/catalogs/plot-threads.json \
+         framework/catalogs/anomalies.json; do
+    if git diff --cached --name-only | grep -qF "$f"; then
+        # File is staged — check if it still looks like an empty template
+        staged_content=$(git show ":$f" 2>/dev/null)
+        if [ -n "$staged_content" ]; then
+            trimmed=$(echo "$staged_content" | tr -d '[:space:]')
+            if [ "$trimmed" != "[]" ] && [ "$trimmed" != "[" ]; then
+                echo "${RED}BLOCKED:${NC} $f contains story data (not empty template)."
+                blocked=1
+            fi
+        fi
+    fi
+done
+
+# 3. Check for framework story/dm-profile changes with real content
+for f in framework/story/summary.md framework/story/world-state.md framework/dm-profile/dm-profile.json; do
+    if git diff --cached --name-only | grep -qF "$f"; then
+        diff_size=$(git diff --cached -- "$f" | wc -l)
+        if [ "$diff_size" -gt 10 ]; then
+            echo "${RED}BLOCKED:${NC} $f has significant changes — review for story content."
+            blocked=1
+        fi
+    fi
+done
+
+if [ "$blocked" -eq 1 ]; then
+    echo ""
+    echo "To bypass this check (if intentional): git commit --no-verify"
+    echo "To unstage private files: git reset HEAD <file>"
+    exit 1
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,15 +6,12 @@
 #
 # Install: git config core.hooksPath .githooks
 
-RED='\033[0;31m'
-NC='\033[0m' # No Color
-
 blocked=0
 
 # 1. Check for private session files being staged
-private_sessions=$(git diff --cached --name-only | grep -E '^sessions/(session-import|test-)/')
+private_sessions=$(git diff --cached --name-only | grep -E '^sessions/(session-import|test-[^/]+)/')
 if [ -n "$private_sessions" ]; then
-    echo "${RED}BLOCKED:${NC} Private session files staged for commit:"
+    printf '\033[0;31mBLOCKED:\033[0m Private session files staged for commit:\n'
     echo "$private_sessions" | head -20
     blocked=1
 fi
@@ -32,8 +29,8 @@ for f in framework/catalogs/characters.json \
         staged_content=$(git show ":$f" 2>/dev/null)
         if [ -n "$staged_content" ]; then
             trimmed=$(echo "$staged_content" | tr -d '[:space:]')
-            if [ "$trimmed" != "[]" ] && [ "$trimmed" != "[" ]; then
-                echo "${RED}BLOCKED:${NC} $f contains story data (not empty template)."
+            if [ "$trimmed" != "[]" ]; then
+                printf '\033[0;31mBLOCKED:\033[0m %s contains story data (not empty template).\n' "$f"
                 blocked=1
             fi
         fi
@@ -45,7 +42,7 @@ for f in framework/story/summary.md framework/story/world-state.md framework/dm-
     if git diff --cached --name-only | grep -qF "$f"; then
         diff_size=$(git diff --cached -- "$f" | wc -l)
         if [ "$diff_size" -gt 10 ]; then
-            echo "${RED}BLOCKED:${NC} $f has significant changes — review for story content."
+            printf '\033[0;31mBLOCKED:\033[0m %s has significant changes — review for story content.\n' "$f"
             blocked=1
         fi
     fi

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,13 @@ Thumbs.db
 
 # Local import source files (real session transcripts)
 sessions/_import/
+
+# Private session data — keep examples/demo-session/ and sessions/session-001/
+# (the public example) tracked; everything else is local-only.
+sessions/session-import/
+sessions/test-*/
+
+# Local framework overrides produced by extraction runs.
+# The empty templates in framework/ stay tracked; if you run extraction
+# with --framework pointed elsewhere, those outputs land here instead.
+framework-local/

--- a/tools/bootstrap_session.py
+++ b/tools/bootstrap_session.py
@@ -436,6 +436,13 @@ def main() -> None:
         help="Convert smart quotes and em-dashes in imported transcript content "
              "to ASCII equivalents.",
     )
+    parser.add_argument(
+        "--framework",
+        default="framework",
+        help="Path to the framework directory for catalog output "
+             "(default: framework). Use e.g. 'framework-local' to keep "
+             "extraction output out of the public repo.",
+    )
     args = parser.parse_args()
 
     # Validate inputs
@@ -591,7 +598,7 @@ def main() -> None:
 
         print("\nRunning semantic extraction:")
         extract_semantic_batch(
-            turn_dicts, session_dir, framework_dir="framework", dry_run=args.dry_run
+            turn_dicts, session_dir, framework_dir=args.framework, dry_run=args.dry_run
         )
     except ModuleNotFoundError as exc:
         if exc.name == "semantic_extraction":

--- a/tools/ingest_turn.py
+++ b/tools/ingest_turn.py
@@ -88,6 +88,13 @@ def main() -> None:
         default=False,
         help="Run LLM-based semantic extraction after ingesting the turn.",
     )
+    parser.add_argument(
+        "--framework",
+        default="framework",
+        help="Path to the framework directory for catalog output "
+             "(default: framework). Use e.g. 'framework-local' to keep "
+             "extraction output out of the public repo.",
+    )
     args = parser.parse_args()
 
     session_dir = args.session
@@ -144,7 +151,7 @@ def main() -> None:
             from semantic_extraction import extract_semantic_single
 
             extract_semantic_single(
-                turn_id, args.speaker, text, session_dir, framework_dir="framework"
+                turn_id, args.speaker, text, session_dir, framework_dir=args.framework
             )
         except ModuleNotFoundError as exc:
             if exc.name == "semantic_extraction":


### PR DESCRIPTION
## Summary

Adds three layers of protection to cleanly separate private story/session content from the public engine code, so extraction testing can run locally without risk of leaking narrative data to the repo.

## Changes

### 1. `.gitignore` — block private session directories

- `sessions/session-import/` and `sessions/test-*/` are now ignored
- `framework-local/` is ignored as a target for redirected extraction output
- Public example data (`sessions/session-001/`, `examples/demo-session/`) remains tracked

### 2. `.githooks/pre-commit` — safety net hook

A pre-commit hook that blocks commits containing:
- Files from private session directories (`session-import/`, `test-*/`)
- Framework catalog files that have grown beyond their empty-template state (indicating story entity data)
- Significant changes to `framework/story/` or `framework/dm-profile/` (indicating story content)

Activated via `core.hooksPath=.githooks` (already configured locally; cloners can run `git config core.hooksPath .githooks` to enable).

Bypassable with `git commit --no-verify` when intentional.

### 3. `--framework` CLI flag on `bootstrap_session.py` and `ingest_turn.py`

Both tools now accept `--framework <path>` (default: `framework`) to redirect catalog output to a different directory. Usage:

```
python tools/bootstrap_session.py \
    --session sessions/session-import \
    --file sessions/_import/ImportSession.txt \
    --framework framework-local
```

This writes extracted entities to `framework-local/catalogs/` (gitignored) instead of `framework/catalogs/` (tracked).
