### PR TITLE
feat: V1 to V2 catalog migration script

### DIFF
--- a/tests/test_migrate_catalogs.py
+++ b/tests/test_migrate_catalogs.py
@@ -1,7 +1,5 @@
 """Tests for tools/migrate_catalogs_v2.py"""
 
-import json
-import shutil
 from pathlib import Path
 
 import pytest
@@ -19,10 +17,8 @@ from migrate_catalogs_v2 import (
     migrate_catalog,
     strip_inference_tag,
     wrap_stable_attribute,
-    find_max_turn,
     write_json,
     read_json,
-    CATALOG_TYPES,
 )
 
 
@@ -309,8 +305,8 @@ def test_index_generation():
     assert entry["first_seen_turn"] == "turn-001"
     assert entry["last_updated_turn"] == "turn-050"
     assert entry["active_relationship_count"] == 1
-    assert len(entry["status_summary"]) <= 80
-    assert entry["status_summary"].startswith("A legendary hero")
+    # status_summary derives from current_status (per schema), not identity
+    assert entry["status_summary"] == "Resting."
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_migrate_catalogs.py
+++ b/tests/test_migrate_catalogs.py
@@ -1,0 +1,505 @@
+"""Tests for tools/migrate_catalogs_v2.py"""
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+# Ensure tools/ is importable
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+
+from migrate_catalogs_v2 import (
+    classify_attributes,
+    consolidate_relationships,
+    convert_entity,
+    build_index_entry,
+    migrate_catalog,
+    strip_inference_tag,
+    wrap_stable_attribute,
+    find_max_turn,
+    write_json,
+    read_json,
+    CATALOG_TYPES,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_framework(tmp_path):
+    """Create a temporary framework directory with V1 catalog files."""
+    catalogs = tmp_path / "catalogs"
+    catalogs.mkdir()
+    return tmp_path
+
+
+def write_catalog(framework_dir: Path, catalog_name: str, entities: list):
+    """Helper to write a V1 catalog file."""
+    path = framework_dir / "catalogs" / f"{catalog_name}.json"
+    write_json(path, entities)
+
+
+# ---------------------------------------------------------------------------
+# test_description_to_identity_split
+# ---------------------------------------------------------------------------
+
+
+def test_description_to_identity_split():
+    """V1 entity with 'description' produces V2 entity with 'identity' + placeholder 'current_status'."""
+    v1 = {
+        "id": "char-test",
+        "name": "Test Character",
+        "type": "character",
+        "description": "A brave warrior from the northern lands.",
+        "attributes": {},
+        "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-010",
+    }
+    v2 = convert_entity(v1, max_turn=50)
+
+    assert v2["identity"] == "A brave warrior from the northern lands."
+    assert v2["current_status"] == "Status unknown \u2014 migrated from V1 catalog."
+    assert v2["status_updated_turn"] == "turn-010"
+
+
+# ---------------------------------------------------------------------------
+# test_stable_attribute_classification
+# ---------------------------------------------------------------------------
+
+
+def test_stable_attribute_classification():
+    """'race', 'class' go to stable_attributes; 'condition', 'equipment' go to volatile_state."""
+    attrs = {
+        "race": "Elf",
+        "class": "Ranger",
+        "appearance": "Tall with dark hair",
+        "condition": "Healthy",
+        "equipment": "sword, shield, lantern",
+    }
+    stable, volatile = classify_attributes(attrs, "turn-001")
+
+    assert "race" in stable
+    assert stable["race"]["value"] == "Elf"
+    assert "class" in stable
+    assert "appearance" in stable
+
+    assert "condition" in volatile
+    assert volatile["condition"] == "Healthy"
+    assert "equipment" in volatile
+    assert isinstance(volatile["equipment"], list)
+    assert "sword" in volatile["equipment"]
+
+
+# ---------------------------------------------------------------------------
+# test_volatile_attribute_classification
+# ---------------------------------------------------------------------------
+
+
+def test_volatile_attribute_classification():
+    """Volatile keys moved correctly with last_updated_turn in volatile_state."""
+    v1 = {
+        "id": "char-v",
+        "name": "Volatile Test",
+        "type": "character",
+        "description": "Test entity.",
+        "attributes": {
+            "condition": "Injured",
+            "status": "Resting",
+            "hp_change": "-2 HP",
+            "location": "loc-camp",
+            "last_action": "sleeping",
+            "race": "Human",
+        },
+        "first_seen_turn": "turn-005",
+        "last_updated_turn": "turn-020",
+    }
+    v2 = convert_entity(v1, max_turn=50)
+
+    vol = v2["volatile_state"]
+    assert vol["condition"] == "Injured"
+    assert vol["status"] == "Resting"
+    assert vol["hp_change"] == "-2 HP"
+    assert vol["location"] == "loc-camp"
+    assert vol["last_action"] == "sleeping"
+    assert vol["last_updated_turn"] == "turn-020"
+
+    stable = v2.get("stable_attributes", {})
+    assert "race" in stable
+    assert stable["race"]["value"] == "Human"
+    # Volatile keys should NOT be in stable
+    assert "condition" not in stable
+    assert "status" not in stable
+
+
+# ---------------------------------------------------------------------------
+# test_inference_tag_parsing
+# ---------------------------------------------------------------------------
+
+
+def test_inference_tag_parsing():
+    """'tall, scarred [inference]' → value stripped, inference=True, confidence=0.7."""
+    clean, inferred = strip_inference_tag("tall, scarred [inference]")
+    assert clean == "tall, scarred"
+    assert inferred is True
+
+    attr = wrap_stable_attribute("tall, scarred [inference]", "turn-003")
+    assert attr["value"] == "tall, scarred"
+    assert attr["inference"] is True
+    assert attr["confidence"] == 0.7
+    assert attr["source_turn"] == "turn-003"
+
+
+def test_no_inference_tag():
+    """Normal value without [inference] → inference=False, no confidence."""
+    attr = wrap_stable_attribute("Elf", "turn-001")
+    assert attr["value"] == "Elf"
+    assert attr["inference"] is False
+    assert "confidence" not in attr
+
+
+# ---------------------------------------------------------------------------
+# test_relationship_consolidation
+# ---------------------------------------------------------------------------
+
+
+def test_relationship_consolidation():
+    """3 relationships for same pair → 1 entry with current_relationship + 2 history entries."""
+    rels = [
+        {
+            "target_id": "char-npc",
+            "relationship": "meets",
+            "type": "social",
+            "first_seen_turn": "turn-010",
+            "last_updated_turn": "turn-010",
+        },
+        {
+            "target_id": "char-npc",
+            "relationship": "befriends",
+            "type": "partnership",
+            "first_seen_turn": "turn-020",
+            "last_updated_turn": "turn-020",
+        },
+        {
+            "target_id": "char-npc",
+            "relationship": "close allies",
+            "type": "partnership",
+            "first_seen_turn": "turn-030",
+            "last_updated_turn": "turn-030",
+        },
+    ]
+    result = consolidate_relationships(rels, "turn-001", max_turn=50)
+
+    assert len(result) == 1
+    r = result[0]
+    assert r["target_id"] == "char-npc"
+    assert r["current_relationship"] == "close allies"
+    assert r["type"] == "partnership"
+    assert r["first_seen_turn"] == "turn-010"
+    assert r["last_updated_turn"] == "turn-030"
+    assert len(r["history"]) == 2
+    assert r["history"][0]["description"] == "meets"
+    assert r["history"][0]["turn"] == "turn-010"
+    assert r["history"][1]["description"] == "befriends"
+
+
+def test_relationship_consolidation_multiple_targets():
+    """Relationships to different targets stay separate."""
+    rels = [
+        {
+            "target_id": "char-a",
+            "relationship": "friends",
+            "type": "social",
+            "first_seen_turn": "turn-005",
+            "last_updated_turn": "turn-005",
+        },
+        {
+            "target_id": "char-b",
+            "relationship": "rivals",
+            "type": "adversarial",
+            "first_seen_turn": "turn-010",
+            "last_updated_turn": "turn-010",
+        },
+    ]
+    result = consolidate_relationships(rels, "turn-001", max_turn=50)
+    assert len(result) == 2
+    targets = {r["target_id"] for r in result}
+    assert targets == {"char-a", "char-b"}
+
+
+# ---------------------------------------------------------------------------
+# test_dormancy_marking
+# ---------------------------------------------------------------------------
+
+
+def test_dormancy_marking():
+    """Entity not updated in 15 turns → relationships marked dormant."""
+    rels = [
+        {
+            "target_id": "char-old",
+            "relationship": "acquaintance",
+            "type": "social",
+            "first_seen_turn": "turn-010",
+            "last_updated_turn": "turn-035",
+        },
+    ]
+    # max_turn=50, last_updated=35, delta=15 > threshold(10) → dormant
+    result = consolidate_relationships(rels, "turn-001", max_turn=50)
+    assert result[0]["status"] == "dormant"
+
+
+def test_active_marking():
+    """Entity recently updated → relationships marked active."""
+    rels = [
+        {
+            "target_id": "char-recent",
+            "relationship": "ally",
+            "type": "partnership",
+            "first_seen_turn": "turn-040",
+            "last_updated_turn": "turn-048",
+        },
+    ]
+    # max_turn=50, last_updated=48, delta=2 ≤ threshold(10) → active
+    result = consolidate_relationships(rels, "turn-001", max_turn=50)
+    assert result[0]["status"] == "active"
+
+
+# ---------------------------------------------------------------------------
+# test_index_generation
+# ---------------------------------------------------------------------------
+
+
+def test_index_generation():
+    """index.json has correct counts and summaries."""
+    v2 = {
+        "id": "char-hero",
+        "name": "Hero",
+        "type": "character",
+        "identity": "A legendary hero known throughout the land for slaying dragons and saving villages from doom.",
+        "current_status": "Resting.",
+        "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-050",
+        "relationships": [
+            {
+                "target_id": "char-sidekick",
+                "current_relationship": "trusted companion",
+                "type": "partnership",
+                "status": "active",
+                "first_seen_turn": "turn-005",
+            },
+            {
+                "target_id": "char-villain",
+                "current_relationship": "nemesis",
+                "type": "adversarial",
+                "status": "dormant",
+                "first_seen_turn": "turn-010",
+            },
+        ],
+    }
+    entry = build_index_entry(v2)
+
+    assert entry["id"] == "char-hero"
+    assert entry["name"] == "Hero"
+    assert entry["type"] == "character"
+    assert entry["first_seen_turn"] == "turn-001"
+    assert entry["last_updated_turn"] == "turn-050"
+    assert entry["active_relationship_count"] == 1
+    assert len(entry["status_summary"]) <= 80
+    assert entry["status_summary"].startswith("A legendary hero")
+
+
+# ---------------------------------------------------------------------------
+# test_idempotency_guard
+# ---------------------------------------------------------------------------
+
+
+def test_idempotency_guard(tmp_framework):
+    """Running twice without --force aborts on second run."""
+    entities = [
+        {
+            "id": "char-test",
+            "name": "Test",
+            "type": "character",
+            "description": "A test entity.",
+            "attributes": {},
+            "first_seen_turn": "turn-001",
+            "last_updated_turn": "turn-005",
+        }
+    ]
+    write_catalog(tmp_framework, "characters", entities)
+
+    # First run succeeds
+    count, warnings = migrate_catalog(tmp_framework, "characters", max_turn=10, force=False)
+    assert count == 1
+    assert not any(w.startswith("ABORT:") for w in warnings)
+
+    # Re-create flat file (simulating a second run setup)
+    write_catalog(tmp_framework, "characters", entities)
+
+    # Second run aborts
+    count2, warnings2 = migrate_catalog(tmp_framework, "characters", max_turn=10, force=False)
+    assert count2 == 0
+    assert any("ABORT" in w for w in warnings2)
+
+
+def test_force_overwrite(tmp_framework):
+    """Running with --force overwrites existing per-entity directories."""
+    entities = [
+        {
+            "id": "char-test",
+            "name": "Test",
+            "type": "character",
+            "description": "Original.",
+            "attributes": {},
+            "first_seen_turn": "turn-001",
+            "last_updated_turn": "turn-005",
+        }
+    ]
+    write_catalog(tmp_framework, "characters", entities)
+    migrate_catalog(tmp_framework, "characters", max_turn=10, force=False)
+
+    # Update entity and re-create flat file
+    entities[0]["description"] = "Updated."
+    write_catalog(tmp_framework, "characters", entities)
+
+    count, warnings = migrate_catalog(tmp_framework, "characters", max_turn=10, force=True)
+    assert count == 1
+    assert not any(w.startswith("ABORT:") for w in warnings)
+
+    # Verify updated content
+    v2 = read_json(tmp_framework / "catalogs" / "characters" / "char-test.json")
+    assert v2["identity"] == "Updated."
+
+
+# ---------------------------------------------------------------------------
+# test_v1_backup
+# ---------------------------------------------------------------------------
+
+
+def test_v1_backup(tmp_framework):
+    """Original file renamed to .v1.json."""
+    entities = [
+        {
+            "id": "loc-test",
+            "name": "Test Location",
+            "type": "location",
+            "description": "A test location.",
+            "attributes": {},
+            "first_seen_turn": "turn-001",
+            "last_updated_turn": "turn-003",
+        }
+    ]
+    write_catalog(tmp_framework, "locations", entities)
+
+    migrate_catalog(tmp_framework, "locations", max_turn=10, force=False)
+
+    assert not (tmp_framework / "catalogs" / "locations.json").exists()
+    assert (tmp_framework / "catalogs" / "locations.v1.json").exists()
+
+    backup = read_json(tmp_framework / "catalogs" / "locations.v1.json")
+    assert len(backup) == 1
+    assert backup[0]["id"] == "loc-test"
+
+
+# ---------------------------------------------------------------------------
+# test_invalid_relationship_type_mapping
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_relationship_type_mapping():
+    """Invalid V1 relationship types map to 'other'."""
+    rels = [
+        {
+            "target_id": "char-x",
+            "relationship": "leaning on",
+            "type": "physical_contact",
+            "first_seen_turn": "turn-054",
+            "last_updated_turn": "turn-054",
+        },
+    ]
+    result = consolidate_relationships(rels, "turn-001", max_turn=60)
+    assert result[0]["type"] == "other"
+
+
+# ---------------------------------------------------------------------------
+# test_equipment_string_to_list
+# ---------------------------------------------------------------------------
+
+
+def test_equipment_string_to_list():
+    """Comma-separated equipment string converted to list."""
+    attrs = {"equipment": "sword, shield, lantern"}
+    _, volatile = classify_attributes(attrs, "turn-001")
+    assert volatile["equipment"] == ["sword", "shield", "lantern"]
+
+
+# ---------------------------------------------------------------------------
+# test_full_migration_roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_full_migration_roundtrip(tmp_framework):
+    """Full migration produces valid V2 files with index."""
+    characters = [
+        {
+            "id": "char-hero",
+            "name": "Hero",
+            "type": "character",
+            "description": "A brave hero.",
+            "attributes": {
+                "race": "Human",
+                "class": "Fighter [inference]",
+                "condition": "Healthy",
+            },
+            "first_seen_turn": "turn-001",
+            "last_updated_turn": "turn-020",
+            "relationships": [
+                {
+                    "target_id": "char-villain",
+                    "relationship": "fights",
+                    "type": "adversarial",
+                    "direction": "outgoing",
+                    "confidence": 0.9,
+                    "first_seen_turn": "turn-005",
+                    "last_updated_turn": "turn-005",
+                },
+                {
+                    "target_id": "char-villain",
+                    "relationship": "defeats",
+                    "type": "adversarial",
+                    "direction": "outgoing",
+                    "confidence": 1.0,
+                    "first_seen_turn": "turn-018",
+                    "last_updated_turn": "turn-018",
+                },
+            ],
+        },
+    ]
+    write_catalog(tmp_framework, "characters", characters)
+
+    count, warnings = migrate_catalog(tmp_framework, "characters", max_turn=20, force=False)
+    assert count == 1
+
+    # Check entity file
+    char_dir = tmp_framework / "catalogs" / "characters"
+    v2 = read_json(char_dir / "char-hero.json")
+    assert v2["identity"] == "A brave hero."
+    assert v2["stable_attributes"]["race"]["value"] == "Human"
+    assert v2["stable_attributes"]["class"]["value"] == "Fighter"
+    assert v2["stable_attributes"]["class"]["inference"] is True
+    assert v2["stable_attributes"]["class"]["confidence"] == 0.7
+    assert v2["volatile_state"]["condition"] == "Healthy"
+    assert len(v2["relationships"]) == 1
+    assert v2["relationships"][0]["current_relationship"] == "defeats"
+    assert len(v2["relationships"][0]["history"]) == 1
+
+    # Check index
+    index = read_json(char_dir / "index.json")
+    assert len(index) == 1
+    assert index[0]["id"] == "char-hero"
+    assert index[0]["active_relationship_count"] == 1

--- a/tools/migrate_catalogs_v2.py
+++ b/tools/migrate_catalogs_v2.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""One-time migration script: V1 flat catalogs → V2 per-entity file layout.
+
+Usage:
+    python tools/migrate_catalogs_v2.py --framework framework/
+    python tools/migrate_catalogs_v2.py --framework framework-local/
+    python tools/migrate_catalogs_v2.py --framework framework/ --force
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CATALOG_TYPES = {
+    "characters": "character",
+    "locations": "location",
+    "factions": "faction",
+    "items": "item",
+}
+
+# V2 relationship type enum from schemas/entity.schema.json
+VALID_RELATIONSHIP_TYPES = {
+    "kinship", "partnership", "mentorship", "political",
+    "factional", "social", "adversarial", "romantic", "other",
+}
+
+STABLE_KEYS = {
+    "race", "class", "appearance", "role", "aliases", "species",
+    "age", "gender", "title", "affiliation",
+}
+
+VOLATILE_KEYS = {
+    "condition", "status", "equipment", "hp_change", "location",
+    "last_action",
+}
+
+INFERENCE_TAG_RE = re.compile(r"\s*\[inference\]\s*$", re.IGNORECASE)
+
+TURN_NUM_RE = re.compile(r"turn-(\d+)")
+
+DEFAULT_DORMANCY_THRESHOLD = 10
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_turn_number(turn_id: str) -> int | None:
+    """Extract numeric part from a turn ID like 'turn-078'."""
+    m = TURN_NUM_RE.search(turn_id or "")
+    return int(m.group(1)) if m else None
+
+
+def read_json(path: Path) -> list | dict:
+    """Read JSON with BOM-safe encoding."""
+    with open(path, "r", encoding="utf-8-sig") as f:
+        return json.load(f)
+
+
+def write_json(path: Path, data) -> None:
+    """Write JSON with 2-space indent, no BOM, trailing newline."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def strip_inference_tag(value: str) -> tuple[str, bool]:
+    """Strip '[inference]' tag from a string value. Returns (clean_value, is_inference)."""
+    if isinstance(value, str) and INFERENCE_TAG_RE.search(value):
+        return INFERENCE_TAG_RE.sub("", value).rstrip(), True
+    return value, False
+
+
+def wrap_stable_attribute(value, first_seen_turn: str | None) -> dict:
+    """Wrap a raw attribute value into the V2 stable_attributes format."""
+    if isinstance(value, str):
+        clean, inferred = strip_inference_tag(value)
+        attr = {"value": clean}
+        if inferred:
+            attr["inference"] = True
+            attr["confidence"] = 0.7
+        else:
+            attr["inference"] = False
+        if first_seen_turn:
+            attr["source_turn"] = first_seen_turn
+        return attr
+
+    if isinstance(value, list):
+        cleaned_items = []
+        any_inferred = False
+        for item in value:
+            if isinstance(item, str):
+                clean, inferred = strip_inference_tag(item)
+                cleaned_items.append(clean)
+                any_inferred = any_inferred or inferred
+            else:
+                cleaned_items.append(item)
+        attr = {"value": cleaned_items}
+        attr["inference"] = any_inferred
+        if any_inferred:
+            attr["confidence"] = 0.7
+        if first_seen_turn:
+            attr["source_turn"] = first_seen_turn
+        return attr
+
+    # Fallback: wrap as-is
+    attr = {"value": value, "inference": False}
+    if first_seen_turn:
+        attr["source_turn"] = first_seen_turn
+    return attr
+
+
+def normalize_aliases(raw_val: str | list) -> list[str]:
+    """Normalize an aliases value to a list of strings."""
+    if isinstance(raw_val, list):
+        return raw_val
+    if isinstance(raw_val, str):
+        # Could be comma-separated or a single value
+        parts = [p.strip() for p in raw_val.split(",")]
+        return [p for p in parts if p]
+    return [str(raw_val)]
+
+
+def map_relationship_type(raw_type: str) -> str:
+    """Map a V1 relationship type to the V2 enum."""
+    if raw_type in VALID_RELATIONSHIP_TYPES:
+        return raw_type
+    return "other"
+
+
+def find_max_turn(framework_dir: Path) -> int:
+    """Find the highest turn number across all entities in catalogs."""
+    max_turn = 0
+    catalogs_dir = framework_dir / "catalogs"
+    for filename in CATALOG_TYPES:
+        flat_file = catalogs_dir / f"{filename}.json"
+        if not flat_file.exists():
+            continue
+        entities = read_json(flat_file)
+        if not isinstance(entities, list):
+            continue
+        for entity in entities:
+            for field in ("last_updated_turn", "first_seen_turn"):
+                t = parse_turn_number(entity.get(field, ""))
+                if t is not None and t > max_turn:
+                    max_turn = t
+            for rel in entity.get("relationships", []):
+                for field in ("last_updated_turn", "first_seen_turn"):
+                    t = parse_turn_number(rel.get(field, ""))
+                    if t is not None and t > max_turn:
+                        max_turn = t
+    return max_turn
+
+
+# ---------------------------------------------------------------------------
+# Core conversion
+# ---------------------------------------------------------------------------
+
+
+def classify_attributes(
+    attributes: dict, first_seen_turn: str | None
+) -> tuple[dict, dict]:
+    """Split V1 freeform attributes into stable_attributes and volatile_state."""
+    stable = {}
+    volatile = {}
+
+    for key, value in attributes.items():
+        if key in VOLATILE_KEYS:
+            # Volatile state: store value directly
+            if key == "equipment" and isinstance(value, str):
+                # Parse comma-separated equipment into list
+                volatile[key] = [
+                    item.strip() for item in value.split(",") if item.strip()
+                ]
+            else:
+                volatile[key] = value
+        else:
+            # Stable (known stable OR unknown keys default to stable)
+            if key == "aliases":
+                raw = normalize_aliases(value)
+                # Strip inference tags from each alias
+                cleaned = []
+                any_inferred = False
+                for alias in raw:
+                    clean, inf = strip_inference_tag(alias)
+                    cleaned.append(clean)
+                    any_inferred = any_inferred or inf
+                attr = {"value": cleaned, "inference": any_inferred}
+                if any_inferred:
+                    attr["confidence"] = 0.7
+                if first_seen_turn:
+                    attr["source_turn"] = first_seen_turn
+                stable[key] = attr
+            else:
+                stable[key] = wrap_stable_attribute(value, first_seen_turn)
+
+    return stable, volatile
+
+
+def consolidate_relationships(
+    relationships: list[dict],
+    entity_first_seen: str | None,
+    max_turn: int,
+) -> list[dict]:
+    """Group V1 relationships by (source, target) pair into consolidated V2 relationships."""
+    if not relationships:
+        return []
+
+    # Group by target_id
+    groups: dict[str, list[dict]] = {}
+    for rel in relationships:
+        target = rel.get("target_id", "unknown")
+        groups.setdefault(target, []).append(rel)
+
+    consolidated = []
+    for target_id, rels in groups.items():
+        # Sort by turn number (use last_updated_turn, fall back to first_seen_turn)
+        def sort_key(r):
+            t = parse_turn_number(r.get("last_updated_turn", "")) or 0
+            if t == 0:
+                t = parse_turn_number(r.get("first_seen_turn", "")) or 0
+            return t
+
+        sorted_rels = sorted(rels, key=sort_key)
+        most_recent = sorted_rels[-1]
+
+        # Build history from all but the most recent
+        history = []
+        for r in sorted_rels[:-1]:
+            entry = {"description": r.get("relationship", "")}
+            turn = r.get("last_updated_turn") or r.get("first_seen_turn")
+            if turn:
+                entry["turn"] = turn
+            history.append(entry)
+
+        # Determine first_seen and last_updated across all rels in the group
+        all_first = [
+            parse_turn_number(r.get("first_seen_turn", "")) for r in sorted_rels
+        ]
+        all_last = [
+            parse_turn_number(r.get("last_updated_turn", "")) for r in sorted_rels
+        ]
+        all_first = [t for t in all_first if t is not None]
+        all_last = [t for t in all_last if t is not None]
+
+        first_turn_num = min(all_first) if all_first else None
+        last_turn_num = max(all_last) if all_last else None
+
+        first_turn_id = (
+            entity_first_seen
+            if first_turn_num is None
+            else f"turn-{first_turn_num:03d}"
+        )
+        last_turn_id = (
+            f"turn-{last_turn_num:03d}" if last_turn_num is not None else None
+        )
+
+        # Determine dormancy status
+        status = "active"
+        if last_turn_num is not None and max_turn > 0:
+            if max_turn - last_turn_num > DEFAULT_DORMANCY_THRESHOLD:
+                status = "dormant"
+
+        v2_rel = {
+            "target_id": target_id,
+            "current_relationship": most_recent.get("relationship", ""),
+            "type": map_relationship_type(most_recent.get("type", "other")),
+            "status": status,
+            "first_seen_turn": first_turn_id,
+        }
+
+        # Optional fields
+        if most_recent.get("direction"):
+            v2_rel["direction"] = most_recent["direction"]
+        if most_recent.get("confidence") is not None:
+            v2_rel["confidence"] = most_recent["confidence"]
+        if last_turn_id:
+            v2_rel["last_updated_turn"] = last_turn_id
+        if history:
+            v2_rel["history"] = history
+
+        consolidated.append(v2_rel)
+
+    return consolidated
+
+
+def convert_entity(entity: dict, max_turn: int) -> dict:
+    """Convert a V1 entity dict to V2 per-entity format."""
+    first_seen = entity.get("first_seen_turn")
+    last_updated = entity.get("last_updated_turn")
+
+    # Identity / status split
+    description = entity.get("description", "")
+    identity = description if description else entity.get("name", "Unknown entity")
+    current_status = "Status unknown \u2014 migrated from V1 catalog."
+
+    # Attributes
+    raw_attrs = entity.get("attributes", {})
+    stable_attrs, volatile_state = classify_attributes(raw_attrs, first_seen)
+
+    # Add last_updated_turn to volatile_state if we have volatile keys
+    if volatile_state and last_updated:
+        volatile_state["last_updated_turn"] = last_updated
+
+    # Relationships
+    raw_rels = entity.get("relationships", [])
+    relationships = consolidate_relationships(raw_rels, first_seen, max_turn)
+
+    # Build V2 entity
+    v2 = {
+        "id": entity["id"],
+        "name": entity["name"],
+        "type": entity["type"],
+        "identity": identity,
+        "current_status": current_status,
+        "first_seen_turn": first_seen,
+    }
+
+    if last_updated:
+        v2["status_updated_turn"] = last_updated
+        v2["last_updated_turn"] = last_updated
+
+    if stable_attrs:
+        v2["stable_attributes"] = stable_attrs
+    if volatile_state:
+        v2["volatile_state"] = volatile_state
+    if relationships:
+        v2["relationships"] = relationships
+
+    if entity.get("notes"):
+        v2["notes"] = entity["notes"]
+
+    return v2
+
+
+def build_index_entry(v2_entity: dict) -> dict:
+    """Build a lightweight index entry from a V2 entity."""
+    identity = v2_entity.get("identity", "")
+    status_summary = identity[:80] if identity else ""
+
+    active_count = sum(
+        1
+        for r in v2_entity.get("relationships", [])
+        if r.get("status") == "active"
+    )
+
+    entry = {
+        "id": v2_entity["id"],
+        "name": v2_entity["name"],
+        "type": v2_entity["type"],
+        "first_seen_turn": v2_entity["first_seen_turn"],
+    }
+
+    if status_summary:
+        entry["status_summary"] = status_summary
+    if v2_entity.get("last_updated_turn"):
+        entry["last_updated_turn"] = v2_entity["last_updated_turn"]
+
+    entry["active_relationship_count"] = active_count
+
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Migration driver
+# ---------------------------------------------------------------------------
+
+
+def migrate_catalog(
+    framework_dir: Path, catalog_name: str, max_turn: int, force: bool
+) -> tuple[int, list[str]]:
+    """Migrate a single flat catalog file to per-entity directory layout.
+
+    Returns (entity_count, list_of_warnings).
+    """
+    catalogs_dir = framework_dir / "catalogs"
+    flat_file = catalogs_dir / f"{catalog_name}.json"
+
+    if not flat_file.exists():
+        return 0, [f"Skipped {catalog_name}: {flat_file} does not exist"]
+
+    entities = read_json(flat_file)
+    if not isinstance(entities, list):
+        return 0, [f"Skipped {catalog_name}: expected array, got {type(entities).__name__}"]
+
+    if not entities:
+        return 0, [f"Skipped {catalog_name}: empty array"]
+
+    entity_dir = catalogs_dir / catalog_name
+
+    # Idempotency guard
+    if entity_dir.exists() and any(entity_dir.iterdir()):
+        if not force:
+            return 0, [
+                f"ABORT: {entity_dir} already exists and is not empty. "
+                f"Use --force to overwrite."
+            ]
+        # Force mode: remove existing files in the directory
+        for child in entity_dir.iterdir():
+            if child.is_file():
+                child.unlink()
+
+    entity_dir.mkdir(parents=True, exist_ok=True)
+
+    warnings = []
+    index_entries = []
+
+    for entity in entities:
+        if not isinstance(entity, dict) or "id" not in entity:
+            warnings.append(f"Skipped malformed entity in {catalog_name}")
+            continue
+
+        v2 = convert_entity(entity, max_turn)
+        entity_file = entity_dir / f"{v2['id']}.json"
+        write_json(entity_file, v2)
+
+        index_entries.append(build_index_entry(v2))
+
+    # Write index
+    if index_entries:
+        write_json(entity_dir / "index.json", index_entries)
+
+    # Backup original flat file
+    backup_name = f"{catalog_name}.v1.json"
+    backup_path = catalogs_dir / backup_name
+    flat_file.replace(backup_path)
+
+    return len(index_entries), warnings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Migrate V1 flat catalog files to V2 per-entity layout."
+    )
+    parser.add_argument(
+        "--framework",
+        required=True,
+        help="Path to framework directory (e.g. framework/ or framework-local/)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing per-entity directories",
+    )
+    args = parser.parse_args()
+
+    framework_dir = Path(args.framework)
+    if not framework_dir.is_dir():
+        print(f"Error: {framework_dir} is not a directory", file=sys.stderr)
+        return 1
+
+    catalogs_dir = framework_dir / "catalogs"
+    if not catalogs_dir.is_dir():
+        print(f"Error: {catalogs_dir} does not exist", file=sys.stderr)
+        return 1
+
+    # Find max turn across all catalogs for dormancy calculation
+    max_turn = find_max_turn(framework_dir)
+    print(f"Max turn detected: turn-{max_turn:03d}")
+
+    total_entities = 0
+    all_warnings = []
+    abort = False
+
+    for catalog_name in CATALOG_TYPES:
+        count, warnings = migrate_catalog(
+            framework_dir, catalog_name, max_turn, args.force
+        )
+        total_entities += count
+        all_warnings.extend(warnings)
+
+        # Check for abort condition
+        for w in warnings:
+            if w.startswith("ABORT:"):
+                abort = True
+
+        if count > 0:
+            print(f"  {catalog_name}: migrated {count} entities")
+
+    if all_warnings:
+        print("\nWarnings:")
+        for w in all_warnings:
+            print(f"  - {w}")
+
+    if abort:
+        print("\nMigration aborted due to existing directories. Use --force to overwrite.")
+        return 1
+
+    print(f"\nMigration complete: {total_entities} entities migrated.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/migrate_catalogs_v2.py
+++ b/tools/migrate_catalogs_v2.py
@@ -9,7 +9,6 @@ Usage:
 
 import argparse
 import json
-import os
 import re
 import sys
 from pathlib import Path
@@ -29,11 +28,6 @@ CATALOG_TYPES = {
 VALID_RELATIONSHIP_TYPES = {
     "kinship", "partnership", "mentorship", "political",
     "factional", "social", "adversarial", "romantic", "other",
-}
-
-STABLE_KEYS = {
-    "race", "class", "appearance", "role", "aliases", "species",
-    "age", "gender", "title", "affiliation",
 }
 
 VOLATILE_KEYS = {
@@ -210,6 +204,7 @@ def consolidate_relationships(
     relationships: list[dict],
     entity_first_seen: str | None,
     max_turn: int,
+    entity_last_updated_turns: dict[str, str] | None = None,
 ) -> list[dict]:
     """Group V1 relationships by (source, target) pair into consolidated V2 relationships."""
     if not relationships:
@@ -236,10 +231,13 @@ def consolidate_relationships(
         # Build history from all but the most recent
         history = []
         for r in sorted_rels[:-1]:
-            entry = {"description": r.get("relationship", "")}
             turn = r.get("last_updated_turn") or r.get("first_seen_turn")
-            if turn:
-                entry["turn"] = turn
+            if not turn:
+                continue
+            entry = {
+                "description": r.get("relationship", ""),
+                "turn": turn,
+            }
             history.append(entry)
 
         # Determine first_seen and last_updated across all rels in the group
@@ -253,7 +251,9 @@ def consolidate_relationships(
         all_last = [t for t in all_last if t is not None]
 
         first_turn_num = min(all_first) if all_first else None
-        last_turn_num = max(all_last) if all_last else None
+        last_turn_num = max(all_last) if all_last else (
+            max(all_first) if all_first else None
+        )
 
         first_turn_id = (
             entity_first_seen
@@ -264,10 +264,24 @@ def consolidate_relationships(
             f"turn-{last_turn_num:03d}" if last_turn_num is not None else None
         )
 
-        # Determine dormancy status
+        # Determine dormancy status — dormant if either the relationship
+        # or the target entity hasn't been updated within the threshold.
         status = "active"
-        if last_turn_num is not None and max_turn > 0:
-            if max_turn - last_turn_num > DEFAULT_DORMANCY_THRESHOLD:
+        if max_turn > 0:
+            rel_stale = (
+                last_turn_num is not None
+                and max_turn - last_turn_num > DEFAULT_DORMANCY_THRESHOLD
+            )
+            target_stale = False
+            if entity_last_updated_turns:
+                target_turn = parse_turn_number(
+                    entity_last_updated_turns.get(target_id, "")
+                )
+                if target_turn is not None:
+                    target_stale = (
+                        max_turn - target_turn > DEFAULT_DORMANCY_THRESHOLD
+                    )
+            if rel_stale or target_stale:
                 status = "dormant"
 
         v2_rel = {
@@ -293,7 +307,11 @@ def consolidate_relationships(
     return consolidated
 
 
-def convert_entity(entity: dict, max_turn: int) -> dict:
+def convert_entity(
+    entity: dict,
+    max_turn: int,
+    entity_last_updated_turns: dict[str, str] | None = None,
+) -> dict:
     """Convert a V1 entity dict to V2 per-entity format."""
     first_seen = entity.get("first_seen_turn")
     last_updated = entity.get("last_updated_turn")
@@ -313,7 +331,9 @@ def convert_entity(entity: dict, max_turn: int) -> dict:
 
     # Relationships
     raw_rels = entity.get("relationships", [])
-    relationships = consolidate_relationships(raw_rels, first_seen, max_turn)
+    relationships = consolidate_relationships(
+        raw_rels, first_seen, max_turn, entity_last_updated_turns
+    )
 
     # Build V2 entity
     v2 = {
@@ -344,8 +364,10 @@ def convert_entity(entity: dict, max_turn: int) -> dict:
 
 def build_index_entry(v2_entity: dict) -> dict:
     """Build a lightweight index entry from a V2 entity."""
+    current_status = v2_entity.get("current_status", "")
     identity = v2_entity.get("identity", "")
-    status_summary = identity[:80] if identity else ""
+    status_source = current_status if current_status else identity
+    status_summary = status_source[:80] if status_source else ""
 
     active_count = sum(
         1
@@ -414,12 +436,27 @@ def migrate_catalog(
     warnings = []
     index_entries = []
 
+    # Build entity_id → last_updated_turn map for two-sided dormancy checks
+    entity_last_updated_turns = {}
+    for e in entities:
+        if isinstance(e, dict) and "id" in e:
+            lut = e.get("last_updated_turn") or e.get("first_seen_turn", "")
+            if lut:
+                entity_last_updated_turns[e["id"]] = lut
+
     for entity in entities:
-        if not isinstance(entity, dict) or "id" not in entity:
+        if not isinstance(entity, dict):
             warnings.append(f"Skipped malformed entity in {catalog_name}")
             continue
+        missing_keys = [k for k in ("id", "name", "type") if k not in entity]
+        if missing_keys:
+            warnings.append(
+                f"Skipped malformed entity in {catalog_name}: "
+                f"missing {', '.join(missing_keys)}"
+            )
+            continue
 
-        v2 = convert_entity(entity, max_turn)
+        v2 = convert_entity(entity, max_turn, entity_last_updated_turns)
         entity_file = entity_dir / f"{v2['id']}.json"
         write_json(entity_file, v2)
 
@@ -467,9 +504,22 @@ def main() -> int:
     max_turn = find_max_turn(framework_dir)
     print(f"Max turn detected: turn-{max_turn:03d}")
 
+    # Preflight: check all target directories before migrating any
+    if not args.force:
+        blockers = []
+        for catalog_name in CATALOG_TYPES:
+            entity_dir = catalogs_dir / catalog_name
+            if entity_dir.exists() and any(entity_dir.iterdir()):
+                blockers.append(str(entity_dir))
+        if blockers:
+            print("ABORT: the following directories already exist and are not empty:")
+            for b in blockers:
+                print(f"  - {b}")
+            print("Use --force to overwrite.")
+            return 1
+
     total_entities = 0
     all_warnings = []
-    abort = False
 
     for catalog_name in CATALOG_TYPES:
         count, warnings = migrate_catalog(
@@ -478,11 +528,6 @@ def main() -> int:
         total_entities += count
         all_warnings.extend(warnings)
 
-        # Check for abort condition
-        for w in warnings:
-            if w.startswith("ABORT:"):
-                abort = True
-
         if count > 0:
             print(f"  {catalog_name}: migrated {count} entities")
 
@@ -490,10 +535,6 @@ def main() -> int:
         print("\nWarnings:")
         for w in all_warnings:
             print(f"  - {w}")
-
-    if abort:
-        print("\nMigration aborted due to existing directories. Use --force to overwrite.")
-        return 1
 
     print(f"\nMigration complete: {total_entities} entities migrated.")
     return 0


### PR DESCRIPTION
## Summary

One-time migration script converting V1 flat catalog files to V2 per-entity layout.

## What it does

1. Reads V1 flat files (`characters.json`, `locations.json`, `factions.json`, `items.json`)
2. Splits each entity into per-entity files in type directories
3. Converts `description` → `identity` + `current_status` placeholder
4. Classifies attributes into `stable_attributes` + `volatile_state`
5. Parses `[inference]` tags into structured `inference: true` + `confidence: 0.7`
6. Consolidates relationships per `(source, target)` pair with history
7. Marks relationships as `dormant` when entity hasn't appeared for 10+ turns
8. Maps invalid V1 relationship types to `other`
9. Generates `index.json` per entity type with status summaries and relationship counts
10. Backs up original flat files as `.v1.json`

## Safety

- Idempotent: aborts if per-entity directory already exists (use `--force` to overwrite)
- UTF-8 throughout (handles BOM on read, no BOM on write)
- Pretty-printed JSON with 2-space indent

## Testing

- 16 unit tests covering all conversion steps (attribute classification, inference parsing, relationship consolidation, dormancy marking, index generation, idempotency guard, backup)
- Full test suite (83 tests) passes
- Migration validated on `framework-local/` with real 345-turn extraction data: 52 entities migrated, all pass V2 schema validation

## Usage

```bash
python tools/migrate_catalogs_v2.py --framework framework/
python tools/migrate_catalogs_v2.py --framework framework-local/
python tools/migrate_catalogs_v2.py --framework framework/ --force
```

Closes #82
