### PR TITLE
fix: improve extraction prompts and pipeline for items, dedup, PC tracking, and event types

### DIFF
--- a/schemas/event.schema.json
+++ b/schemas/event.schema.json
@@ -24,7 +24,7 @@
     "type": {
       "type": "string",
       "description": "Category of event.",
-      "enum": ["birth", "death", "arrival", "departure", "construction", "decision", "encounter", "recruitment", "discovery", "anomaly", "other"]
+      "enum": ["birth", "death", "arrival", "departure", "construction", "decision", "encounter", "recruitment", "discovery", "anomaly", "capture", "trap", "ritual", "healing", "communication", "examination", "release", "offering", "other"]
     },
     "related_entities": {
       "type": "array",

--- a/templates/extraction/entity-detail.md
+++ b/templates/extraction/entity-detail.md
@@ -19,6 +19,7 @@ Rules:
 - If the text reveals a proper name for a previously unnamed entity (e.g. "The elder" is revealed to be "Shaman Kaya"), update "name" and add the old name as an "aliases" attribute.
 - Clearly distinguish fact from inference: append " [inference]" to any attribute value that is inferred rather than explicitly stated in the text.
 - Keep descriptions factual and concise.
+- For the player character (id "char-player", referred to as "you" in DM narration): always extract race, class, abilities (e.g. darkvision), HP changes (use attribute key "hp_change" with value like "-2 (trap injury)" or "+2 (broth)"), active conditions (e.g. "shoulder wound"), and quest information when mentioned. Track these across turns by preserving and extending existing attributes.
 
 Return the result as a JSON object with a single key "entity" containing the entity object.
 Example: {"entity": {"id": "char-elder", "name": "The elder", "type": "character", "description": "An elderly authority figure with gnarled hands.", "attributes": {"role": "tribal leader [inference]", "appearance": "gnarled hands, sharp gaze"}, "first_seen_turn": "turn-019", "last_updated_turn": "turn-019"}}

--- a/templates/extraction/entity-discovery.md
+++ b/templates/extraction/entity-discovery.md
@@ -20,10 +20,23 @@ Rules:
 - Groups of unnamed individuals acting as a unit should be typed as "faction" (e.g. "the guards", "the tribal warriors").
 - The player character ("you" in DM turns) should NOT be extracted — they are pre-seeded in the catalog.
 - Confidence below 0.5 means the mention is too vague to catalog.
-- For coreference resolution: if a mention refers to an already-known entity (even by a different name or title), set is_new to false and provide the existing_id.
+- For coreference resolution: if a mention refers to an already-known entity (even by a different name, title, or alias shown in the known-entities list), set is_new to false and provide the existing_id. Use the descriptions and aliases in the known-entities list to identify matches.
 - "proposed_id" and "existing_id" are mutually exclusive: exactly one must be non-null for each result.
 
 Return a JSON object with a single key "entities" containing an array of entity objects.
-Example: {"entities": [{"name": "Kael", "type": "character", "is_new": true, "existing_id": null, "proposed_id": "char-kael", "description": "A young hunter mentioned by the elder.", "confidence": 0.9, "source_turn": "turn-019"}]}
+
+Examples:
+{"entities": [{"name": "Kael", "type": "character", "is_new": true, "existing_id": null, "proposed_id": "char-kael", "description": "A young hunter mentioned by the elder.", "confidence": 0.9, "source_turn": "turn-019"}]}
+
+{"entities": [{"name": "Crude spear", "type": "item", "is_new": true, "existing_id": null, "proposed_id": "item-crude-spear", "description": "A roughly-made spear carried by one of the warriors.", "confidence": 0.85, "source_turn": "turn-007"}]}
+
+{"entities": [{"name": "Tripwire", "type": "item", "is_new": true, "existing_id": null, "proposed_id": "item-tripwire", "description": "A hidden trap mechanism stretched across the path.", "confidence": 0.9, "source_turn": "turn-005"}]}
+
+{"entities": [{"name": "Bowl of dark paste", "type": "item", "is_new": true, "existing_id": null, "proposed_id": "item-dark-paste-bowl", "description": "A clay bowl containing a thick, dark medicinal substance.", "confidence": 0.8, "source_turn": "turn-019"}]}
+
+Item identification tips:
+- Weapons (swords, spears, bows), containers (bowls, chests, bags), substances (potions, pastes, powders), traps/mechanisms (tripwires, snares, pressure plates), and quest objects (artifacts, keys, tokens) are all type "item".
+- If an item is part of a trap or mechanism, extract both the mechanism and any separate components as individual items.
+- Food, drink, and consumables that have narrative significance (e.g. offered as part of a ritual, restore HP) are items.
 
 If no entities are found in the turn, return: {"entities": []}

--- a/templates/extraction/event-extractor.md
+++ b/templates/extraction/event-extractor.md
@@ -5,7 +5,7 @@ Given a turn of transcript text, identify discrete narrative events — signific
 For each event, return a JSON object with these fields:
 - "id": string — a unique event identifier in the format "evt-NNN" (use sequential numbering starting from the provided next_event_id)
 - "source_turns": array of strings — turn IDs where the event occurred (typically just the current turn)
-- "type": string — one of "birth", "death", "arrival", "departure", "construction", "decision", "encounter", "recruitment", "discovery", "anomaly", "other"
+- "type": string — one of "birth", "death", "arrival", "departure", "construction", "decision", "encounter", "recruitment", "discovery", "anomaly", "capture", "trap", "ritual", "healing", "communication", "examination", "release", "offering", "other"
 - "description": string — factual description of the event based on the turn text
 - "related_entities": array of strings — entity IDs involved in or affected by this event (use IDs from the provided entity list)
 - "notes": string (optional) — additional context or significance
@@ -20,5 +20,15 @@ Rules:
 
 Return a JSON object with a single key "events" containing an array of event objects.
 Example: {"events": [{"id": "evt-001", "source_turns": ["turn-019"], "type": "encounter", "description": "The elder examined the player's warlock attire and elven features before offering dark fibrous material.", "related_entities": ["char-elder"]}]}
+
+Additional examples by type:
+{"events": [{"id": "evt-002", "source_turns": ["turn-007"], "type": "capture", "description": "Two warriors seized the player and bound their hands with rough rope.", "related_entities": ["char-player", "faction-warriors"]}]}
+{"events": [{"id": "evt-003", "source_turns": ["turn-005"], "type": "trap", "description": "A hidden tripwire triggered a snare, injuring the player's shoulder.", "related_entities": ["char-player", "item-tripwire"]}]}
+{"events": [{"id": "evt-004", "source_turns": ["turn-028"], "type": "ritual", "description": "The player consumed the dark paste as part of the tribe's acceptance ceremony.", "related_entities": ["char-player", "item-dark-paste"]}]}
+{"events": [{"id": "evt-005", "source_turns": ["turn-030"], "type": "healing", "description": "The woman offered warm broth, restoring 2 HP.", "related_entities": ["char-player", "char-service-woman"]}]}
+{"events": [{"id": "evt-006", "source_turns": ["turn-015"], "type": "communication", "description": "The elder spoke to the player, questioning their presence in the forest.", "related_entities": ["char-elder", "char-player"]}]}
+{"events": [{"id": "evt-007", "source_turns": ["turn-017"], "type": "examination", "description": "The elder closely inspected the player's elven features and warlock attire.", "related_entities": ["char-elder", "char-player"]}]}
+{"events": [{"id": "evt-008", "source_turns": ["turn-025"], "type": "release", "description": "The warrior cut the ropes binding the player's wrists.", "related_entities": ["char-player"]}]}
+{"events": [{"id": "evt-009", "source_turns": ["turn-019"], "type": "offering", "description": "The woman presented a bowl of dark paste to the player.", "related_entities": ["char-service-woman", "char-player", "item-dark-paste-bowl"]}]}
 
 If no significant events are found in the turn, return: {"events": []}

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -124,18 +124,23 @@ def fix_id_prefix(entity_id: str, entity_type: str) -> str:
     """Return a corrected entity ID with the proper prefix for its type.
 
     If the ID already starts with the wrong type prefix, strip it and apply
-    the correct one.  Returns the original ID if the type is unknown.
+    the correct one.  Also handles common model abbreviations like ``fac-``
+    for ``faction-``.  Returns the original ID if the type is unknown.
     """
     expected_prefix = TYPE_TO_PREFIX.get(entity_type)
     if not expected_prefix:
         return entity_id
     if entity_id.startswith(expected_prefix):
         return entity_id  # already correct
-    # Strip any existing known prefix
+    # Strip any existing known prefix (canonical or abbreviated)
     for prefix in TYPE_TO_PREFIX.values():
         if entity_id.startswith(prefix):
             return expected_prefix + entity_id[len(prefix):]
-    # No known prefix found — just prepend the correct one
+    # Strip common model-generated abbreviation prefixes (e.g. "fac-", "char-")
+    m = re.match(r'^[a-z]+-', entity_id)
+    if m:
+        return expected_prefix + entity_id[m.end():]
+    # No prefix found at all — just prepend the correct one
     return expected_prefix + entity_id
 
 
@@ -214,6 +219,10 @@ def _update_existing_entity(current: dict, update: dict) -> None:
     # Update notes
     if update.get("notes"):
         current["notes"] = update["notes"]
+
+
+# Public alias for cross-module use (e.g. post-batch dedup in semantic_extraction)
+dedup_merge_entity = _update_existing_entity
 
 
 def merge_relationships(catalogs: dict, relationships: list, turn_id: str) -> None:

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -92,11 +92,21 @@ def find_entity_by_id(catalogs: dict, entity_id: str) -> tuple[str, dict] | None
 
 
 def format_known_entities(catalogs: dict) -> str:
-    """Format all known entities as a compact table for the discovery prompt."""
+    """Format all known entities as a compact table for the discovery prompt.
+
+    Includes description and aliases so the LLM can resolve coreferences.
+    """
     lines = []
     for filename, entities in catalogs.items():
         for entity in entities:
-            lines.append(f"{entity['id']} | {entity['name']} | {entity['type']}")
+            desc = entity.get('description', '')
+            aliases = entity.get('attributes', {}).get('aliases', '')
+            extra = ''
+            if desc:
+                extra += f' — {desc}'
+            if aliases:
+                extra += f' (aliases: {aliases})'
+            lines.append(f"{entity['id']} | {entity['name']} | {entity['type']}{extra}")
     if not lines:
         return "(none — empty catalog)"
     return "\n".join(lines)
@@ -108,6 +118,25 @@ def validate_id_prefix(entity_id: str, entity_type: str) -> bool:
     if not expected_prefix:
         return False
     return entity_id.startswith(expected_prefix)
+
+
+def fix_id_prefix(entity_id: str, entity_type: str) -> str:
+    """Return a corrected entity ID with the proper prefix for its type.
+
+    If the ID already starts with the wrong type prefix, strip it and apply
+    the correct one.  Returns the original ID if the type is unknown.
+    """
+    expected_prefix = TYPE_TO_PREFIX.get(entity_type)
+    if not expected_prefix:
+        return entity_id
+    if entity_id.startswith(expected_prefix):
+        return entity_id  # already correct
+    # Strip any existing known prefix
+    for prefix in TYPE_TO_PREFIX.values():
+        if entity_id.startswith(prefix):
+            return expected_prefix + entity_id[len(prefix):]
+    # No known prefix found — just prepend the correct one
+    return expected_prefix + entity_id
 
 
 def merge_entity(catalogs: dict, entity: dict) -> None:

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -92,6 +92,25 @@ def _validate_event(event_data: dict) -> bool:
         return False
 
 
+PLAYER_CHARACTER_SEED = {
+    "id": "char-player",
+    "name": "Player Character",
+    "type": "character",
+    "description": "The player character (referred to as 'you' in DM narration).",
+    "attributes": {},
+    "first_seen_turn": "turn-001",
+    "last_updated_turn": "turn-001",
+}
+
+
+def _ensure_player_character(catalogs: dict) -> None:
+    """Pre-seed the player character entry if it doesn't already exist."""
+    for entity in catalogs.get("characters.json", []):
+        if entity.get("id") == "char-player":
+            return
+    catalogs.setdefault("characters.json", []).append(dict(PLAYER_CHARACTER_SEED))
+
+
 def load_template(name: str) -> str:
     """Load a prompt template by name (without .md extension)."""
     filepath = os.path.join(TEMPLATES_DIR, f"{name}.md")
@@ -209,11 +228,13 @@ def extract_and_merge(
         # Ensure source_turn is always set (smaller models may omit it)
         if not entity.get("source_turn"):
             entity["source_turn"] = turn_id
-        # Fix proposed_id prefix for factions (models may use "fac-" instead of "faction-")
+        # Fix proposed_id prefix if it doesn't match the declared type
         pid = entity.get("proposed_id", "")
-        if entity.get("type") == "faction" and pid and not pid.startswith("faction-"):
-            suffix = pid.removeprefix("fac-").lstrip("-")
-            entity["proposed_id"] = "faction-" + suffix
+        etype = entity.get("type", "")
+        if pid and etype:
+            from catalog_merger import fix_id_prefix, validate_id_prefix
+            if not validate_id_prefix(pid, etype):
+                entity["proposed_id"] = fix_id_prefix(pid, etype)
 
     # Filter by confidence
     qualified = filter_by_confidence(discovered, min_confidence)
@@ -248,6 +269,29 @@ def extract_and_merge(
 
         llm.delay()
 
+    # --- 2b. Always run detail extraction for the player character ---
+    # The PC is "you" in DM narration, so they won't be "discovered" but are
+    # affected by almost every turn.
+    pc_already_extracted = any(
+        get_entity_id(e) == "char-player" for e in qualified
+    )
+    if not pc_already_extracted:
+        pc_result = find_entity_by_id(catalogs, "char-player")
+        pc_entry = pc_result[1] if pc_result else dict(PLAYER_CHARACTER_SEED)
+        pc_ref = {"name": pc_entry["name"], "type": "character",
+                  "existing_id": "char-player", "is_new": False}
+        try:
+            detail_result = llm.extract_json(
+                system_prompt=load_template("entity-detail"),
+                user_prompt=format_detail_prompt(turn, pc_ref, pc_entry),
+            )
+            entity_data = detail_result.get("entity")
+            if entity_data and _validate_entity(entity_data):
+                merge_entity(catalogs, entity_data)
+        except LLMExtractionError as e:
+            print(f"  WARNING: PC detail extraction failed at {turn_id}: {e}", file=sys.stderr)
+        llm.delay()
+
     # --- 3. Relationship Mapping ---
     mentioned_entities = []
     for entity_ref in qualified:
@@ -258,6 +302,16 @@ def extract_and_merge(
                 "name": entity_ref["name"],
                 "type": entity_ref["type"],
             })
+
+    # Always include the player character in relationships and events
+    if not any(e["id"] == "char-player" for e in mentioned_entities):
+        pc_result = find_entity_by_id(catalogs, "char-player")
+        pc_name = pc_result[1]["name"] if pc_result else "Player Character"
+        mentioned_entities.append({
+            "id": "char-player",
+            "name": pc_name,
+            "type": "character",
+        })
 
     if len(mentioned_entities) >= 2:
         try:
@@ -291,6 +345,78 @@ def extract_and_merge(
     return catalogs, events_list
 
 
+def _dedup_catalogs(catalogs: dict) -> int:
+    """Post-batch deduplication pass.
+
+    Merges entities within each catalog file that share the same lowercased
+    name or have overlapping aliases.  The entry seen earliest
+    (lowest first_seen_turn) is kept as the survivor; later duplicates are
+    merged into it via ``_update_existing_entity`` from catalog_merger.
+    Returns the number of duplicates merged.
+    """
+    from catalog_merger import _update_existing_entity
+
+    merged_count = 0
+
+    for filename, entities in catalogs.items():
+        # Build lookup: normalised name -> list of indices
+        name_map: dict[str, list[int]] = {}
+        for idx, entity in enumerate(entities):
+            # Collect all names this entity is known by
+            names = {entity.get("name", "").strip().lower()}
+            aliases_str = entity.get("attributes", {}).get("aliases", "")
+            if aliases_str:
+                for a in aliases_str.split(","):
+                    a = a.strip().lower()
+                    if a:
+                        names.add(a)
+            for n in names:
+                if n:
+                    name_map.setdefault(n, []).append(idx)
+
+        # Identify groups of indices that should be merged (connected-component)
+        parent: dict[int, int] = {}
+
+        def find(x: int) -> int:
+            while parent.get(x, x) != x:
+                parent[x] = parent.get(parent[x], parent[x])
+                x = parent[x]
+            return x
+
+        def union(a: int, b: int) -> None:
+            ra, rb = find(a), find(b)
+            if ra != rb:
+                parent[rb] = ra
+
+        for _name, idxs in name_map.items():
+            for i in range(1, len(idxs)):
+                union(idxs[0], idxs[i])
+
+        # Group by root
+        groups: dict[int, list[int]] = {}
+        for idx in range(len(entities)):
+            root = find(idx)
+            groups.setdefault(root, []).append(idx)
+
+        # Merge groups with more than one member
+        to_remove: set[int] = set()
+        for _root, members in groups.items():
+            if len(members) < 2:
+                continue
+            # Keep the entry with the earliest first_seen_turn
+            members.sort(key=lambda i: entities[i].get("first_seen_turn", ""))
+            survivor_idx = members[0]
+            for dup_idx in members[1:]:
+                _update_existing_entity(entities[survivor_idx], entities[dup_idx])
+                to_remove.add(dup_idx)
+                merged_count += 1
+
+        if to_remove:
+            catalogs[filename] = [e for i, e in enumerate(entities) if i not in to_remove]
+
+    return merged_count
+
+
 def extract_semantic_batch(
     turn_dicts: list,
     session_dir: str,
@@ -320,6 +446,9 @@ def extract_semantic_batch(
     catalog_dir = os.path.join(framework_dir, "catalogs")
     catalogs = load_catalogs(catalog_dir)
     events_list = load_events(catalog_dir)
+
+    # Pre-seed the player character so it can be tracked every turn
+    _ensure_player_character(catalogs)
 
     # Progress tracking
     progress_file = os.path.join(session_dir, "derived", "extraction-progress.json")
@@ -377,6 +506,13 @@ def extract_semantic_batch(
     # Final save
     entities_after = sum(len(v) for v in catalogs.values())
     events_after = len(events_list)
+
+    # Post-batch dedup: merge entities that share the same name/aliases but got separate IDs
+    dupes_merged = _dedup_catalogs(catalogs)
+    if dupes_merged:
+        entities_after = sum(len(v) for v in catalogs.values())
+        print(f"  Post-batch dedup merged {dupes_merged} duplicate(s); {entities_after} entities remain")
+
     print(f"  Semantic extraction complete: {entities_after} entities, {events_after} events")
 
     if not dry_run:
@@ -417,6 +553,9 @@ def extract_semantic_single(
     catalog_dir = os.path.join(framework_dir, "catalogs")
     catalogs = load_catalogs(catalog_dir)
     events_list = load_events(catalog_dir)
+
+    # Pre-seed the player character so it can be tracked every turn
+    _ensure_player_character(catalogs)
 
     turn = {"turn_id": turn_id, "speaker": speaker, "text": text}
 

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -103,12 +103,20 @@ PLAYER_CHARACTER_SEED = {
 }
 
 
-def _ensure_player_character(catalogs: dict) -> None:
-    """Pre-seed the player character entry if it doesn't already exist."""
+def _ensure_player_character(catalogs: dict, first_turn_id: str | None = None) -> None:
+    """Pre-seed the player character entry if it doesn't already exist.
+
+    *first_turn_id* overrides the default ``turn-001`` provenance so the
+    seed is correct when extraction starts from a later turn.
+    """
     for entity in catalogs.get("characters.json", []):
         if entity.get("id") == "char-player":
             return
-    catalogs.setdefault("characters.json", []).append(dict(PLAYER_CHARACTER_SEED))
+    seed = dict(PLAYER_CHARACTER_SEED)
+    if first_turn_id:
+        seed["first_seen_turn"] = first_turn_id
+        seed["last_updated_turn"] = first_turn_id
+    catalogs.setdefault("characters.json", []).append(seed)
 
 
 def load_template(name: str) -> str:
@@ -213,15 +221,13 @@ def extract_and_merge(
         )
     except LLMExtractionError as e:
         print(f"  WARNING: Entity discovery failed for {turn_id}: {e}", file=sys.stderr)
-        return catalogs, events_list
+        discovery_result = {"entities": []}
 
     if not isinstance(discovery_result, dict):
         print(f"  WARNING: Discovery returned non-dict for {turn_id}, skipping", file=sys.stderr)
-        return catalogs, events_list
+        discovery_result = {"entities": []}
 
     discovered = discovery_result.get("entities", [])
-    if not discovered:
-        return catalogs, events_list
 
     # Post-process discovery results: ensure provenance and fix ID prefixes
     for entity in discovered:
@@ -238,8 +244,6 @@ def extract_and_merge(
 
     # Filter by confidence
     qualified = filter_by_confidence(discovered, min_confidence)
-    if not qualified:
-        return catalogs, events_list
 
     # --- 2. Entity Detail Extraction (per entity above threshold) ---
     for entity_ref in qualified:
@@ -327,7 +331,7 @@ def extract_and_merge(
 
     # --- 4. Event Extraction ---
     next_evt_id = get_next_event_id(events_list)
-    entity_ids = [get_entity_id(e) for e in qualified if get_entity_id(e)]
+    entity_ids = [e["id"] for e in mentioned_entities]
 
     try:
         event_result = llm.extract_json(
@@ -351,10 +355,10 @@ def _dedup_catalogs(catalogs: dict) -> int:
     Merges entities within each catalog file that share the same lowercased
     name or have overlapping aliases.  The entry seen earliest
     (lowest first_seen_turn) is kept as the survivor; later duplicates are
-    merged into it via ``_update_existing_entity`` from catalog_merger.
+    merged into it via ``dedup_merge_entity`` from catalog_merger.
     Returns the number of duplicates merged.
     """
-    from catalog_merger import _update_existing_entity
+    from catalog_merger import dedup_merge_entity
 
     merged_count = 0
 
@@ -407,7 +411,7 @@ def _dedup_catalogs(catalogs: dict) -> int:
             members.sort(key=lambda i: entities[i].get("first_seen_turn", ""))
             survivor_idx = members[0]
             for dup_idx in members[1:]:
-                _update_existing_entity(entities[survivor_idx], entities[dup_idx])
+                dedup_merge_entity(entities[survivor_idx], entities[dup_idx])
                 to_remove.add(dup_idx)
                 merged_count += 1
 
@@ -448,7 +452,8 @@ def extract_semantic_batch(
     events_list = load_events(catalog_dir)
 
     # Pre-seed the player character so it can be tracked every turn
-    _ensure_player_character(catalogs)
+    first_turn = turn_dicts[0]["turn_id"] if turn_dicts else None
+    _ensure_player_character(catalogs, first_turn)
 
     # Progress tracking
     progress_file = os.path.join(session_dir, "derived", "extraction-progress.json")
@@ -555,7 +560,7 @@ def extract_semantic_single(
     events_list = load_events(catalog_dir)
 
     # Pre-seed the player character so it can be tracked every turn
-    _ensure_player_character(catalogs)
+    _ensure_player_character(catalogs, turn_id)
 
     turn = {"turn_id": turn_id, "speaker": speaker, "text": text}
 


### PR DESCRIPTION
## Summary

Fixes four extraction prompt and pipeline gaps discovered during the 3B model validation run on turns 1-30 of session-import. These are design-level issues (not model-capability issues) that affect extraction quality regardless of model size.

## Issue #48 — Items never extracted

- Added 3 item-specific examples to entity-discovery prompt (weapons, traps, containers/substances)
- Added item identification tips covering weapons, containers, substances, traps/mechanisms, and consumables
- Verified the pipeline has no item-type filtering in `semantic_extraction.py` or `catalog_merger.py` — the gap was prompt-only

## Issue #49 — Entity deduplication fails

- Enriched `format_known_entities()` to include entity descriptions and aliases alongside ID/name/type, giving the LLM much better coreference context
- Updated the discovery prompt to explicitly reference aliases in the coreference instruction
- Added generic `fix_id_prefix()` in `catalog_merger.py` that corrects any type/prefix mismatch (replaces the previous faction-only fix)
- Added `_dedup_catalogs()` post-batch pass using union-find on normalised name/alias overlap to merge entries that slipped through per-turn coreference

## Issue #50 — Player character not tracked

- Added `_ensure_player_character()` to pre-seed `char-player` in catalogs before extraction begins (both batch and single modes)
- Added step 2b in `extract_and_merge()` that always runs entity-detail extraction for `char-player` against the current turn text, even when the PC is not among discovered entities
- Included `char-player` in mentioned_entities for relationship mapping and event extraction
- Added PC-specific attribute guidance to entity-detail prompt: race, class, abilities, HP changes, conditions, quest info

## Issue #51 — Event types too narrow

- Added 8 new event types to `event.schema.json` and the event-extractor prompt: `capture`, `trap`, `ritual`, `healing`, `communication`, `examination`, `release`, `offering`
- Added one example per new type in the prompt

Closes #48
Closes #49
Closes #50
Closes #51
