### PR TITLE
feat: reduce extraction noise with event significance filter and PC attribute discipline

### DIFF
--- a/templates/extraction/entity-detail.md
+++ b/templates/extraction/entity-detail.md
@@ -19,7 +19,11 @@ Rules:
 - If the text reveals a proper name for a previously unnamed entity (e.g. "The elder" is revealed to be "Shaman Kaya"), update "name" and add the old name as an "aliases" attribute.
 - Clearly distinguish fact from inference: append " [inference]" to any attribute value that is inferred rather than explicitly stated in the text.
 - Keep descriptions factual and concise.
-- For the player character (id "char-player", referred to as "you" in DM narration): always extract race, class, abilities (e.g. darkvision), HP changes (use attribute key "hp_change" with value like "-2 (trap injury)" or "+2 (broth)"), active conditions (e.g. "shoulder wound"), and quest information when mentioned. Track these across turns by preserving and extending existing attributes.
+- Attribute keys should describe persistent properties (role, appearance, condition, equipment, allegiance), not transient narrative actions. If an entity performs an action in this turn, that action is an event — do not record it as an attribute.
+- For the player character (id "char-player", referred to as "you" in DM narration): only extract STABLE traits and state changes, not transient narrative actions.
+  Allowed attribute keys for char-player: "race", "class", "abilities", "appearance", "hp_change", "condition", "equipment", "quest", "allegiance", "status", "aliases".
+  Do NOT create attribute keys for temporary actions (e.g., "carries_wood", "talks_to_elder", "watches_sunset") — those belong in events, not entity attributes.
+  Preserve existing stable attributes across turns. Only add or update attributes that represent lasting character state.
 
 Return the result as a JSON object with a single key "entity" containing the entity object.
 Example: {"entity": {"id": "char-elder", "name": "The elder", "type": "character", "description": "An elderly authority figure with gnarled hands.", "attributes": {"role": "tribal leader [inference]", "appearance": "gnarled hands, sharp gaze"}, "first_seen_turn": "turn-019", "last_updated_turn": "turn-019"}}

--- a/templates/extraction/entity-detail.md
+++ b/templates/extraction/entity-detail.md
@@ -15,7 +15,7 @@ Return a single JSON object conforming to this structure:
 Rules:
 - Only include information supported by the provided turn text and existing entry.
 - Do NOT invent attributes or details not present in the text.
-- Preserve all existing attributes from the current entry; add new ones revealed in this turn.
+- Preserve all existing attributes from the current entry; add new ones revealed in this turn. Exception: for char-player, only preserve attributes whose keys are in the allowed set listed below — drop any transient action keys that may exist in the current entry.
 - If the text reveals a proper name for a previously unnamed entity (e.g. "The elder" is revealed to be "Shaman Kaya"), update "name" and add the old name as an "aliases" attribute.
 - Clearly distinguish fact from inference: append " [inference]" to any attribute value that is inferred rather than explicitly stated in the text.
 - Keep descriptions factual and concise.

--- a/templates/extraction/event-extractor.md
+++ b/templates/extraction/event-extractor.md
@@ -14,6 +14,14 @@ Rules:
 - Only extract events that are directly described or clearly implied in the provided turn text.
 - Do NOT invent events not supported by the text.
 - Focus on significant narrative events, not routine actions or minor dialogue.
+- An event is significant ONLY if it does at least one of:
+  (a) Changes game state (HP, conditions, inventory, location)
+  (b) Advances the plot or reveals new information
+  (c) Alters a relationship between entities
+  (d) Introduces a new entity or removes one from play
+- Do NOT extract: routine dialogue exchanges, minor observations, flavor descriptions, repeated actions, or emotional reactions that don't change anything.
+- When in doubt, omit the event. Fewer high-quality events are better than many trivial ones.
+- Aim for 0-2 events per turn. Most turns should produce 0-1 events.
 - If a turn contains no significant events, return an empty array.
 - Each event should be atomic — one discrete occurrence, not a compound summary.
 - Use the entity IDs provided in the context to populate related_entities.
@@ -30,5 +38,10 @@ Additional examples by type:
 {"events": [{"id": "evt-007", "source_turns": ["turn-017"], "type": "examination", "description": "The elder closely inspected the player's elven features and warlock attire.", "related_entities": ["char-elder", "char-player"]}]}
 {"events": [{"id": "evt-008", "source_turns": ["turn-025"], "type": "release", "description": "The warrior cut the ropes binding the player's wrists.", "related_entities": ["char-player"]}]}
 {"events": [{"id": "evt-009", "source_turns": ["turn-019"], "type": "offering", "description": "The woman presented a bowl of dark paste to the player.", "related_entities": ["char-service-woman", "char-player", "item-dark-paste-bowl"]}]}
+
+Negative examples — do NOT extract events like these:
+NOT an event (too minor): "The player looks around the campfire" — observation, no state change.
+NOT an event (routine dialogue): "The elder grunts dismissively" — minor reaction, no plot advancement.
+NOT an event (flavor): "Snow continues to fall on the lean-tos" — atmospheric, no game impact.
 
 If no significant events are found in the turn, return: {"events": []}

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -58,6 +58,26 @@ def _filter_pc_attributes(entity_data: dict) -> dict:
         entity_data["attributes"] = {k: v for k, v in attrs.items() if k in PC_ALLOWED_ATTRS}
     return entity_data
 
+
+def _sanitize_pc_catalog_entry(catalogs: dict) -> None:
+    """Purge non-allowed attribute keys from the stored char-player catalog entry.
+
+    Ensures historical action-sprawl attributes are cleaned up even if they
+    were merged before the filter was in place.
+    """
+    for entity in catalogs.get("characters.json", []):
+        if entity.get("id") != "char-player":
+            continue
+        attrs = entity.get("attributes", {})
+        disallowed = {k for k in attrs if k not in PC_ALLOWED_ATTRS}
+        if disallowed:
+            print(
+                f"  WARNING: Purging stale char-player catalog attributes: {sorted(disallowed)}",
+                file=sys.stderr,
+            )
+            entity["attributes"] = {k: v for k, v in attrs.items() if k in PC_ALLOWED_ATTRS}
+        break
+
 # Directory containing prompt templates (relative to repo root)
 TEMPLATES_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
@@ -292,6 +312,9 @@ def extract_and_merge(
         if entity_data and _validate_entity(entity_data):
             _filter_pc_attributes(entity_data)
             merge_entity(catalogs, entity_data)
+            # If this was char-player, also purge stale keys from catalog
+            if entity_data.get("id") == "char-player":
+                _sanitize_pc_catalog_entry(catalogs)
 
         llm.delay()
 
@@ -304,6 +327,9 @@ def extract_and_merge(
     if not pc_already_extracted:
         pc_result = find_entity_by_id(catalogs, "char-player")
         pc_entry = pc_result[1] if pc_result else dict(PLAYER_CHARACTER_SEED)
+        # Sanitize existing entry before sending to LLM so stale keys
+        # don't appear in the prompt and get echoed back.
+        _sanitize_pc_catalog_entry(catalogs)
         pc_ref = {"name": pc_entry["name"], "type": "character",
                   "existing_id": "char-player", "is_new": False}
         try:
@@ -315,6 +341,8 @@ def extract_and_merge(
             if entity_data and _validate_entity(entity_data):
                 _filter_pc_attributes(entity_data)
                 merge_entity(catalogs, entity_data)
+                # Purge any stale keys that survived the merge
+                _sanitize_pc_catalog_entry(catalogs)
         except LLMExtractionError as e:
             print(f"  WARNING: PC detail extraction failed at {turn_id}: {e}", file=sys.stderr)
         llm.delay()

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -37,6 +37,27 @@ except ImportError:
 # Default confidence threshold — entities below this are logged but not cataloged
 DEFAULT_MIN_CONFIDENCE = 0.6
 
+# Allowed attribute keys for the player character — safety net for prompt discipline
+PC_ALLOWED_ATTRS = {
+    "race", "class", "abilities", "appearance", "hp_change",
+    "condition", "equipment", "quest", "allegiance", "status", "aliases",
+}
+
+
+def _filter_pc_attributes(entity_data: dict) -> dict:
+    """Strip non-allowed attribute keys from char-player entities."""
+    if entity_data.get("id") != "char-player":
+        return entity_data
+    attrs = entity_data.get("attributes", {})
+    disallowed = {k for k in attrs if k not in PC_ALLOWED_ATTRS}
+    if disallowed:
+        print(
+            f"  WARNING: Dropping non-allowed char-player attributes: {sorted(disallowed)}",
+            file=sys.stderr,
+        )
+        entity_data["attributes"] = {k: v for k, v in attrs.items() if k in PC_ALLOWED_ATTRS}
+    return entity_data
+
 # Directory containing prompt templates (relative to repo root)
 TEMPLATES_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
@@ -269,6 +290,7 @@ def extract_and_merge(
 
         entity_data = detail_result.get("entity")
         if entity_data and _validate_entity(entity_data):
+            _filter_pc_attributes(entity_data)
             merge_entity(catalogs, entity_data)
 
         llm.delay()
@@ -291,6 +313,7 @@ def extract_and_merge(
             )
             entity_data = detail_result.get("entity")
             if entity_data and _validate_entity(entity_data):
+                _filter_pc_attributes(entity_data)
                 merge_entity(catalogs, entity_data)
         except LLMExtractionError as e:
             print(f"  WARNING: PC detail extraction failed at {turn_id}: {e}", file=sys.stderr)


### PR DESCRIPTION
## Summary

Reduces extraction noise by adding significance filtering to the event-extractor prompt and restricting PC attribute keys to stable traits only.

## Issue #56 — Reduce event over-extraction

Added significance criteria to the event-extractor prompt: events must change game state, advance the plot, or alter relationships. Added negative examples showing what NOT to extract. Added guidance to aim for 0-2 events per turn.

## Issue #58 — Distinguish stable PC attributes from per-turn actions

Restricted char-player attribute keys to a defined allowed set (race, class, abilities, appearance, hp_change, condition, equipment, quest, allegiance, status, aliases). Transient actions are explicitly directed to events instead. Added general attribute discipline rule for all entities. Added pipeline-level filtering as a safety net.

Closes #56
Closes #58
