### PR TITLE
fix: metadata start_date, CLI model overrides, and model size docs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -95,6 +95,8 @@ python tools/bootstrap_session.py \
     --base-url http://localhost:11434/v1
 ```
 
+**Note:** `--model` and `--base-url` override only those settings. The current implementation still reads `api_key_env` from `config/llm.json` (by default this is often `OPENAI_API_KEY`). If your local OpenAI-compatible server does not require an API key, either set the expected environment variable anyway or set `"api_key_env": ""` in `config/llm.json` before running the command.
+
 ---
 
 ## Ingesting Turns

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,6 +31,72 @@ EOF
 
 ---
 
+## LLM Model Requirements
+
+Semantic extraction uses an LLM to identify entities, relationships, and events from transcript text. The quality of extraction depends significantly on model size.
+
+### Minimum Requirements
+
+- **Minimum**: 7B parameters — basic entity extraction works but expect some ID format errors and weak coreference resolution
+- **Recommended**: 14B+ parameters — reliable JSON output, good coreference, accurate entity classification
+- **Best**: GPT-4o or equivalent cloud model — highest accuracy but requires API key and costs per token
+
+### Tested Models
+
+| Model | Parameters | Quantization | VRAM | Extraction Quality |
+|---|---|---|---|---|
+| `qwen2.5:3b` | 3B | Q4_K_M | ~2.5 GB | Poor — 0% item recall, frequent hallucinations, ID format violations |
+| `qwen2.5:14b` | 14B | Q4_K_M | ~9 GB | Good — reliable entity classification, items extracted, acceptable coreference |
+| `gpt-4o` (OpenAI) | Unknown | N/A | Cloud | Best — accurate structured JSON, strong coreference, minimal hallucination |
+
+### VRAM Quick Reference
+
+| GPU VRAM | Maximum Model Size (Q4 quantization) |
+|---|---|
+| 8 GB | Up to 7B |
+| 12 GB | Up to 14B |
+| 16 GB | Up to 22B |
+| 24 GB | Up to 32B |
+
+### Known Limitations of Small Models (<7B)
+
+- Entity IDs generated with wrong type prefixes (e.g., `loc-` for an item)
+- Poor coreference resolution — same entity gets multiple catalog entries
+- Items rarely or never extracted
+- Location/character/faction type confusion
+- Hallucinated entities not present in the source text
+
+### Using a Local Model
+
+Configure Ollama or any OpenAI-compatible server in `config/llm.json`:
+
+```json
+{
+  "provider": "ollama",
+  "base_url": "http://localhost:11434/v1",
+  "model": "qwen2.5:14b",
+  "api_key_env": "",
+  "temperature": 0.0,
+  "max_tokens": 4096,
+  "timeout_seconds": 180,
+  "retry_attempts": 3,
+  "batch_delay_ms": 500
+}
+```
+
+Or use CLI overrides for one-off runs:
+
+```bash
+python tools/bootstrap_session.py \
+    --session sessions/my-session \
+    --file transcript.txt \
+    --framework framework-local \
+    --model qwen2.5:14b \
+    --base-url http://localhost:11434/v1
+```
+
+---
+
 ## Ingesting Turns
 
 ### Adding a DM Response

--- a/tools/bootstrap_session.py
+++ b/tools/bootstrap_session.py
@@ -286,7 +286,7 @@ def write_full_transcript(
     print(f"  [WRITE]  {transcript_path}")
 
 
-def ensure_metadata(session_dir: str, turns: list[Turn], dry_run: bool) -> None:
+def ensure_metadata(session_dir: str, turns: list[Turn], dry_run: bool, start_date: str | None = None) -> None:
     """Create metadata.json if it does not exist."""
     metadata_path = os.path.join(session_dir, "metadata.json")
     if os.path.exists(metadata_path):
@@ -308,7 +308,7 @@ def ensure_metadata(session_dir: str, turns: list[Turn], dry_run: bool) -> None:
     metadata = {
         "session_id": session_id,
         "title": session_id.replace("-", " ").title(),
-        "start_date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        "start_date": start_date,  # null when unknown
         "description": "Bootstrapped from existing transcript. Update this description.",
         "turn_count": len(turns),
     }
@@ -443,6 +443,22 @@ def main() -> None:
              "(default: framework). Use e.g. 'framework-local' to keep "
              "extraction output out of the public repo.",
     )
+    parser.add_argument(
+        "--start-date",
+        default=None,
+        help="Session start date in YYYY-MM-DD format. "
+             "Defaults to null for imported sessions where the date is unknown.",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Override the LLM model name from config/llm.json for this run.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Override the LLM API base URL from config/llm.json for this run.",
+    )
     args = parser.parse_args()
 
     # Validate inputs
@@ -542,7 +558,7 @@ def main() -> None:
     )
 
     print("\nChecking metadata:")
-    ensure_metadata(session_dir, turns, dry_run=args.dry_run)
+    ensure_metadata(session_dir, turns, dry_run=args.dry_run, start_date=args.start_date)
 
     print("\nScaffolding derived files:")
     ensure_derived_scaffolds(session_dir, latest_turn_id, dry_run=args.dry_run)
@@ -596,9 +612,16 @@ def main() -> None:
     try:
         from semantic_extraction import extract_semantic_batch
 
+        llm_overrides = {}
+        if args.model:
+            llm_overrides["model"] = args.model
+        if args.base_url:
+            llm_overrides["base_url"] = args.base_url
+
         print("\nRunning semantic extraction:")
         extract_semantic_batch(
-            turn_dicts, session_dir, framework_dir=args.framework, dry_run=args.dry_run
+            turn_dicts, session_dir, framework_dir=args.framework, dry_run=args.dry_run,
+            overrides=llm_overrides or None,
         )
     except ModuleNotFoundError as exc:
         if exc.name == "semantic_extraction":

--- a/tools/bootstrap_session.py
+++ b/tools/bootstrap_session.py
@@ -461,6 +461,18 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    # Validate --start-date format if provided
+    if args.start_date is not None:
+        try:
+            datetime.strptime(args.start_date, "%Y-%m-%d")
+        except ValueError:
+            print(
+                f"ERROR: Invalid --start-date '{args.start_date}'. "
+                "Expected format: YYYY-MM-DD (e.g. 2026-01-15).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
     # Validate inputs
     if not os.path.isfile(args.file):
         print(f"ERROR: Source file not found: {args.file}", file=sys.stderr)

--- a/tools/ingest_turn.py
+++ b/tools/ingest_turn.py
@@ -95,6 +95,16 @@ def main() -> None:
              "(default: framework). Use e.g. 'framework-local' to keep "
              "extraction output out of the public repo.",
     )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Override the LLM model name from config/llm.json for this run.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Override the LLM API base URL from config/llm.json for this run.",
+    )
     args = parser.parse_args()
 
     session_dir = args.session
@@ -150,8 +160,15 @@ def main() -> None:
         try:
             from semantic_extraction import extract_semantic_single
 
+            llm_overrides = {}
+            if args.model:
+                llm_overrides["model"] = args.model
+            if args.base_url:
+                llm_overrides["base_url"] = args.base_url
+
             extract_semantic_single(
-                turn_id, args.speaker, text, session_dir, framework_dir=args.framework
+                turn_id, args.speaker, text, session_dir, framework_dir=args.framework,
+                overrides=llm_overrides or None,
             )
         except ModuleNotFoundError as exc:
             if exc.name == "semantic_extraction":

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -19,9 +19,12 @@ class LLMExtractionError(Exception):
 class LLMClient:
     """Thin wrapper around the OpenAI Chat Completions API."""
 
-    def __init__(self, config_path: str = "config/llm.json"):
+    def __init__(self, config_path: str = "config/llm.json", overrides: dict | None = None):
         with open(config_path, "r", encoding="utf-8") as f:
             self.config = json.load(f)
+
+        if overrides:
+            self.config.update(overrides)
 
         try:
             from openai import OpenAI

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -548,6 +548,7 @@ def extract_semantic_batch(
     config_path: str = "config/llm.json",
     dry_run: bool = False,
     min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+    overrides: dict | None = None,
 ) -> None:
     """Run semantic extraction over all turns in batch mode.
 
@@ -562,7 +563,7 @@ def extract_semantic_batch(
         min_confidence: Minimum confidence to catalog an entity.
     """
     try:
-        llm = LLMClient(config_path)
+        llm = LLMClient(config_path, overrides=overrides)
     except (ImportError, LLMExtractionError, FileNotFoundError) as e:
         print(f"  WARNING: Semantic extraction not available: {e}", file=sys.stderr)
         return
@@ -656,6 +657,7 @@ def extract_semantic_single(
     framework_dir: str = "framework",
     config_path: str = "config/llm.json",
     min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+    overrides: dict | None = None,
 ) -> None:
     """Run semantic extraction for a single new turn.
 
@@ -671,7 +673,7 @@ def extract_semantic_single(
         min_confidence: Minimum confidence to catalog an entity.
     """
     try:
-        llm = LLMClient(config_path)
+        llm = LLMClient(config_path, overrides=overrides)
     except (ImportError, LLMExtractionError, FileNotFoundError) as e:
         print(f"  WARNING: Semantic extraction not available: {e}", file=sys.stderr)
         return

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -561,6 +561,11 @@ def extract_semantic_batch(
         config_path: Path to LLM configuration file.
         dry_run: If True, don't write files.
         min_confidence: Minimum confidence to catalog an entity.
+        overrides: Optional runtime overrides for LLM client configuration.
+            Supported keys include provider settings such as ``model`` and
+            ``base_url``. Any keys supplied here take precedence over values
+            loaded from ``config_path``; settings not provided in ``overrides``
+            continue to use the configuration file values.
     """
     try:
         llm = LLMClient(config_path, overrides=overrides)
@@ -671,6 +676,8 @@ def extract_semantic_single(
         framework_dir: Path to the framework directory containing catalogs.
         config_path: Path to LLM configuration file.
         min_confidence: Minimum confidence to catalog an entity.
+        overrides: Optional dictionary of config key/value overrides passed to
+            ``LLMClient`` to override settings loaded from ``config_path``.
     """
     try:
         llm = LLMClient(config_path, overrides=overrides)


### PR DESCRIPTION
## Summary

Three small independent fixes: metadata start_date default, CLI model overrides, and model size documentation.

## Issue #42 — start_date defaults to null

Changed `bootstrap_session.py` to default `start_date` to `null` instead of today's date. Added `--start-date` CLI flag for explicit dates.

## Issue #52 — --model and --base-url CLI overrides

Added `--model` and `--base-url` arguments to `bootstrap_session.py` and `ingest_turn.py`. `LLMClient` accepts an overrides dict that is applied after loading config. Allows per-run model selection without editing `config/llm.json`.

## Issue #53 — Model size documentation

Added LLM Model Requirements section to `docs/usage.md` covering minimum model sizes, tested models with quality notes, VRAM reference, known small-model limitations, and local model configuration.

Closes #42
Closes #52
Closes #53
