### PR TITLE
feat: expand season summary extraction patterns

### DIFF
--- a/tests/test_season_summaries.py
+++ b/tests/test_season_summaries.py
@@ -1,5 +1,10 @@
 """Tests for season summary extraction."""
 
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
 from tools.extract_structured_data import extract_season_summaries
 
 
@@ -103,6 +108,42 @@ First frost observed.
     results = extract_season_summaries(text, "turn-020")
     assert len(results) == 1
     assert results[0].get("season") == "fall"
+
+
+def test_economic_or_ecological_section():
+    """'Economic or Ecological Shifts' variant is captured."""
+    text = """\
+**Season Summary**
+
+**Regional Changes:**
+Rivers are rising.
+
+**Economic or Ecological Shifts:**
+Trade caravans grow scarce as wildlife migrates south.
+"""
+    results = extract_season_summaries(text, "turn-030")
+    assert len(results) == 1
+    sections = results[0]["sections"]
+    assert "economic_shifts" in sections
+    assert "caravans" in sections["economic_shifts"]
+
+
+def test_singular_header_forms():
+    """Singular header forms (Rumor, Consequence) are mapped correctly."""
+    text = """\
+**Season Summary**
+
+**Rumor Reaching the Tribe:**
+A dragon was spotted.
+
+**Consequence of Prior Actions:**
+The village was rebuilt.
+"""
+    results = extract_season_summaries(text, "turn-035")
+    assert len(results) == 1
+    sections = results[0]["sections"]
+    assert "rumors" in sections
+    assert "consequences" in sections
 
 
 def test_no_match_on_normal_text():

--- a/tests/test_season_summaries.py
+++ b/tests/test_season_summaries.py
@@ -1,0 +1,112 @@
+"""Tests for season summary extraction."""
+
+from tools.extract_structured_data import extract_season_summaries
+
+
+# Minimal DM season summary block matching the reported format
+SAMPLE_SEASON_SUMMARY = """\
+**Season 2 Summary: Autumn**
+
+**Regional Changes:**
+The northern passes have begun to freeze. River crossings are treacherous.
+
+**Faction Actions:**
+The Iron Covenant increased border patrols. The River Clans stockpile grain.
+
+**Rumors Reaching the Tribe:**
+Travelers speak of strange lights in the western mountains.
+
+**Consequences of Prior Developments:**
+The bridge repair from last season has improved trade flow.
+"""
+
+
+def test_detects_season_2_summary_header():
+    """Season N Summary: <season> format is detected."""
+    results = extract_season_summaries(SAMPLE_SEASON_SUMMARY, "turn-042")
+    assert len(results) == 1
+    assert results[0]["source_turn"] == "turn-042"
+
+
+def test_extracts_season_name_from_header():
+    """Season name is extracted from the header line."""
+    results = extract_season_summaries(SAMPLE_SEASON_SUMMARY, "turn-042")
+    assert results[0].get("season") == "fall"  # "autumn" normalized to "fall"
+
+
+def test_extracts_standard_sections():
+    """Regional Changes and Faction Actions are extracted."""
+    results = extract_season_summaries(SAMPLE_SEASON_SUMMARY, "turn-042")
+    sections = results[0]["sections"]
+    assert "regional_changes" in sections
+    assert "faction_actions" in sections
+
+
+def test_extracts_rumors_section():
+    """Rumors Reaching the Tribe is captured."""
+    results = extract_season_summaries(SAMPLE_SEASON_SUMMARY, "turn-042")
+    sections = results[0]["sections"]
+    assert "rumors" in sections
+    assert "strange lights" in sections["rumors"]
+
+
+def test_extracts_consequences_section():
+    """Consequences of Prior Developments is captured."""
+    results = extract_season_summaries(SAMPLE_SEASON_SUMMARY, "turn-042")
+    sections = results[0]["sections"]
+    assert "consequences" in sections
+    assert "bridge repair" in sections["consequences"]
+
+
+def test_captures_raw_text():
+    """raw_text field is populated."""
+    results = extract_season_summaries(SAMPLE_SEASON_SUMMARY, "turn-042")
+    assert results[0].get("raw_text")
+    assert len(results[0]["raw_text"]) > 0
+
+
+def test_id_format():
+    """ID follows ss-NNN pattern."""
+    results = extract_season_summaries(SAMPLE_SEASON_SUMMARY, "turn-042")
+    assert results[0]["id"] == "ss-001"
+
+
+def test_original_format_still_works():
+    """Original 'Season Summary' header (no number, no colon) still detected."""
+    text = """\
+**Season Summary**
+
+**Regional Changes:**
+Snow covers the lowlands.
+
+**Faction Actions:**
+The guild suspends trade.
+"""
+    results = extract_season_summaries(text, "turn-010")
+    assert len(results) == 1
+    sections = results[0]["sections"]
+    assert "regional_changes" in sections
+    assert "faction_actions" in sections
+
+
+def test_season_summary_with_just_season_name():
+    """'Autumn Summary' format is detected."""
+    text = """\
+**Autumn Summary**
+
+**Regional Changes:**
+Leaves fall.
+
+**Environmental Notes:**
+First frost observed.
+"""
+    results = extract_season_summaries(text, "turn-020")
+    assert len(results) == 1
+    assert results[0].get("season") == "fall"
+
+
+def test_no_match_on_normal_text():
+    """Normal narrative text does not trigger season summary detection."""
+    text = "The party traveled through autumn forests. The consequences of their actions were unclear."
+    results = extract_season_summaries(text, "turn-005")
+    assert len(results) == 0

--- a/tools/extract_structured_data.py
+++ b/tools/extract_structured_data.py
@@ -228,10 +228,12 @@ _SECTION_HEADER_RE = re.compile(
     r"(?P<name>"
     r"Regional\s+Changes?"
     r"|Faction\s+Actions?"
-    r"|Economic\s+(?:Shifts?|Changes?|Updates?)"
+    r"|Economic\s+(?:(?:or\s+)?Ecological\s+)?(?:Shifts?|Changes?|Updates?)"
     r"|Environmental\s+(?:Notes?|Conditions?|Changes?)"
+    r"|Rumors?\s+(?:Reaching|and\s+).*"
+    r"|Consequences?\s+(?:of\s+).*"
     r")"
-    r"\1\s*:?\s*$",
+    r":?\s*\1\s*:?\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
 
@@ -240,12 +242,20 @@ _SECTION_NAME_MAP = {
     "faction": "faction_actions",
     "economic": "economic_shifts",
     "environmental": "environmental_notes",
+    "rumors": "rumors",
+    "consequences": "consequences",
 }
 
 SEASON_SUMMARY_BLOCK_PATTERN = re.compile(
-    r"(?:^|\n)(?:\*{0,2})?(?:Season\s+Summary|(?:"
-    + _SEASON_ALT
-    + r")\s+(?:Summary|Overview|Report|Update))(?:\*{0,2})?\s*:?\s*\n",
+    r"(?:^|\n)(?:\*{0,2})?(?:"
+    r"Season\s+(?:\d+\s+)?Summary"
+    r"|(?:" + _SEASON_ALT + r")\s+(?:Summary|Overview|Report|Update)"
+    r")(?:\*{0,2})?\s*(?::\s*(?:\*{0,2})?(?:" + _SEASON_ALT + r")?(?:\*{0,2})?)?\s*\n",
+    re.IGNORECASE,
+)
+
+_HEADER_SEASON_RE = re.compile(
+    r"Season\s+(?:\d+\s+)?Summary\s*:\s*(?:\*{0,2})?(?P<season>" + _SEASON_ALT + r")",
     re.IGNORECASE,
 )
 
@@ -318,12 +328,16 @@ def extract_season_summaries(
     if not has_explicit_header and not has_enough_sections:
         return []
 
-    # Detect which season this summary covers
+    # Detect which season this summary covers — first try the header line
     season = None
-    for sn in SEASON_NAMES:
-        if re.search(r"\b" + sn + r"\b", text[:300], re.IGNORECASE):
-            season = _normalize_season(sn)
-            break
+    hdr_season_match = _HEADER_SEASON_RE.search(text)
+    if hdr_season_match:
+        season = _normalize_season(hdr_season_match.group("season"))
+    else:
+        for sn in SEASON_NAMES:
+            if re.search(r"\b" + sn + r"\b", text[:300], re.IGNORECASE):
+                season = _normalize_season(sn)
+                break
 
     year = _detect_year(text)
 

--- a/tools/extract_structured_data.py
+++ b/tools/extract_structured_data.py
@@ -243,7 +243,9 @@ _SECTION_NAME_MAP = {
     "economic": "economic_shifts",
     "environmental": "environmental_notes",
     "rumors": "rumors",
+    "rumor": "rumors",
     "consequences": "consequences",
+    "consequence": "consequences",
 }
 
 SEASON_SUMMARY_BLOCK_PATTERN = re.compile(


### PR DESCRIPTION
## Summary

Expands season summary extraction patterns in `extract_structured_data.py` to match real DM transcript formats.

### Changes

- Expanded `SEASON_SUMMARY_BLOCK_PATTERN` to match "Season N Summary: \<season\>" format (with optional number and colon-separated season name)
- Fixed `_SECTION_HEADER_RE` to handle colon-inside-bold format (`**Header:**`) used by the DM
- Added section header patterns for "Rumors" and "Consequences" sections
- Added "Economic or Ecological" variant to economic section pattern
- Added section name mappings for the new headers
- Extract season name from header line before falling back to text scan
- Added comprehensive tests covering new and existing formats (10 tests)

Closes #40
