### PR TITLE
fix: same-speaker warning and metadata schema validation

### DIFF
--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "metadata.schema.json",
+  "title": "Session Metadata",
+  "description": "Metadata for a single session directory.",
+  "type": "object",
+  "required": ["session_id", "title", "turn_count"],
+  "additionalProperties": false,
+  "properties": {
+    "session_id": {
+      "type": "string",
+      "description": "Unique session identifier matching the directory name.",
+      "minLength": 1
+    },
+    "title": {
+      "type": "string",
+      "description": "Human-readable session title.",
+      "minLength": 1
+    },
+    "start_date": {
+      "type": ["string", "null"],
+      "description": "Session start date in YYYY-MM-DD format, or null if unknown.",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "description": {
+      "type": "string",
+      "description": "Brief session description."
+    },
+    "turn_count": {
+      "type": "integer",
+      "description": "Number of turns in the session.",
+      "minimum": 0
+    }
+  }
+}

--- a/tests/test_consecutive_speaker_warning.py
+++ b/tests/test_consecutive_speaker_warning.py
@@ -1,7 +1,11 @@
 """Tests for consecutive same-speaker turn detection."""
 
 import io
+import os
 import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
 from tools.bootstrap_session import Turn
 
 

--- a/tests/test_consecutive_speaker_warning.py
+++ b/tests/test_consecutive_speaker_warning.py
@@ -1,0 +1,62 @@
+"""Tests for consecutive same-speaker turn detection."""
+
+import io
+import sys
+from tools.bootstrap_session import Turn
+
+
+# Helper to capture stderr
+def _capture_warnings(turns):
+    from tools.bootstrap_session import _warn_consecutive_speakers
+    buf = io.StringIO()
+    old_stderr = sys.stderr
+    sys.stderr = buf
+    try:
+        _warn_consecutive_speakers(turns)
+    finally:
+        sys.stderr = old_stderr
+    return buf.getvalue()
+
+
+def test_no_warning_on_alternating_speakers():
+    turns = [
+        Turn(1, "player", "I look around."),
+        Turn(2, "dm", "You see a door."),
+        Turn(3, "player", "I open it."),
+    ]
+    output = _capture_warnings(turns)
+    assert output == ""
+
+
+def test_warns_consecutive_player_turns():
+    turns = [
+        Turn(1, "player", "I look around."),
+        Turn(2, "player", "I also check the ceiling."),
+        Turn(3, "dm", "You see a door."),
+    ]
+    output = _capture_warnings(turns)
+    assert "turns 1 and 2" in output
+    assert "player" in output
+
+
+def test_warns_consecutive_dm_turns():
+    turns = [
+        Turn(1, "dm", "The room is dark."),
+        Turn(2, "dm", "A sound echoes."),
+        Turn(3, "player", "I listen."),
+    ]
+    output = _capture_warnings(turns)
+    assert "turns 1 and 2" in output
+    assert "dm" in output
+
+
+def test_warns_multiple_consecutive_runs():
+    turns = [
+        Turn(1, "player", "A"),
+        Turn(2, "player", "B"),
+        Turn(3, "player", "C"),
+        Turn(4, "dm", "D"),
+    ]
+    output = _capture_warnings(turns)
+    assert "turns 1 and 2" in output
+    assert "turns 2 and 3" in output

--- a/tools/bootstrap_session.py
+++ b/tools/bootstrap_session.py
@@ -181,6 +181,21 @@ def parse_alternating_format(content: str, first_speaker: str) -> list[Turn]:
 
 
 # ---------------------------------------------------------------------------
+# Consecutive-speaker warning
+# ---------------------------------------------------------------------------
+
+def _warn_consecutive_speakers(turns: list[Turn]) -> None:
+    """Emit warnings for consecutive turns from the same speaker."""
+    for i in range(1, len(turns)):
+        if turns[i].speaker == turns[i - 1].speaker:
+            print(
+                f"WARNING: turns {turns[i - 1].sequence} and {turns[i].sequence} "
+                f"are both {turns[i].speaker} turns — possible parsing error",
+                file=sys.stderr,
+            )
+
+
+# ---------------------------------------------------------------------------
 # Format detection
 # ---------------------------------------------------------------------------
 
@@ -545,6 +560,8 @@ def main() -> None:
         print("ERROR: No turns could be parsed from the source file.", file=sys.stderr)
         print("Check --format, --dm-label, --player-label, and --first-speaker.", file=sys.stderr)
         sys.exit(1)
+
+    _warn_consecutive_speakers(turns)
 
     dm_count = sum(1 for t in turns if t.speaker == "dm")
     player_count = sum(1 for t in turns if t.speaker == "player")

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -47,6 +47,7 @@ SCHEMA_MAP = {
     "session-events.json": "schemas/session-events.schema.json",
     "timeline.json": "schemas/timeline.schema.json",
     "season-summaries.json": "schemas/season-summary.schema.json",
+    "metadata.json": "schemas/metadata.schema.json",
 }
 
 


### PR DESCRIPTION
## Summary

Two small independent fixes: consecutive same-speaker turn detection during bootstrap, and metadata.json schema validation.

## Issue #39 — Warn on consecutive same-speaker turns

Added `_warn_consecutive_speakers()` helper to `bootstrap_session.py` that emits a warning to stderr when consecutive turns share the same speaker. Runs after all parser formats. Added tests covering alternating, consecutive player, consecutive DM, and multi-run scenarios.

## Issue #41 — Add metadata.json schema and validation

Created `schemas/metadata.schema.json` with fields matching the existing metadata format. Added `metadata.json` to the SCHEMA_MAP in `validate.py`. `start_date` allows null per issue #42.

Closes #39
Closes #41
