### PR TITLE
fix: LLM array coercion and BOM-safe catalog reads

### DIFF
--- a/tests/test_coerce_entity.py
+++ b/tests/test_coerce_entity.py
@@ -1,0 +1,76 @@
+"""Tests for LLM output coercion before entity validation."""
+
+import io
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from semantic_extraction import _coerce_entity_fields
+
+
+def test_unwraps_single_element_array_name():
+    entity = {"name": ["A younger woman"], "type": "character"}
+    result = _coerce_entity_fields(entity)
+    assert result["name"] == "A younger woman"
+
+
+def test_joins_multi_element_array_name():
+    entity = {"name": ["Kael", "Player Character"], "type": "character"}
+    result = _coerce_entity_fields(entity)
+    assert result["name"] == "Kael, Player Character"
+
+
+def test_stringifies_array_attribute():
+    entity = {
+        "name": "Herb",
+        "type": "item",
+        "attributes": {"uses": ["healing", "cooking"]},
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["attributes"]["uses"] == "healing, cooking"
+
+
+def test_stringifies_dict_attribute():
+    entity = {
+        "name": "Herb",
+        "type": "item",
+        "attributes": {"relationship": {"target_id": "char-001", "type": "owned_by"}},
+    }
+    result = _coerce_entity_fields(entity)
+    assert isinstance(result["attributes"]["relationship"], str)
+
+
+def test_wraps_single_relationship_dict():
+    entity = {
+        "name": "Kael",
+        "type": "character",
+        "relationships": {"target_id": "loc-camp", "type": "located_at"},
+    }
+    result = _coerce_entity_fields(entity)
+    assert isinstance(result["relationships"], list)
+    assert len(result["relationships"]) == 1
+
+
+def test_leaves_valid_entity_unchanged():
+    entity = {
+        "name": "Kael",
+        "type": "character",
+        "description": "The player character.",
+        "attributes": {"role": "protagonist"},
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["name"] == "Kael"
+    assert result["attributes"]["role"] == "protagonist"
+
+
+def test_logs_coercions_to_stderr():
+    entity = {"name": ["Test"], "type": "character"}
+    buf = io.StringIO()
+    old = sys.stderr
+    sys.stderr = buf
+    try:
+        _coerce_entity_fields(entity)
+    finally:
+        sys.stderr = old
+    assert "COERCE" in buf.getvalue()

--- a/tests/test_coerce_entity.py
+++ b/tests/test_coerce_entity.py
@@ -74,3 +74,37 @@ def test_logs_coercions_to_stderr():
     finally:
         sys.stderr = old
     assert "COERCE" in buf.getvalue()
+
+
+def test_returns_none_for_non_dict():
+    assert _coerce_entity_fields(["not", "a", "dict"]) is None
+    assert _coerce_entity_fields("just a string") is None
+    assert _coerce_entity_fields(42) is None
+
+
+def test_empty_array_becomes_empty_string():
+    entity = {"name": [], "type": "character"}
+    result = _coerce_entity_fields(entity)
+    assert result["name"] == ""
+
+
+def test_coerces_numeric_attribute_to_string():
+    entity = {
+        "name": "Herb",
+        "type": "item",
+        "attributes": {"weight": 5, "magical": True, "value": 3.5},
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["attributes"]["weight"] == "5"
+    assert result["attributes"]["magical"] == "True"
+    assert result["attributes"]["value"] == "3.5"
+
+
+def test_coerces_none_attribute_to_empty_string():
+    entity = {
+        "name": "Herb",
+        "type": "item",
+        "attributes": {"notes": None},
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["attributes"]["notes"] == ""

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -41,7 +41,7 @@ def load_catalogs(catalog_dir: str) -> dict:
     for filename in ["characters.json", "locations.json", "factions.json", "items.json"]:
         filepath = os.path.join(catalog_dir, filename)
         if os.path.exists(filepath):
-            with open(filepath, "r", encoding="utf-8") as f:
+            with open(filepath, "r", encoding="utf-8-sig") as f:
                 catalogs[filename] = json.load(f)
         else:
             catalogs[filename] = []
@@ -52,7 +52,7 @@ def load_events(catalog_dir: str) -> list:
     """Load the events catalog."""
     filepath = os.path.join(catalog_dir, "events.json")
     if os.path.exists(filepath):
-        with open(filepath, "r", encoding="utf-8") as f:
+        with open(filepath, "r", encoding="utf-8-sig") as f:
             return json.load(f)
     return []
 

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -107,14 +107,21 @@ def _load_schema(name: str) -> dict | None:
     return _schema_cache.get(name)
 
 
-def _coerce_entity_fields(entity_data: dict) -> dict:
+def _coerce_entity_fields(entity_data) -> dict | None:
     """Auto-coerce common LLM output quirks before schema validation.
 
     Fixes:
+    - Non-dict entity → return None with warning
     - Single-element arrays → unwrap to string
     - Multi-element arrays → join with ', '
-    - Dict/list values in attributes → stringify
+    - Empty arrays → empty string
+    - Dict/list/numeric/bool/None values in attributes → stringify
     """
+    if not isinstance(entity_data, dict):
+        print(f"  WARNING: entity_data is {type(entity_data).__name__}, expected dict — skipping",
+              file=sys.stderr)
+        return None
+
     # Top-level string fields that the LLM sometimes wraps in arrays
     string_fields = ["name", "description", "type", "proposed_id",
                      "first_seen_turn", "last_updated_turn"]
@@ -125,18 +132,25 @@ def _coerce_entity_fields(entity_data: dict) -> dict:
                 entity_data[field] = str(val[0])
             elif len(val) > 1:
                 entity_data[field] = ", ".join(str(v) for v in val)
+            else:
+                entity_data[field] = ""
             print(f"  COERCE: {field} array → string: {val!r}", file=sys.stderr)
 
     # Attributes: values must be strings per schema
     attrs = entity_data.get("attributes", {})
     if isinstance(attrs, dict):
         for key, val in list(attrs.items()):
+            if isinstance(val, str):
+                continue
             if isinstance(val, list):
                 attrs[key] = ", ".join(str(v) for v in val)
-                print(f"  COERCE: attributes.{key} array → string", file=sys.stderr)
             elif isinstance(val, dict):
                 attrs[key] = json.dumps(val)
-                print(f"  COERCE: attributes.{key} dict → string", file=sys.stderr)
+            elif val is None:
+                attrs[key] = ""
+            else:
+                attrs[key] = str(val)
+            print(f"  COERCE: attributes.{key} {type(val).__name__} → string", file=sys.stderr)
 
     # Relationships: should be an array of objects, but sometimes a single dict
     rels = entity_data.get("relationships")

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -107,6 +107,46 @@ def _load_schema(name: str) -> dict | None:
     return _schema_cache.get(name)
 
 
+def _coerce_entity_fields(entity_data: dict) -> dict:
+    """Auto-coerce common LLM output quirks before schema validation.
+
+    Fixes:
+    - Single-element arrays → unwrap to string
+    - Multi-element arrays → join with ', '
+    - Dict/list values in attributes → stringify
+    """
+    # Top-level string fields that the LLM sometimes wraps in arrays
+    string_fields = ["name", "description", "type", "proposed_id",
+                     "first_seen_turn", "last_updated_turn"]
+    for field in string_fields:
+        val = entity_data.get(field)
+        if isinstance(val, list):
+            if len(val) == 1:
+                entity_data[field] = str(val[0])
+            elif len(val) > 1:
+                entity_data[field] = ", ".join(str(v) for v in val)
+            print(f"  COERCE: {field} array → string: {val!r}", file=sys.stderr)
+
+    # Attributes: values must be strings per schema
+    attrs = entity_data.get("attributes", {})
+    if isinstance(attrs, dict):
+        for key, val in list(attrs.items()):
+            if isinstance(val, list):
+                attrs[key] = ", ".join(str(v) for v in val)
+                print(f"  COERCE: attributes.{key} array → string", file=sys.stderr)
+            elif isinstance(val, dict):
+                attrs[key] = json.dumps(val)
+                print(f"  COERCE: attributes.{key} dict → string", file=sys.stderr)
+
+    # Relationships: should be an array of objects, but sometimes a single dict
+    rels = entity_data.get("relationships")
+    if isinstance(rels, dict):
+        entity_data["relationships"] = [rels]
+        print("  COERCE: relationships dict → single-element array", file=sys.stderr)
+
+    return entity_data
+
+
 def _validate_entity(entity_data: dict) -> bool:
     """Validate an entity dict against entity.schema.json. Returns True if valid."""
     schema = _load_schema("entity.schema.json")
@@ -309,6 +349,8 @@ def extract_and_merge(
             continue
 
         entity_data = detail_result.get("entity")
+        if entity_data:
+            entity_data = _coerce_entity_fields(entity_data)
         if entity_data and _validate_entity(entity_data):
             _filter_pc_attributes(entity_data)
             merge_entity(catalogs, entity_data)
@@ -338,6 +380,8 @@ def extract_and_merge(
                 user_prompt=format_detail_prompt(turn, pc_ref, pc_entry),
             )
             entity_data = detail_result.get("entity")
+            if entity_data:
+                entity_data = _coerce_entity_fields(entity_data)
             if entity_data and _validate_entity(entity_data):
                 _filter_pc_attributes(entity_data)
                 merge_entity(catalogs, entity_data)


### PR DESCRIPTION
## Summary

Fixes two bugs found during the extraction test run on turns 1-30.

## Issue #69 — Auto-coerce LLM array-wrapped strings

Added `_coerce_entity_fields()` to `semantic_extraction.py` that runs before `_validate_entity()` at both call sites. Handles:
- Single-element arrays unwrapped to strings
- Multi-element arrays joined with comma
- Dict/list attribute values stringified
- Single relationship dicts wrapped in arrays

This recovers entities that were previously silently dropped (at least 4 observed in the test run). Added 7 unit tests.

## Issue #70 — UTF-8 BOM handling in catalog_merger.py

Changed read operations in `load_catalogs()` and `load_events()` from `utf-8` to `utf-8-sig` encoding. Write operations unchanged (no BOM on output).

Closes #69
Closes #70
