### PR TITLE
fix: comma-ID coercion, backstory extraction, pronoun prevention

### DIFF
--- a/templates/extraction/entity-discovery.md
+++ b/templates/extraction/entity-discovery.md
@@ -25,7 +25,7 @@ Rules:
 - For items: if a previously cataloged item is referenced by a shorter name, partial description, or with/without adjectives (e.g., "the spear" referring to a previously seen "crude wood-hafted spear"), set is_new to false and provide the existing_id. Do not create a new entry for a name variant of the same physical object.
 - "proposed_id" and "existing_id" are mutually exclusive: exactly one must be non-null for each result.
 - Extract entities from ALL parts of the turn text, including: backstory narration, environmental descriptions, recalled memories, quest briefings, and scene-setting passages. A location where a scene takes place should be extracted even if it is unnamed — use the descriptive phrase (e.g., "a dense forest", "the winding path").
-- Abstract or distant references count: if the text mentions a village the PC departed from, a artifact they are seeking, or a council that sent them on a mission, extract those as entities with the appropriate type.
+- Abstract or distant references count: if the text mentions a village the PC departed from, an artifact they are seeking, or a council that sent them on a mission, extract those as entities with the appropriate type.
 - Environmental and transitional locations (forests, paths, clearings, rivers) should be extracted as locations when the narrative establishes them as distinct settings where action occurs.
 
 Return a JSON object with a single key "entities" containing an array of entity objects.

--- a/templates/extraction/entity-discovery.md
+++ b/templates/extraction/entity-discovery.md
@@ -21,8 +21,12 @@ Rules:
 - The player character ("you" in DM turns) should NOT be extracted — they are pre-seeded in the catalog.
 - Confidence below 0.5 means the mention is too vague to catalog.
 - For coreference resolution: if a mention refers to an already-known entity (even by a different name, title, or alias shown in the known-entities list), set is_new to false and provide the existing_id. Use the descriptions and aliases in the known-entities list to identify matches.
+- NEVER create a new entity whose name is a pronoun (he, she, they, it, him, her, them, this one, that one, the figure, etc. when used as a pure anaphoric reference). Instead, resolve the pronoun to an already-known entity and set is_new to false. If the referent cannot be determined, skip the mention entirely — do not create a placeholder entity.
 - For items: if a previously cataloged item is referenced by a shorter name, partial description, or with/without adjectives (e.g., "the spear" referring to a previously seen "crude wood-hafted spear"), set is_new to false and provide the existing_id. Do not create a new entry for a name variant of the same physical object.
 - "proposed_id" and "existing_id" are mutually exclusive: exactly one must be non-null for each result.
+- Extract entities from ALL parts of the turn text, including: backstory narration, environmental descriptions, recalled memories, quest briefings, and scene-setting passages. A location where a scene takes place should be extracted even if it is unnamed — use the descriptive phrase (e.g., "a dense forest", "the winding path").
+- Abstract or distant references count: if the text mentions a village the PC departed from, a artifact they are seeking, or a council that sent them on a mission, extract those as entities with the appropriate type.
+- Environmental and transitional locations (forests, paths, clearings, rivers) should be extracted as locations when the narrative establishes them as distinct settings where action occurs.
 
 Return a JSON object with a single key "entities" containing an array of entity objects.
 
@@ -39,5 +43,12 @@ Item identification tips:
 - Weapons (swords, spears, bows), containers (bowls, chests, bags), substances (potions, pastes, powders), traps/mechanisms (tripwires, snares, pressure plates), and quest objects (artifacts, keys, tokens) are all type "item".
 - If an item is part of a trap or mechanism, extract both the mechanism and any separate components as individual items.
 - Food, drink, and consumables that have narrative significance (e.g. offered as part of a ritual, restore HP) are items.
+
+Location identification tips:
+- Named places (cities, temples, inns) are locations.
+- Unnamed but distinct settings where scenes occur are locations — use the descriptive phrase as the name (e.g., "dense forest", "snow-covered clearing", "narrow mountain path").
+- Environmental features that serve as landmarks or scene boundaries are locations (rivers, bridges, cave entrances).
+- Backstory locations (where the PC came from, places mentioned in quest briefings) should be extracted even if the PC is not currently there.
+- Do NOT extract vague directional references ("to the north", "ahead") as locations unless they describe a specific place.
 
 If no entities are found in the turn, return: {"entities": []}

--- a/tests/test_coerce_entity.py
+++ b/tests/test_coerce_entity.py
@@ -131,6 +131,37 @@ def test_leaves_non_comma_proposed_id_unchanged():
     assert result["proposed_id"] == "char-elder"
 
 
+def test_splits_comma_separated_id():
+    entity = {
+        "name": "two figures",
+        "type": "faction",
+        "id": "char-broad-figure,char-companion-of-broad-figure,faction-two-figures",
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["id"] == "faction-two-figures"
+
+
+def test_splits_comma_separated_id_takes_first_when_no_type_match():
+    entity = {
+        "name": "something",
+        "type": "creature",
+        "id": "char-a,loc-b,faction-c",
+    }
+    result = _coerce_entity_fields(entity)
+    # No creature- prefix match, takes first
+    assert result["id"] == "char-a"
+
+
+def test_leaves_non_comma_id_unchanged():
+    entity = {
+        "name": "elder",
+        "type": "character",
+        "id": "char-elder",
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["id"] == "char-elder"
+
+
 def test_coerces_none_attribute_to_empty_string():
     entity = {
         "name": "Herb",

--- a/tests/test_coerce_entity.py
+++ b/tests/test_coerce_entity.py
@@ -100,6 +100,37 @@ def test_coerces_numeric_attribute_to_string():
     assert result["attributes"]["value"] == "3.5"
 
 
+def test_splits_comma_separated_proposed_id():
+    entity = {
+        "name": "two figures",
+        "type": "faction",
+        "proposed_id": "char-broad-figure,char-companion-of-broad-figure,faction-two-figures",
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["proposed_id"] == "faction-two-figures"
+
+
+def test_splits_comma_id_takes_first_when_no_type_match():
+    entity = {
+        "name": "something",
+        "type": "creature",
+        "proposed_id": "char-a,loc-b,faction-c",
+    }
+    result = _coerce_entity_fields(entity)
+    # No creature- prefix match, takes first
+    assert result["proposed_id"] == "char-a"
+
+
+def test_leaves_non_comma_proposed_id_unchanged():
+    entity = {
+        "name": "elder",
+        "type": "character",
+        "proposed_id": "char-elder",
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["proposed_id"] == "char-elder"
+
+
 def test_coerces_none_attribute_to_empty_string():
     entity = {
         "name": "Herb",

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -136,17 +136,18 @@ def _coerce_entity_fields(entity_data) -> dict | None:
                 entity_data[field] = ""
             print(f"  COERCE: {field} array → string: {val!r}", file=sys.stderr)
 
-    # If proposed_id contains commas, the LLM crammed multiple IDs into one
-    # field.  Pick the one whose prefix matches the declared entity type.
-    pid = entity_data.get("proposed_id", "")
+    # If proposed_id or id contains commas, the LLM crammed multiple IDs into
+    # one field.  Pick the one whose prefix matches the declared entity type.
     etype = entity_data.get("type", "")
-    if isinstance(pid, str) and "," in pid:
-        from catalog_merger import validate_id_prefix
-        parts = [p.strip() for p in pid.split(",") if p.strip()]
-        matched = [p for p in parts if etype and validate_id_prefix(p, etype)]
-        chosen = matched[0] if matched else parts[0] if parts else pid
-        print(f"  COERCE: proposed_id comma-split: {pid!r} → {chosen!r}", file=sys.stderr)
-        entity_data["proposed_id"] = chosen
+    for id_field in ("proposed_id", "id"):
+        pid = entity_data.get(id_field, "")
+        if isinstance(pid, str) and "," in pid:
+            from catalog_merger import validate_id_prefix
+            parts = [p.strip() for p in pid.split(",") if p.strip()]
+            matched = [p for p in parts if etype and validate_id_prefix(p, etype)]
+            chosen = matched[0] if matched else parts[0] if parts else pid
+            print(f"  COERCE: {id_field} comma-split: {pid!r} → {chosen!r}", file=sys.stderr)
+            entity_data[id_field] = chosen
 
     # Attributes: values must be strings per schema
     attrs = entity_data.get("attributes", {})

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -136,6 +136,18 @@ def _coerce_entity_fields(entity_data) -> dict | None:
                 entity_data[field] = ""
             print(f"  COERCE: {field} array → string: {val!r}", file=sys.stderr)
 
+    # If proposed_id contains commas, the LLM crammed multiple IDs into one
+    # field.  Pick the one whose prefix matches the declared entity type.
+    pid = entity_data.get("proposed_id", "")
+    etype = entity_data.get("type", "")
+    if isinstance(pid, str) and "," in pid:
+        from catalog_merger import validate_id_prefix
+        parts = [p.strip() for p in pid.split(",") if p.strip()]
+        matched = [p for p in parts if etype and validate_id_prefix(p, etype)]
+        chosen = matched[0] if matched else parts[0] if parts else pid
+        print(f"  COERCE: proposed_id comma-split: {pid!r} → {chosen!r}", file=sys.stderr)
+        entity_data["proposed_id"] = chosen
+
     # Attributes: values must be strings per schema
     attrs = entity_data.get("attributes", {})
     if isinstance(attrs, dict):


### PR DESCRIPTION
## Summary

Three targeted fixes to improve extraction quality, based on test report findings (Run 2, 2026-04-10).

## Issue #73 — Comma-separated multi-ID coercion

Added comma-split logic to `_coerce_entity_fields()`. When `proposed_id` contains commas, splits on comma and selects the part whose prefix matches the entity's declared type. Falls back to the first part if no match. Added 3 tests.

## Issue #74 — Backstory entity extraction

Expanded `entity-discovery.md` prompt with rules for extracting entities from backstory narration, environmental descriptions, quest briefings, and abstract references. Added location identification tips section with examples of unnamed but distinct settings.

## Issue #75 — Pronoun entity prevention

Added explicit rule to `entity-discovery.md` forbidding creation of entities whose name is a pronoun. Requires resolution to known entities or skipping the mention.

Closes #73
Closes #74
Closes #75
