### PR TITLE
feat: improve item dedup with fuzzy/substring name matching

### DIFF
--- a/templates/extraction/entity-discovery.md
+++ b/templates/extraction/entity-discovery.md
@@ -21,6 +21,7 @@ Rules:
 - The player character ("you" in DM turns) should NOT be extracted — they are pre-seeded in the catalog.
 - Confidence below 0.5 means the mention is too vague to catalog.
 - For coreference resolution: if a mention refers to an already-known entity (even by a different name, title, or alias shown in the known-entities list), set is_new to false and provide the existing_id. Use the descriptions and aliases in the known-entities list to identify matches.
+- For items: if a previously cataloged item is referenced by a shorter name, partial description, or with/without adjectives (e.g., "the spear" referring to a previously seen "crude wood-hafted spear"), set is_new to false and provide the existing_id. Do not create a new entry for a name variant of the same physical object.
 - "proposed_id" and "existing_id" are mutually exclusive: exactly one must be non-null for each result.
 
 Return a JSON object with a single key "entities" containing an array of entity objects.

--- a/tests/test_dedup_fuzzy.py
+++ b/tests/test_dedup_fuzzy.py
@@ -21,7 +21,7 @@ def _ids(catalogs, filename):
     return {e["id"] for e in catalogs[filename]}
 
 
-def test_substring_merge_spear():
+def test_token_overlap_merge_spear():
     catalogs = {
         "items.json": [
             _make_entity("item-crude-woodhafted-spear", "Crude wood-hafted spear", "turn-003"),
@@ -83,19 +83,35 @@ def test_no_cross_catalog_merge():
 def test_id_stem_merge():
     catalogs = {
         "items.json": [
-            _make_entity("item-crude-spear", "Pointy stick", "turn-003"),
-            _make_entity("item-crude-spear-broken", "Broken pointy stick", "turn-010"),
+            _make_entity("item-crude-spear", "Ashbrand", "turn-003"),
+            _make_entity("item-crude-spear-broken", "Nightglass", "turn-010"),
         ]
     }
     count, merge_map = _dedup_catalogs(catalogs)
     assert count == 1
     assert len(catalogs["items.json"]) == 1
+    assert "item-crude-spear-broken" in merge_map
+    assert merge_map["item-crude-spear-broken"] == "item-crude-spear"
+
+
+def test_no_partial_word_substring_merge():
+    """'ring' should NOT match 'spring' — only whole-token containment."""
+    catalogs = {
+        "items.json": [
+            _make_entity("item-ring", "Ring", "turn-001"),
+            _make_entity("item-spring", "Spring", "turn-002"),
+        ]
+    }
+    count, merge_map = _dedup_catalogs(catalogs)
+    assert count == 0
+    assert len(catalogs["items.json"]) == 2
 
 
 if __name__ == "__main__":
-    test_substring_merge_spear()
+    test_token_overlap_merge_spear()
     test_substring_merge_bowl_group()
     test_substring_merge_moonpetal()
     test_no_cross_catalog_merge()
     test_id_stem_merge()
+    test_no_partial_word_substring_merge()
     print("All tests passed!")

--- a/tests/test_dedup_fuzzy.py
+++ b/tests/test_dedup_fuzzy.py
@@ -1,0 +1,101 @@
+"""Tests for fuzzy dedup matching in _dedup_catalogs()."""
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from semantic_extraction import _dedup_catalogs
+
+
+def _make_entity(id_, name, turn="turn-001"):
+    return {
+        "id": id_,
+        "name": name,
+        "first_seen_turn": turn,
+        "attributes": {},
+        "relationships": [],
+    }
+
+
+def _ids(catalogs, filename):
+    return {e["id"] for e in catalogs[filename]}
+
+
+def test_substring_merge_spear():
+    catalogs = {
+        "items.json": [
+            _make_entity("item-crude-woodhafted-spear", "Crude wood-hafted spear", "turn-003"),
+            _make_entity("item-crude-spear", "Crude spear", "turn-007"),
+        ]
+    }
+    count, merge_map = _dedup_catalogs(catalogs)
+    assert count == 1
+    assert len(catalogs["items.json"]) == 1
+    assert "item-crude-spear" in merge_map
+    assert merge_map["item-crude-spear"] == "item-crude-woodhafted-spear"
+
+
+def test_substring_merge_bowl_group():
+    catalogs = {
+        "items.json": [
+            _make_entity("item-bowl", "Bowl", "turn-002"),
+            _make_entity("item-steaming-bowl", "Steaming bowl", "turn-005"),
+            _make_entity("item-steaming-broth-bowl", "Steaming broth bowl", "turn-008"),
+            _make_entity("item-warm-wooden-bowl", "Warm wooden bowl", "turn-010"),
+        ]
+    }
+    count, merge_map = _dedup_catalogs(catalogs)
+    # All should merge into the earliest entry
+    assert len(catalogs["items.json"]) == 1
+    survivor = catalogs["items.json"][0]
+    assert survivor["id"] == "item-bowl"
+    assert count == 3
+
+
+def test_substring_merge_moonpetal():
+    catalogs = {
+        "items.json": [
+            _make_entity("item-dried-moonpetal", "Dried moonpetal", "turn-004"),
+            _make_entity("item-moonpetal", "Moonpetal", "turn-009"),
+        ]
+    }
+    count, merge_map = _dedup_catalogs(catalogs)
+    assert count == 1
+    assert len(catalogs["items.json"]) == 1
+    assert "item-moonpetal" in merge_map
+
+
+def test_no_cross_catalog_merge():
+    catalogs = {
+        "characters.json": [
+            _make_entity("char-elder", "Elder", "turn-001"),
+        ],
+        "locations.json": [
+            _make_entity("loc-forest", "Forest", "turn-001"),
+        ],
+    }
+    count, merge_map = _dedup_catalogs(catalogs)
+    assert count == 0
+    assert len(catalogs["characters.json"]) == 1
+    assert len(catalogs["locations.json"]) == 1
+
+
+def test_id_stem_merge():
+    catalogs = {
+        "items.json": [
+            _make_entity("item-crude-spear", "Pointy stick", "turn-003"),
+            _make_entity("item-crude-spear-broken", "Broken pointy stick", "turn-010"),
+        ]
+    }
+    count, merge_map = _dedup_catalogs(catalogs)
+    assert count == 1
+    assert len(catalogs["items.json"]) == 1
+
+
+if __name__ == "__main__":
+    test_substring_merge_spear()
+    test_substring_merge_bowl_group()
+    test_substring_merge_moonpetal()
+    test_no_cross_catalog_merge()
+    test_id_stem_merge()
+    print("All tests passed!")

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -462,16 +462,17 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
                 if find(idx_a) == find(idx_b):
                     continue  # already in same group
 
-                # Rule 1: Whole-token substring containment
+                # Tokenize once for Rules 1 and 2
                 tokens_a = set(name_a.replace("-", " ").split()) - STOPWORDS
                 tokens_b = set(name_b.replace("-", " ").split()) - STOPWORDS
-                if tokens_a and tokens_b and (tokens_a <= tokens_b or tokens_b <= tokens_a):
-                    union(idx_a, idx_b)
-                    print(f"  DEDUP (substring): linking '{name_a}' and '{name_b}' as duplicates")
-                    continue
-
-                # Rule 2: Token overlap >= 50%
                 if tokens_a and tokens_b:
+                    # Rule 1: Whole-token subset containment
+                    if tokens_a <= tokens_b or tokens_b <= tokens_a:
+                        union(idx_a, idx_b)
+                        print(f"  DEDUP (substring): linking '{name_a}' and '{name_b}' as duplicates")
+                        continue
+
+                    # Rule 2: Token overlap >= 50%
                     overlap = tokens_a & tokens_b
                     smaller = min(len(tokens_a), len(tokens_b))
                     if smaller > 0 and len(overlap) / smaller >= 0.5:
@@ -487,7 +488,7 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
                 if stem_a and stem_b:
                     parts_a = set(stem_a.split("-"))
                     parts_b = set(stem_b.split("-"))
-                    if parts_a and parts_b and (parts_a <= parts_b or parts_b <= parts_a):
+                    if parts_a <= parts_b or parts_b <= parts_a:
                         union(idx_a, idx_b)
                         print(f"  DEDUP (id-stem): linking '{name_a}' ({id_a}) and '{name_b}' ({id_b}) as duplicates")
 

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -467,7 +467,7 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
                 tokens_b = set(name_b.replace("-", " ").split()) - STOPWORDS
                 if tokens_a and tokens_b:
                     # Rule 1: Whole-token subset containment
-                    if tokens_a <= tokens_b or tokens_b <= tokens_a:
+                    if tokens_a.issubset(tokens_b) or tokens_b.issubset(tokens_a):
                         union(idx_a, idx_b)
                         print(f"  DEDUP (substring): linking '{name_a}' and '{name_b}' as duplicates")
                         continue
@@ -475,7 +475,7 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
                     # Rule 2: Token overlap >= 50%
                     overlap = tokens_a & tokens_b
                     smaller = min(len(tokens_a), len(tokens_b))
-                    if smaller > 0 and len(overlap) / smaller >= 0.5:
+                    if len(overlap) / smaller >= 0.5:
                         union(idx_a, idx_b)
                         print(f"  DEDUP (token-overlap): linking '{name_a}' and '{name_b}' as duplicates")
                         continue
@@ -488,7 +488,7 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
                 if stem_a and stem_b:
                     parts_a = set(stem_a.split("-"))
                     parts_b = set(stem_b.split("-"))
-                    if parts_a <= parts_b or parts_b <= parts_a:
+                    if parts_a.issubset(parts_b) or parts_b.issubset(parts_a):
                         union(idx_a, idx_b)
                         print(f"  DEDUP (id-stem): linking '{name_a}' ({id_a}) and '{name_b}' ({id_b}) as duplicates")
 

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -449,6 +449,45 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
             for i in range(1, len(idxs)):
                 union(idxs[0], idxs[i])
 
+        # --- Fuzzy pass: substring and token overlap (same catalog only) ---
+        STOPWORDS = {"a", "an", "the", "of", "and", "with", "in", "on", "to"}
+        all_names = [(idx, entity.get("name", "").strip().lower()) for idx, entity in enumerate(entities)]
+
+        for i, (idx_a, name_a) in enumerate(all_names):
+            if not name_a:
+                continue
+            for idx_b, name_b in all_names[i + 1:]:
+                if not name_b:
+                    continue
+                if find(idx_a) == find(idx_b):
+                    continue  # already in same group
+
+                # Rule 1: Substring containment
+                if name_a in name_b or name_b in name_a:
+                    union(idx_a, idx_b)
+                    print(f"  DEDUP (substring): merging '{name_a}' into '{name_b}'")
+                    continue
+
+                # Rule 2: Token overlap >= 50%
+                tokens_a = set(name_a.replace("-", " ").split()) - STOPWORDS
+                tokens_b = set(name_b.replace("-", " ").split()) - STOPWORDS
+                if tokens_a and tokens_b:
+                    overlap = tokens_a & tokens_b
+                    smaller = min(len(tokens_a), len(tokens_b))
+                    if smaller > 0 and len(overlap) / smaller >= 0.5:
+                        union(idx_a, idx_b)
+                        print(f"  DEDUP (token-overlap): merging '{name_a}' into '{name_b}'")
+                        continue
+
+                # Rule 3: ID stem overlap
+                id_a = entities[idx_a].get("proposed_id", entities[idx_a].get("id", ""))
+                id_b = entities[idx_b].get("proposed_id", entities[idx_b].get("id", ""))
+                stem_a = id_a.split("-", 1)[1] if "-" in id_a else id_a
+                stem_b = id_b.split("-", 1)[1] if "-" in id_b else id_b
+                if stem_a and stem_b and (stem_a in stem_b or stem_b in stem_a):
+                    union(idx_a, idx_b)
+                    print(f"  DEDUP (id-stem): merging '{name_a}' ({id_a}) into '{name_b}' ({id_b})")
+
         # Group by root
         groups: dict[int, list[int]] = {}
         for idx in range(len(entities)):

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -462,31 +462,34 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
                 if find(idx_a) == find(idx_b):
                     continue  # already in same group
 
-                # Rule 1: Substring containment
-                if name_a in name_b or name_b in name_a:
+                # Rule 1: Whole-token substring containment
+                tokens_a = set(name_a.replace("-", " ").split()) - STOPWORDS
+                tokens_b = set(name_b.replace("-", " ").split()) - STOPWORDS
+                if tokens_a and tokens_b and (tokens_a <= tokens_b or tokens_b <= tokens_a):
                     union(idx_a, idx_b)
-                    print(f"  DEDUP (substring): merging '{name_a}' into '{name_b}'")
+                    print(f"  DEDUP (substring): linking '{name_a}' and '{name_b}' as duplicates")
                     continue
 
                 # Rule 2: Token overlap >= 50%
-                tokens_a = set(name_a.replace("-", " ").split()) - STOPWORDS
-                tokens_b = set(name_b.replace("-", " ").split()) - STOPWORDS
                 if tokens_a and tokens_b:
                     overlap = tokens_a & tokens_b
                     smaller = min(len(tokens_a), len(tokens_b))
                     if smaller > 0 and len(overlap) / smaller >= 0.5:
                         union(idx_a, idx_b)
-                        print(f"  DEDUP (token-overlap): merging '{name_a}' into '{name_b}'")
+                        print(f"  DEDUP (token-overlap): linking '{name_a}' and '{name_b}' as duplicates")
                         continue
 
-                # Rule 3: ID stem overlap
+                # Rule 3: ID stem overlap (hyphen-segment containment)
                 id_a = entities[idx_a].get("proposed_id", entities[idx_a].get("id", ""))
                 id_b = entities[idx_b].get("proposed_id", entities[idx_b].get("id", ""))
                 stem_a = id_a.split("-", 1)[1] if "-" in id_a else id_a
                 stem_b = id_b.split("-", 1)[1] if "-" in id_b else id_b
-                if stem_a and stem_b and (stem_a in stem_b or stem_b in stem_a):
-                    union(idx_a, idx_b)
-                    print(f"  DEDUP (id-stem): merging '{name_a}' ({id_a}) into '{name_b}' ({id_b})")
+                if stem_a and stem_b:
+                    parts_a = set(stem_a.split("-"))
+                    parts_b = set(stem_b.split("-"))
+                    if parts_a and parts_b and (parts_a <= parts_b or parts_b <= parts_a):
+                        union(idx_a, idx_b)
+                        print(f"  DEDUP (id-stem): linking '{name_a}' ({id_a}) and '{name_b}' ({id_b}) as duplicates")
 
         # Group by root
         groups: dict[int, list[int]] = {}


### PR DESCRIPTION
## Summary

Improves item deduplication by adding fuzzy/substring name matching to the post-batch dedup pass and coreference guidance to the entity-discovery prompt.

## Changes

### Fuzzy dedup in `_dedup_catalogs()`

Added a second matching pass after exact name/alias matching, applied within each catalog file:
1. **Substring containment** — "bowl" matches "steaming bowl"
2. **Token overlap >= 50%** with stopword filtering — "crude spear" matches "crude wood-hafted spear"
3. **ID stem substring** — `item-crude-spear` matches `item-crude-spear-broken`

Only matches within the same catalog file to prevent cross-type false merges. Logs each fuzzy merge for transparency.

### Entity-discovery prompt

Added item-specific coreference rule instructing the model to match shorter name variants to existing catalog entries rather than creating duplicates.

### Tests

Added `tests/test_dedup_fuzzy.py` covering:
- Spear variant merge (token overlap)
- Bowl group merge (substring, 4 entries → 1)
- Moonpetal merge (substring)
- Cross-catalog non-merge (char vs loc)
- ID stem merge

Closes #57
