### PR TITLE
fix: post-dedup ID rewrite and ground truth fixture turn numbers

### DIFF
--- a/tests/fixtures/extraction-ground-truth-turns-1-30.json
+++ b/tests/fixtures/extraction-ground-truth-turns-1-30.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "../extraction-ground-truth.schema.json",
   "description": "Ground truth for extraction validation — session-import turns 1-30. Entity descriptions use abstract role labels to avoid leaking story content. Match on count, type distribution, and structural completeness.",
   "source_session": "session-import",
   "numbering_note": "Turn numbers correspond to the session-import transcript as produced by bootstrap_session.py. All turns have a DM file (turn-NNN-dm.md); even-numbered turns additionally have a separate player file (turn-NNN-player.md). Each DM file includes the player action as the final lines.",

--- a/tests/fixtures/extraction-ground-truth-turns-1-30.json
+++ b/tests/fixtures/extraction-ground-truth-turns-1-30.json
@@ -1,0 +1,197 @@
+{
+  "$schema": "../extraction-ground-truth.schema.json",
+  "description": "Ground truth for extraction validation — session-import turns 1-30. Entity descriptions use abstract role labels to avoid leaking story content. Match on count, type distribution, and structural completeness.",
+  "source_session": "session-import",
+  "numbering_note": "Turn numbers correspond to the session-import transcript as produced by bootstrap_session.py. All turns have a DM file (turn-NNN-dm.md); even-numbered turns additionally have a separate player file (turn-NNN-player.md). Each DM file includes the player action as the final lines.",
+  "turn_range": [1, 30],
+  "expected_characters": {
+    "count": 5,
+    "entries": [
+      {
+        "role_label": "authority-leader",
+        "type": "character",
+        "expected_attributes": ["appearance", "role"],
+        "first_seen_turn_range": [8, 10],
+        "notes": "Senior authority figure; commands others; makes decisions about PC"
+      },
+      {
+        "role_label": "captor-broad",
+        "type": "character",
+        "expected_attributes": ["appearance"],
+        "first_seen_turn_range": [4, 5],
+        "notes": "Distinct physical build from captor-slight; carries weapon"
+      },
+      {
+        "role_label": "captor-slight",
+        "type": "character",
+        "expected_attributes": ["appearance"],
+        "first_seen_turn_range": [4, 5],
+        "notes": "Smaller build than captor-broad; same role; should not be merged with captor-broad"
+      },
+      {
+        "role_label": "service-woman",
+        "type": "character",
+        "expected_attributes": ["appearance", "role"],
+        "first_seen_turn_range": [10, 11],
+        "notes": "Serves authority-leader; interacts with PC; younger individual"
+      },
+      {
+        "role_label": "background-group",
+        "type": "character",
+        "expected_attributes": ["appearance"],
+        "first_seen_turn_range": [7, 8],
+        "notes": "Multiple unnamed observers; may be typed as faction instead"
+      }
+    ]
+  },
+  "expected_locations": {
+    "count_min": 4,
+    "count_max": 5,
+    "entries": [
+      {
+        "role_label": "origin-settlement",
+        "type": "location",
+        "first_seen_turn_range": [1, 1],
+        "notes": "Mentioned in backstory; PC departed from here"
+      },
+      {
+        "role_label": "forest-path",
+        "type": "location",
+        "first_seen_turn_range": [1, 2],
+        "notes": "Transition area; where PC regains consciousness"
+      },
+      {
+        "role_label": "dense-forest",
+        "type": "location",
+        "first_seen_turn_range": [2, 3],
+        "notes": "Hostile environment containing trap; main traversal area"
+      },
+      {
+        "role_label": "encampment",
+        "type": "location",
+        "first_seen_turn_range": [7, 8],
+        "notes": "Destination settlement with structures and central fire"
+      },
+      {
+        "role_label": "fire-gathering",
+        "type": "location",
+        "first_seen_turn_range": [7, 8],
+        "notes": "Sub-area within encampment; may be merged with encampment"
+      }
+    ]
+  },
+  "expected_factions": {
+    "count": 2,
+    "entries": [
+      {
+        "role_label": "origin-community",
+        "type": "faction",
+        "first_seen_turn_range": [1, 1],
+        "notes": "Mentioned in backstory; hired PC for quest"
+      },
+      {
+        "role_label": "wilderness-tribe",
+        "type": "faction",
+        "first_seen_turn_range": [7, 8],
+        "notes": "Group that captured PC; should be ONE entry, not duplicated"
+      }
+    ]
+  },
+  "expected_items": {
+    "count_min": 8,
+    "entries": [
+      {
+        "role_label": "quest-artifact",
+        "type": "item",
+        "first_seen_turn_range": [1, 1],
+        "notes": "Central quest object; name deliberately unknown to PC"
+      },
+      {
+        "role_label": "trap-trigger",
+        "type": "item",
+        "first_seen_turn_range": [3, 3],
+        "notes": "Hidden mechanism that initiates capture"
+      },
+      {
+        "role_label": "trap-snare",
+        "type": "item",
+        "first_seen_turn_range": [3, 3],
+        "notes": "Entanglement device; causes injury"
+      },
+      {
+        "role_label": "weapon-spear",
+        "type": "item",
+        "first_seen_turn_range": [4, 5],
+        "notes": "Carried by captors; crude construction"
+      },
+      {
+        "role_label": "binding-rope",
+        "type": "item",
+        "first_seen_turn_range": [5, 5],
+        "notes": "Used to restrain PC"
+      },
+      {
+        "role_label": "ritual-substance",
+        "type": "item",
+        "first_seen_turn_range": [10, 13],
+        "notes": "Damp, sticky, medicinal; central to acceptance scene"
+      },
+      {
+        "role_label": "container-bowl-substance",
+        "type": "item",
+        "first_seen_turn_range": [10, 10],
+        "notes": "Holds ritual-substance"
+      },
+      {
+        "role_label": "consumable-broth",
+        "type": "item",
+        "first_seen_turn_range": [15, 16],
+        "notes": "Restorative; restores HP"
+      }
+    ]
+  },
+  "expected_player_character": {
+    "should_exist": true,
+    "expected_attributes": {
+      "race": "present",
+      "class": "present",
+      "abilities": ["darkvision"],
+      "hp_changes": [
+        {"turn": 3, "delta": -2, "cause": "trap-snare"},
+        {"turn": 15, "delta": 2, "cause": "consumable-broth"}
+      ],
+      "conditions": ["shoulder-wound"],
+      "quest": "retrieve quest-artifact for origin-community"
+    }
+  },
+  "expected_events": {
+    "count_min": 10,
+    "count_max": 15,
+    "significant_beats": [
+      {"turn_range": [1, 1], "type": "arrival", "label": "PC regains consciousness"},
+      {"turn_range": [3, 3], "type": "trap", "label": "trap triggered, PC injured"},
+      {"turn_range": [3, 4], "type": "decision", "label": "PC surrenders"},
+      {"turn_range": [4, 5], "type": "capture", "label": "PC bound by captors"},
+      {"turn_range": [7, 8], "type": "arrival", "label": "arrive at encampment"},
+      {"turn_range": [8, 10], "type": "encounter", "label": "presented to authority"},
+      {"turn_range": [10, 11], "type": "offering", "label": "ritual substance offered"},
+      {"turn_range": [13, 15], "type": "release", "label": "bonds removed"},
+      {"turn_range": [14, 15], "type": "ritual", "label": "PC performs acceptance ritual"},
+      {"turn_range": [15, 16], "type": "healing", "label": "broth offered, HP restored"}
+    ]
+  },
+  "coreference_checks": [
+    {
+      "description": "Both captors should share faction membership, not be separate factions",
+      "expected_faction_count_for_captors": 1
+    },
+    {
+      "description": "Authority-leader mentioned by different descriptions across turns should be ONE character entry",
+      "expected_character_entries": 1
+    },
+    {
+      "description": "Encampment/fire-gathering may be 1 or 2 locations but NOT typed as character or faction",
+      "expected_type": "location"
+    }
+  ]
+}

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -220,6 +220,20 @@ def _update_existing_entity(current: dict, update: dict) -> None:
     if update.get("notes"):
         current["notes"] = update["notes"]
 
+    # Merge relationships (dedup by target_id + relationship)
+    if update.get("relationships"):
+        if "relationships" not in current:
+            current["relationships"] = []
+        existing_keys = {
+            (r.get("target_id"), r.get("relationship"))
+            for r in current["relationships"]
+        }
+        for rel in update["relationships"]:
+            key = (rel.get("target_id"), rel.get("relationship"))
+            if key not in existing_keys:
+                current["relationships"].append(rel)
+                existing_keys.add(key)
+
 
 # Public alias for cross-module use (e.g. post-batch dedup in semantic_extraction)
 dedup_merge_entity = _update_existing_entity

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -349,18 +349,20 @@ def extract_and_merge(
     return catalogs, events_list
 
 
-def _dedup_catalogs(catalogs: dict) -> int:
+def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
     """Post-batch deduplication pass.
 
     Merges entities within each catalog file that share the same lowercased
     name or have overlapping aliases.  The entry seen earliest
     (lowest first_seen_turn) is kept as the survivor; later duplicates are
     merged into it via ``dedup_merge_entity`` from catalog_merger.
-    Returns the number of duplicates merged.
+    Returns (merge_count, merge_map) where merge_map maps each removed
+    entity ID to its survivor ID.
     """
     from catalog_merger import dedup_merge_entity
 
     merged_count = 0
+    merge_map: dict[str, str] = {}
 
     for filename, entities in catalogs.items():
         # Build lookup: normalised name -> list of indices
@@ -410,15 +412,39 @@ def _dedup_catalogs(catalogs: dict) -> int:
             # Keep the entry with the earliest first_seen_turn
             members.sort(key=lambda i: entities[i].get("first_seen_turn", ""))
             survivor_idx = members[0]
+            survivor_id = entities[survivor_idx].get("id", "")
             for dup_idx in members[1:]:
+                removed_id = entities[dup_idx].get("id", "")
                 dedup_merge_entity(entities[survivor_idx], entities[dup_idx])
                 to_remove.add(dup_idx)
+                if removed_id and survivor_id:
+                    merge_map[removed_id] = survivor_id
                 merged_count += 1
 
         if to_remove:
             catalogs[filename] = [e for i, e in enumerate(entities) if i not in to_remove]
 
-    return merged_count
+    return merged_count, merge_map
+
+
+def _rewrite_stale_ids(catalogs: dict, events_list: list, merge_map: dict[str, str]) -> None:
+    """Replace dangling entity IDs left by dedup with their survivor IDs."""
+    if not merge_map:
+        return
+
+    # Rewrite event related_entities
+    for event in events_list:
+        related = event.get("related_entities", [])
+        event["related_entities"] = [merge_map.get(eid, eid) for eid in related]
+
+    # Rewrite relationship source_id and target_id in catalog entries
+    for _filename, entities in catalogs.items():
+        for entity in entities:
+            for rel in entity.get("relationships", []):
+                if rel.get("source_id") in merge_map:
+                    rel["source_id"] = merge_map[rel["source_id"]]
+                if rel.get("target_id") in merge_map:
+                    rel["target_id"] = merge_map[rel["target_id"]]
 
 
 def extract_semantic_batch(
@@ -513,8 +539,9 @@ def extract_semantic_batch(
     events_after = len(events_list)
 
     # Post-batch dedup: merge entities that share the same name/aliases but got separate IDs
-    dupes_merged = _dedup_catalogs(catalogs)
+    dupes_merged, merge_map = _dedup_catalogs(catalogs)
     if dupes_merged:
+        _rewrite_stale_ids(catalogs, events_list, merge_map)
         entities_after = sum(len(v) for v in catalogs.values())
         print(f"  Post-batch dedup merged {dupes_merged} duplicate(s); {entities_after} entities remain")
 


### PR DESCRIPTION
## Summary

Fixes dangling entity ID references after dedup and corrects ground truth fixture turn numbering.

## Issue #59 — Post-dedup ID rewrite pass

`_dedup_catalogs()` now returns a `merge_map` (`dict[str, str]`) mapping each removed entity ID to its survivor ID, alongside the existing merge count.

New helper `_rewrite_stale_ids(catalogs, events_list, merge_map)` runs immediately after dedup and replaces:
- `related_entities` entries in every event that reference a removed ID
- `source_id` and `target_id` fields in relationship arrays on surviving catalog entries

This eliminates dangling IDs (e.g., events referencing `char-fenouille-moonwind` after it was merged into `char-player`).

## Issue #55 — Ground truth fixture turn numbers

The fixture assumed interleaved DM/player turns (turn 1 = DM, turn 2 = player, …) but the actual `session-import` transcript numbers each DM+player exchange sequentially. All turns have a DM file; even-numbered turns additionally have a separate player file.

Updated `first_seen_turn_range` values in all `expected_*` sections and `turn_range` values in `significant_beats` to match the real transcript. Added a `numbering_note` field documenting the scheme.

Closes #55
Closes #59
