### PR TITLE
feat: per-entity file layout and catalog_merger V2

### DIFF
--- a/tests/test_catalog_merger_v2.py
+++ b/tests/test_catalog_merger_v2.py
@@ -1,0 +1,562 @@
+"""Tests for V2 catalog_merger: per-entity I/O, relationship consolidation,
+dormancy marking, and index generation."""
+import json
+import os
+import sys
+import warnings
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from catalog_merger import (
+    _consolidate_relationship,
+    _generate_index,
+    _merge_entity_relationships,
+    _parse_turn_number,
+    _read_v2_entities,
+    _write_v2_entity,
+    detect_format,
+    load_catalogs,
+    mark_dormant_relationships,
+    merge_entity,
+    merge_relationships,
+    save_catalogs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_v2_entity(id_, name, etype="character", turn="turn-001", **kwargs):
+    """Create a minimal V2-shaped entity dict."""
+    entity = {
+        "id": id_,
+        "name": name,
+        "type": etype,
+        "identity": f"{name} identity.",
+        "first_seen_turn": turn,
+        "last_updated_turn": turn,
+    }
+    entity.update(kwargs)
+    return entity
+
+
+def _make_v1_entity(id_, name, etype="character", turn="turn-001"):
+    """Create a V1-shaped entity dict."""
+    return {
+        "id": id_,
+        "name": name,
+        "type": etype,
+        "description": f"{name} description.",
+        "attributes": {},
+        "first_seen_turn": turn,
+        "last_updated_turn": turn,
+        "relationships": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Format detection
+# ---------------------------------------------------------------------------
+
+class TestFormatDetection:
+    def test_v2_detected_when_directory_exists(self, tmp_path):
+        (tmp_path / "characters").mkdir()
+        assert detect_format(str(tmp_path)) == "v2"
+
+    def test_v1_detected_when_no_directories(self, tmp_path):
+        (tmp_path / "characters.json").write_text("[]")
+        assert detect_format(str(tmp_path)) == "v1"
+
+    def test_v2_detected_with_any_type_dir(self, tmp_path):
+        (tmp_path / "locations").mkdir()
+        assert detect_format(str(tmp_path)) == "v2"
+
+    def test_v1_on_empty_dir(self, tmp_path):
+        assert detect_format(str(tmp_path)) == "v1"
+
+
+# ---------------------------------------------------------------------------
+# V2 per-entity file I/O
+# ---------------------------------------------------------------------------
+
+class TestV2ReadPerEntityFiles:
+    def test_reads_all_entity_files(self, tmp_path):
+        edir = tmp_path / "characters"
+        edir.mkdir()
+        e1 = _make_v2_entity("char-alpha", "Alpha")
+        e2 = _make_v2_entity("char-beta", "Beta")
+        (edir / "char-alpha.json").write_text(json.dumps(e1), encoding="utf-8")
+        (edir / "char-beta.json").write_text(json.dumps(e2), encoding="utf-8")
+        result = _read_v2_entities(str(edir))
+        assert len(result) == 2
+        ids = {e["id"] for e in result}
+        assert ids == {"char-alpha", "char-beta"}
+
+    def test_skips_index_json(self, tmp_path):
+        edir = tmp_path / "characters"
+        edir.mkdir()
+        e1 = _make_v2_entity("char-alpha", "Alpha")
+        (edir / "char-alpha.json").write_text(json.dumps(e1), encoding="utf-8")
+        (edir / "index.json").write_text("[]", encoding="utf-8")
+        result = _read_v2_entities(str(edir))
+        assert len(result) == 1
+
+    def test_returns_empty_for_missing_dir(self, tmp_path):
+        result = _read_v2_entities(str(tmp_path / "nonexistent"))
+        assert result == []
+
+    def test_handles_bom(self, tmp_path):
+        edir = tmp_path / "characters"
+        edir.mkdir()
+        e1 = _make_v2_entity("char-alpha", "Alpha")
+        # Write with BOM
+        (edir / "char-alpha.json").write_bytes(
+            b"\xef\xbb\xbf" + json.dumps(e1).encode("utf-8")
+        )
+        result = _read_v2_entities(str(edir))
+        assert len(result) == 1
+        assert result[0]["id"] == "char-alpha"
+
+
+class TestV2WritePerEntityFiles:
+    def test_writes_entity_file(self, tmp_path):
+        edir = tmp_path / "characters"
+        e1 = _make_v2_entity("char-alpha", "Alpha")
+        _write_v2_entity(str(edir), e1)
+        fpath = edir / "char-alpha.json"
+        assert fpath.exists()
+        data = json.loads(fpath.read_text(encoding="utf-8"))
+        assert data["id"] == "char-alpha"
+        assert data["name"] == "Alpha"
+
+    def test_creates_directory_if_missing(self, tmp_path):
+        edir = tmp_path / "new_type"
+        e1 = _make_v2_entity("char-alpha", "Alpha")
+        _write_v2_entity(str(edir), e1)
+        assert (edir / "char-alpha.json").exists()
+
+    def test_pretty_prints_with_two_space_indent(self, tmp_path):
+        edir = tmp_path / "characters"
+        e1 = _make_v2_entity("char-alpha", "Alpha")
+        _write_v2_entity(str(edir), e1)
+        text = (edir / "char-alpha.json").read_text(encoding="utf-8")
+        # Check 2-space indent (not 4)
+        assert '  "id"' in text
+        assert '    "id"' not in text
+
+
+# ---------------------------------------------------------------------------
+# V1 fallback read
+# ---------------------------------------------------------------------------
+
+class TestV1FallbackRead:
+    def test_reads_flat_file(self, tmp_path):
+        entities = [_make_v1_entity("char-alpha", "Alpha")]
+        (tmp_path / "characters.json").write_text(json.dumps(entities), encoding="utf-8")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            catalogs = load_catalogs(str(tmp_path))
+            assert len(w) == 1
+            assert "V1 flat catalog" in str(w[0].message)
+        assert len(catalogs["characters.json"]) == 1
+        assert catalogs["characters.json"][0]["id"] == "char-alpha"
+
+    def test_v1_returns_empty_for_missing_files(self, tmp_path):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            catalogs = load_catalogs(str(tmp_path))
+        for filename in ["characters.json", "locations.json", "factions.json", "items.json"]:
+            assert catalogs[filename] == []
+
+
+# ---------------------------------------------------------------------------
+# Full load/save round-trip (V2)
+# ---------------------------------------------------------------------------
+
+class TestV2LoadSaveRoundTrip:
+    def test_round_trip(self, tmp_path):
+        # Set up V2 directory structure
+        cdir = tmp_path / "characters"
+        cdir.mkdir()
+        e1 = _make_v2_entity("char-alpha", "Alpha")
+        (cdir / "char-alpha.json").write_text(json.dumps(e1), encoding="utf-8")
+        # Also create other type dirs (empty)
+        for d in ["locations", "factions", "items"]:
+            (tmp_path / d).mkdir()
+
+        catalogs = load_catalogs(str(tmp_path))
+        assert len(catalogs["characters.json"]) == 1
+
+        # Add a new entity and save
+        catalogs["characters.json"].append(
+            _make_v2_entity("char-beta", "Beta")
+        )
+        save_catalogs(str(tmp_path), catalogs)
+
+        # Verify individual files exist
+        assert (cdir / "char-alpha.json").exists()
+        assert (cdir / "char-beta.json").exists()
+        assert (cdir / "index.json").exists()
+
+        # Reload and verify
+        catalogs2 = load_catalogs(str(tmp_path))
+        assert len(catalogs2["characters.json"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Relationship consolidation
+# ---------------------------------------------------------------------------
+
+class TestRelationshipConsolidation:
+    def test_existing_pair_updates_current_and_adds_history(self):
+        existing = {
+            "target_id": "char-beta",
+            "current_relationship": "ally",
+            "type": "partnership",
+            "status": "active",
+            "first_seen_turn": "turn-010",
+            "last_updated_turn": "turn-010",
+        }
+        update = {
+            "current_relationship": "close friend and ally",
+            "type": "partnership",
+            "last_updated_turn": "turn-020",
+        }
+        _consolidate_relationship(existing, update)
+        assert existing["current_relationship"] == "close friend and ally"
+        assert existing["last_updated_turn"] == "turn-020"
+        assert len(existing["history"]) == 1
+        assert existing["history"][0]["turn"] == "turn-010"
+        assert existing["history"][0]["description"] == "ally"
+
+    def test_same_description_does_not_add_history(self):
+        existing = {
+            "target_id": "char-beta",
+            "current_relationship": "ally",
+            "type": "partnership",
+            "status": "active",
+            "first_seen_turn": "turn-010",
+            "last_updated_turn": "turn-010",
+        }
+        update = {
+            "current_relationship": "ally",
+            "type": "partnership",
+            "last_updated_turn": "turn-020",
+        }
+        _consolidate_relationship(existing, update)
+        assert existing["current_relationship"] == "ally"
+        assert existing["last_updated_turn"] == "turn-020"
+        assert "history" not in existing
+
+    def test_history_accumulates(self):
+        existing = {
+            "target_id": "char-beta",
+            "current_relationship": "acquaintance",
+            "type": "social",
+            "status": "active",
+            "first_seen_turn": "turn-005",
+            "last_updated_turn": "turn-005",
+            "history": [
+                {"turn": "turn-003", "description": "stranger"},
+            ],
+        }
+        update = {
+            "current_relationship": "friend",
+            "type": "partnership",
+            "last_updated_turn": "turn-015",
+        }
+        _consolidate_relationship(existing, update)
+        assert existing["current_relationship"] == "friend"
+        assert len(existing["history"]) == 2
+        assert existing["history"][1]["description"] == "acquaintance"
+
+
+class TestRelationshipNewPair:
+    def test_new_pair_creates_fresh_entry(self):
+        existing_rels = []
+        new_rels = [
+            {
+                "target_id": "char-gamma",
+                "current_relationship": "mentor",
+                "type": "mentorship",
+                "first_seen_turn": "turn-005",
+                "last_updated_turn": "turn-005",
+            }
+        ]
+        _merge_entity_relationships(existing_rels, new_rels)
+        assert len(existing_rels) == 1
+        assert existing_rels[0]["target_id"] == "char-gamma"
+        assert existing_rels[0]["status"] == "active"
+
+    def test_v1_relationship_field_becomes_current_relationship(self):
+        existing_rels = []
+        new_rels = [
+            {
+                "target_id": "char-gamma",
+                "relationship": "mentor",
+                "type": "mentorship",
+                "first_seen_turn": "turn-005",
+            }
+        ]
+        _merge_entity_relationships(existing_rels, new_rels)
+        assert existing_rels[0]["current_relationship"] == "mentor"
+
+    def test_no_duplicate_pairs(self):
+        existing_rels = [
+            {
+                "target_id": "char-beta",
+                "current_relationship": "ally",
+                "type": "partnership",
+                "status": "active",
+                "first_seen_turn": "turn-010",
+                "last_updated_turn": "turn-010",
+            }
+        ]
+        new_rels = [
+            {
+                "target_id": "char-beta",
+                "current_relationship": "close friend",
+                "type": "partnership",
+                "last_updated_turn": "turn-020",
+            }
+        ]
+        _merge_entity_relationships(existing_rels, new_rels)
+        assert len(existing_rels) == 1  # no duplicate
+        assert existing_rels[0]["current_relationship"] == "close friend"
+
+
+class TestMergeRelationshipsTopLevel:
+    def test_consolidates_per_pair(self):
+        """merge_relationships() should consolidate by (source, target) pair."""
+        catalogs = {
+            "characters.json": [
+                _make_v2_entity("char-alpha", "Alpha", relationships=[
+                    {
+                        "target_id": "char-beta",
+                        "current_relationship": "acquaintance",
+                        "type": "social",
+                        "status": "active",
+                        "first_seen_turn": "turn-005",
+                        "last_updated_turn": "turn-005",
+                    }
+                ]),
+            ]
+        }
+        new_rels = [
+            {
+                "source_id": "char-alpha",
+                "target_id": "char-beta",
+                "relationship": "close friend",
+                "type": "partnership",
+            }
+        ]
+        merge_relationships(catalogs, new_rels, "turn-020")
+        rels = catalogs["characters.json"][0]["relationships"]
+        assert len(rels) == 1
+        assert rels[0]["current_relationship"] == "close friend"
+        assert len(rels[0].get("history", [])) == 1
+
+
+# ---------------------------------------------------------------------------
+# Dormancy marking
+# ---------------------------------------------------------------------------
+
+class TestDormancyMarking:
+    def test_marks_dormant_after_threshold(self):
+        catalogs = {
+            "characters.json": [
+                _make_v2_entity("char-alpha", "Alpha", turn="turn-001",
+                                last_updated_turn="turn-001",
+                                relationships=[
+                                    {
+                                        "target_id": "char-beta",
+                                        "current_relationship": "ally",
+                                        "type": "partnership",
+                                        "status": "active",
+                                        "first_seen_turn": "turn-001",
+                                        "last_updated_turn": "turn-001",
+                                    }
+                                ]),
+                _make_v2_entity("char-beta", "Beta", turn="turn-001",
+                                last_updated_turn="turn-001"),
+            ]
+        }
+        marked = mark_dormant_relationships(catalogs, "turn-015", dormancy_threshold=10)
+        assert marked == 1
+        rel = catalogs["characters.json"][0]["relationships"][0]
+        assert rel["status"] == "dormant"
+
+    def test_does_not_mark_recently_active(self):
+        catalogs = {
+            "characters.json": [
+                _make_v2_entity("char-alpha", "Alpha", turn="turn-010",
+                                last_updated_turn="turn-010",
+                                relationships=[
+                                    {
+                                        "target_id": "char-beta",
+                                        "current_relationship": "ally",
+                                        "type": "partnership",
+                                        "status": "active",
+                                        "first_seen_turn": "turn-005",
+                                        "last_updated_turn": "turn-010",
+                                    }
+                                ]),
+                _make_v2_entity("char-beta", "Beta", turn="turn-003",
+                                last_updated_turn="turn-003"),
+            ]
+        }
+        marked = mark_dormant_relationships(catalogs, "turn-015", dormancy_threshold=10)
+        # source (turn-010) is only 5 turns ago → not stale → relationship stays active
+        assert marked == 0
+
+    def test_does_not_mark_resolved(self):
+        catalogs = {
+            "characters.json": [
+                _make_v2_entity("char-alpha", "Alpha", turn="turn-001",
+                                last_updated_turn="turn-001",
+                                relationships=[
+                                    {
+                                        "target_id": "char-beta",
+                                        "current_relationship": "captured by",
+                                        "type": "adversarial",
+                                        "status": "resolved",
+                                        "first_seen_turn": "turn-001",
+                                        "last_updated_turn": "turn-001",
+                                    }
+                                ]),
+                _make_v2_entity("char-beta", "Beta", turn="turn-001",
+                                last_updated_turn="turn-001"),
+            ]
+        }
+        marked = mark_dormant_relationships(catalogs, "turn-050", dormancy_threshold=10)
+        assert marked == 0  # already resolved, not touched
+
+    def test_threshold_configurable(self):
+        catalogs = {
+            "characters.json": [
+                _make_v2_entity("char-alpha", "Alpha", turn="turn-005",
+                                last_updated_turn="turn-005",
+                                relationships=[
+                                    {
+                                        "target_id": "char-beta",
+                                        "current_relationship": "ally",
+                                        "type": "partnership",
+                                        "status": "active",
+                                        "first_seen_turn": "turn-005",
+                                        "last_updated_turn": "turn-005",
+                                    }
+                                ]),
+                _make_v2_entity("char-beta", "Beta", turn="turn-005",
+                                last_updated_turn="turn-005"),
+            ]
+        }
+        # With threshold 20, turn-015 is only 10 turns → not dormant
+        marked = mark_dormant_relationships(catalogs, "turn-015", dormancy_threshold=20)
+        assert marked == 0
+
+        # With threshold 5, turn-015 is 10 turns → dormant
+        # Reset status
+        catalogs["characters.json"][0]["relationships"][0]["status"] = "active"
+        marked = mark_dormant_relationships(catalogs, "turn-015", dormancy_threshold=5)
+        assert marked == 1
+
+
+# ---------------------------------------------------------------------------
+# Index generation
+# ---------------------------------------------------------------------------
+
+class TestIndexGeneration:
+    def test_index_generated_correctly(self, tmp_path):
+        edir = tmp_path / "characters"
+        edir.mkdir()
+        entities = [
+            _make_v2_entity("char-alpha", "Alpha", turn="turn-001",
+                            current_status="Active warrior."),
+            _make_v2_entity("char-beta", "Beta", turn="turn-003",
+                            current_status="Village healer.",
+                            relationships=[
+                                {"target_id": "char-alpha", "current_relationship": "ally",
+                                 "type": "partnership", "status": "active",
+                                 "first_seen_turn": "turn-003"},
+                                {"target_id": "char-gamma", "current_relationship": "enemy",
+                                 "type": "adversarial", "status": "dormant",
+                                 "first_seen_turn": "turn-003"},
+                            ]),
+        ]
+        _generate_index(str(edir), entities)
+        index_path = edir / "index.json"
+        assert index_path.exists()
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+        assert len(index) == 2
+
+        alpha_idx = next(e for e in index if e["id"] == "char-alpha")
+        assert alpha_idx["name"] == "Alpha"
+        assert alpha_idx["active_relationship_count"] == 0
+        assert alpha_idx["status_summary"] == "Active warrior."
+
+        beta_idx = next(e for e in index if e["id"] == "char-beta")
+        assert beta_idx["active_relationship_count"] == 1  # only 'active' status counted
+
+    def test_index_status_summary_truncated(self, tmp_path):
+        edir = tmp_path / "characters"
+        edir.mkdir()
+        long_status = "A" * 200
+        entities = [_make_v2_entity("char-alpha", "Alpha", current_status=long_status)]
+        _generate_index(str(edir), entities)
+        index = json.loads((edir / "index.json").read_text(encoding="utf-8"))
+        assert len(index[0]["status_summary"]) == 80
+
+    def test_index_falls_back_to_identity(self, tmp_path):
+        edir = tmp_path / "characters"
+        edir.mkdir()
+        entities = [_make_v2_entity("char-alpha", "Alpha")]  # no current_status
+        _generate_index(str(edir), entities)
+        index = json.loads((edir / "index.json").read_text(encoding="utf-8"))
+        assert "identity" in index[0]["status_summary"].lower() or len(index[0]["status_summary"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Merge entity (V2)
+# ---------------------------------------------------------------------------
+
+class TestMergeEntityV2:
+    def test_new_v2_entity_appended(self):
+        catalogs = {"characters.json": []}
+        entity = _make_v2_entity("char-alpha", "Alpha", turn="turn-001")
+        merge_entity(catalogs, entity)
+        assert len(catalogs["characters.json"]) == 1
+
+    def test_existing_v2_entity_updated(self):
+        catalogs = {
+            "characters.json": [
+                _make_v2_entity("char-alpha", "Alpha", turn="turn-001")
+            ]
+        }
+        update = _make_v2_entity("char-alpha", "Alpha", turn="turn-010")
+        update["current_status"] = "Now a leader."
+        update["last_updated_turn"] = "turn-010"
+        merge_entity(catalogs, update)
+        assert len(catalogs["characters.json"]) == 1
+        assert catalogs["characters.json"][0]["current_status"] == "Now a leader."
+        assert catalogs["characters.json"][0]["last_updated_turn"] == "turn-010"
+
+
+# ---------------------------------------------------------------------------
+# parse_turn_number
+# ---------------------------------------------------------------------------
+
+class TestParseTurnNumber:
+    def test_valid_turn(self):
+        assert _parse_turn_number("turn-078") == 78
+
+    def test_none(self):
+        assert _parse_turn_number(None) is None
+
+    def test_invalid(self):
+        assert _parse_turn_number("invalid") is None
+
+    def test_large_number(self):
+        assert _parse_turn_number("turn-345") == 345

--- a/tests/test_catalog_merger_v2.py
+++ b/tests/test_catalog_merger_v2.py
@@ -5,8 +5,6 @@ import os
 import sys
 import warnings
 
-import pytest
-
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
 from catalog_merger import (
@@ -62,20 +60,34 @@ def _make_v1_entity(id_, name, etype="character", turn="turn-001"):
 # ---------------------------------------------------------------------------
 
 class TestFormatDetection:
-    def test_v2_detected_when_directory_exists(self, tmp_path):
-        (tmp_path / "characters").mkdir()
+    def test_v2_detected_when_all_directories_exist(self, tmp_path):
+        for d in ["characters", "locations", "factions", "items"]:
+            (tmp_path / d).mkdir()
         assert detect_format(str(tmp_path)) == "v2"
 
     def test_v1_detected_when_no_directories(self, tmp_path):
         (tmp_path / "characters.json").write_text("[]")
         assert detect_format(str(tmp_path)) == "v1"
 
-    def test_v2_detected_with_any_type_dir(self, tmp_path):
+    def test_v2_detected_with_partial_dirs_no_v1_files(self, tmp_path):
         (tmp_path / "locations").mkdir()
         assert detect_format(str(tmp_path)) == "v2"
 
     def test_v1_on_empty_dir(self, tmp_path):
         assert detect_format(str(tmp_path)) == "v1"
+
+    def test_mixed_layout_falls_back_to_v1(self, tmp_path):
+        """If some V2 dirs exist but V1 flat files also remain, use V1."""
+        (tmp_path / "characters").mkdir()
+        (tmp_path / "locations.json").write_text("[]")
+        assert detect_format(str(tmp_path)) == "v1"
+
+    def test_all_dirs_overrides_v1_files(self, tmp_path):
+        """If all V2 dirs exist, use V2 even if stale flat files remain."""
+        for d in ["characters", "locations", "factions", "items"]:
+            (tmp_path / d).mkdir()
+        (tmp_path / "characters.json").write_text("[]")  # stale leftover
+        assert detect_format(str(tmp_path)) == "v2"
 
 
 # ---------------------------------------------------------------------------
@@ -204,6 +216,31 @@ class TestV2LoadSaveRoundTrip:
         # Reload and verify
         catalogs2 = load_catalogs(str(tmp_path))
         assert len(catalogs2["characters.json"]) == 2
+
+    def test_stale_file_removed_on_save(self, tmp_path):
+        """After dedup removes an entity, its file should be deleted on save."""
+        cdir = tmp_path / "characters"
+        cdir.mkdir()
+        for d in ["locations", "factions", "items"]:
+            (tmp_path / d).mkdir()
+
+        e1 = _make_v2_entity("char-alpha", "Alpha")
+        e2 = _make_v2_entity("char-beta", "Beta")
+        (cdir / "char-alpha.json").write_text(json.dumps(e1), encoding="utf-8")
+        (cdir / "char-beta.json").write_text(json.dumps(e2), encoding="utf-8")
+
+        # Load, then remove one entity (simulating dedup)
+        catalogs = load_catalogs(str(tmp_path))
+        catalogs["characters.json"] = [
+            e for e in catalogs["characters.json"] if e["id"] != "char-beta"
+        ]
+        save_catalogs(str(tmp_path), catalogs)
+
+        assert (cdir / "char-alpha.json").exists()
+        assert not (cdir / "char-beta.json").exists()  # stale file removed
+        # Reload confirms only one entity
+        catalogs2 = load_catalogs(str(tmp_path))
+        assert len(catalogs2["characters.json"]) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -3,27 +3,62 @@
 catalog_merger.py — Merge agent-extracted entities, relationships, and events
 into existing catalog files.
 
+Supports both V2 per-entity file layout (preferred) and V1 flat file fallback.
+
+V2 layout (per-entity files):
+  framework/catalogs/characters/
+    index.json            → lightweight roster (regenerated)
+    char-player.json      → full entity detail
+    char-elder.json       → full entity detail
+
+V1 layout (flat files — deprecated):
+  framework/catalogs/characters.json
+
 Handles:
+- Format detection (V2 directory vs V1 flat file)
 - New entity insertion with ID prefix validation
-- Existing entity updates (attributes, description, last_updated_turn)
+- Existing entity updates (identity, status, attributes, last_updated_turn)
 - Name changes and alias tracking
-- Relationship deduplication by (source_id, target_id, relationship)
+- Relationship consolidation per (source_id, target_id) pair
+- Relationship dormancy marking for inactive entities
+- Index.json generation after merge
 - Event deduplication by ID
 """
+
+from __future__ import annotations
 
 import json
 import os
 import re
+import sys
+import warnings
+from pathlib import Path
 
-# Map entity type to catalog filename and ID prefix
+# Map entity type to catalog filename/directory and ID prefix
 TYPE_TO_CATALOG = {
+    "character": "characters",
+    "location": "locations",
+    "faction": "factions",
+    "item": "items",
+    "creature": "characters",  # creatures go to characters catalog
+    "concept": "items",  # concepts go to items catalog
+}
+
+# V1 flat file mapping (for backward compat)
+TYPE_TO_CATALOG_V1 = {
     "character": "characters.json",
     "location": "locations.json",
     "faction": "factions.json",
     "item": "items.json",
-    "creature": "characters.json",  # creatures go to characters catalog
-    "concept": "items.json",  # concepts go to items catalog
+    "creature": "characters.json",
+    "concept": "items.json",
 }
+
+# Flat file names used by the V1 format
+_V1_FILENAMES = ["characters.json", "locations.json", "factions.json", "items.json"]
+
+# Directory names used by the V2 format
+_V2_DIRNAMES = ["characters", "locations", "factions", "items"]
 
 TYPE_TO_PREFIX = {
     "character": "char-",
@@ -34,18 +69,143 @@ TYPE_TO_PREFIX = {
     "concept": "concept-",
 }
 
+DEFAULT_DORMANCY_THRESHOLD = 10
+
+
+# ---------------------------------------------------------------------------
+# Format detection
+# ---------------------------------------------------------------------------
+
+def detect_format(catalog_dir: str) -> str:
+    """Detect whether catalog_dir uses V2 (per-entity dirs) or V1 (flat files).
+
+    Returns ``"v2"`` if any entity-type subdirectory exists, ``"v1"`` otherwise.
+    """
+    for dirname in _V2_DIRNAMES:
+        if os.path.isdir(os.path.join(catalog_dir, dirname)):
+            return "v2"
+    return "v1"
+
+
+# ---------------------------------------------------------------------------
+# V2 per-entity I/O
+# ---------------------------------------------------------------------------
+
+def _read_v2_entities(entity_dir: str) -> list[dict]:
+    """Read all per-entity JSON files from a V2 directory.
+
+    Skips ``index.json`` which is a derived artifact.
+    """
+    entities = []
+    if not os.path.isdir(entity_dir):
+        return entities
+    for fname in sorted(os.listdir(entity_dir)):
+        if fname == "index.json" or not fname.endswith(".json"):
+            continue
+        fpath = os.path.join(entity_dir, fname)
+        with open(fpath, "r", encoding="utf-8-sig") as f:
+            entities.append(json.load(f))
+    return entities
+
+
+def _write_v2_entity(entity_dir: str, entity: dict) -> None:
+    """Write a single entity to its per-entity JSON file."""
+    os.makedirs(entity_dir, exist_ok=True)
+    entity_id = entity["id"]
+    fpath = os.path.join(entity_dir, f"{entity_id}.json")
+    with open(fpath, "w", encoding="utf-8") as f:
+        json.dump(entity, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def _generate_index(entity_dir: str, entities: list[dict]) -> None:
+    """Generate index.json from per-entity data."""
+    index = []
+    for entity in entities:
+        active_rels = sum(
+            1 for r in entity.get("relationships", [])
+            if r.get("status") == "active"
+        )
+        index.append({
+            "id": entity["id"],
+            "name": entity["name"],
+            "type": entity["type"],
+            "status_summary": (entity.get("current_status") or entity.get("identity", ""))[:80],
+            "first_seen_turn": entity.get("first_seen_turn"),
+            "last_updated_turn": entity.get("last_updated_turn"),
+            "active_relationship_count": active_rels,
+        })
+    fpath = os.path.join(entity_dir, "index.json")
+    with open(fpath, "w", encoding="utf-8") as f:
+        json.dump(index, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# Unified load / save (V2 preferred, V1 fallback)
+# ---------------------------------------------------------------------------
 
 def load_catalogs(catalog_dir: str) -> dict:
-    """Load all entity catalog files into a dict keyed by filename."""
-    catalogs = {}
-    for filename in ["characters.json", "locations.json", "factions.json", "items.json"]:
-        filepath = os.path.join(catalog_dir, filename)
-        if os.path.exists(filepath):
-            with open(filepath, "r", encoding="utf-8-sig") as f:
-                catalogs[filename] = json.load(f)
-        else:
-            catalogs[filename] = []
+    """Load all entity catalogs into a dict keyed by catalog name.
+
+    V2 mode: reads per-entity files from type directories.
+    V1 mode: reads flat JSON files (emits deprecation warning).
+
+    The returned dict is keyed by the canonical V1 filenames
+    (``characters.json``, etc.) for backward compatibility with callers.
+    """
+    fmt = detect_format(catalog_dir)
+    catalogs: dict[str, list[dict]] = {}
+
+    if fmt == "v2":
+        for dirname, filename in zip(_V2_DIRNAMES, _V1_FILENAMES):
+            entity_dir = os.path.join(catalog_dir, dirname)
+            catalogs[filename] = _read_v2_entities(entity_dir)
+    else:
+        warnings.warn(
+            "V1 flat catalog format detected; run migrate_catalogs_v2.py to upgrade",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        for filename in _V1_FILENAMES:
+            filepath = os.path.join(catalog_dir, filename)
+            if os.path.exists(filepath):
+                with open(filepath, "r", encoding="utf-8-sig") as f:
+                    catalogs[filename] = json.load(f)
+            else:
+                catalogs[filename] = []
     return catalogs
+
+
+def save_catalogs(catalog_dir: str, catalogs: dict, dry_run: bool = False) -> None:
+    """Write all catalogs back to disk.
+
+    V2 mode: writes per-entity files and regenerates index.json.
+    V1 mode: writes flat JSON files.
+    """
+    fmt = detect_format(catalog_dir)
+
+    if fmt == "v2":
+        for dirname, filename in zip(_V2_DIRNAMES, _V1_FILENAMES):
+            entities = catalogs.get(filename, [])
+            entity_dir = os.path.join(catalog_dir, dirname)
+            if dry_run:
+                print(f"  [DRY RUN] Would write {len(entities)} entities to {entity_dir}/")
+                continue
+            os.makedirs(entity_dir, exist_ok=True)
+            for entity in entities:
+                _write_v2_entity(entity_dir, entity)
+            _generate_index(entity_dir, entities)
+    else:
+        for filename, data in catalogs.items():
+            filepath = os.path.join(catalog_dir, filename)
+            if dry_run:
+                print(f"  [DRY RUN] Would write {len(data)} entries to {filepath}")
+                continue
+            os.makedirs(catalog_dir, exist_ok=True)
+            with open(filepath, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2, ensure_ascii=False)
+                f.write("\n")
 
 
 def load_events(catalog_dir: str) -> list:
@@ -55,19 +215,6 @@ def load_events(catalog_dir: str) -> list:
         with open(filepath, "r", encoding="utf-8-sig") as f:
             return json.load(f)
     return []
-
-
-def save_catalogs(catalog_dir: str, catalogs: dict, dry_run: bool = False) -> None:
-    """Write all catalog files back to disk."""
-    for filename, data in catalogs.items():
-        filepath = os.path.join(catalog_dir, filename)
-        if dry_run:
-            print(f"  [DRY RUN] Would write {len(data)} entries to {filepath}")
-            continue
-        os.makedirs(catalog_dir, exist_ok=True)
-        with open(filepath, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2, ensure_ascii=False)
-            f.write("\n")
 
 
 def save_events(catalog_dir: str, events: list, dry_run: bool = False) -> None:
@@ -82,6 +229,10 @@ def save_events(catalog_dir: str, events: list, dry_run: bool = False) -> None:
         f.write("\n")
 
 
+# ---------------------------------------------------------------------------
+# Entity lookup and formatting
+# ---------------------------------------------------------------------------
+
 def find_entity_by_id(catalogs: dict, entity_id: str) -> tuple[str, dict] | None:
     """Find an entity across all catalogs. Returns (catalog_filename, entity) or None."""
     for filename, entities in catalogs.items():
@@ -94,23 +245,39 @@ def find_entity_by_id(catalogs: dict, entity_id: str) -> tuple[str, dict] | None
 def format_known_entities(catalogs: dict) -> str:
     """Format all known entities as a compact table for the discovery prompt.
 
-    Includes description and aliases so the LLM can resolve coreferences.
+    Supports both V2 (identity + stable_attributes.aliases) and
+    V1 (description + attributes.aliases) entity shapes.
     """
     lines = []
     for filename, entities in catalogs.items():
         for entity in entities:
-            desc = entity.get('description', '')
-            aliases = entity.get('attributes', {}).get('aliases', '')
-            extra = ''
+            # V2: identity field; V1: description field
+            desc = entity.get("identity") or entity.get("description", "")
+            # V2: stable_attributes.aliases.value; V1: attributes.aliases (string)
+            aliases = ""
+            sa = entity.get("stable_attributes", {}).get("aliases")
+            if sa:
+                val = sa.get("value", "") if isinstance(sa, dict) else sa
+                if isinstance(val, list):
+                    aliases = ", ".join(val)
+                else:
+                    aliases = str(val)
+            if not aliases:
+                aliases = entity.get("attributes", {}).get("aliases", "")
+            extra = ""
             if desc:
-                extra += f' — {desc}'
+                extra += f" — {desc}"
             if aliases:
-                extra += f' (aliases: {aliases})'
+                extra += f" (aliases: {aliases})"
             lines.append(f"{entity['id']} | {entity['name']} | {entity['type']}{extra}")
     if not lines:
         return "(none — empty catalog)"
     return "\n".join(lines)
 
+
+# ---------------------------------------------------------------------------
+# ID prefix validation and correction
+# ---------------------------------------------------------------------------
 
 def validate_id_prefix(entity_id: str, entity_type: str) -> bool:
     """Check that an entity ID starts with the correct prefix for its type."""
@@ -144,11 +311,30 @@ def fix_id_prefix(entity_id: str, entity_type: str) -> str:
     return expected_prefix + entity_id
 
 
+# ---------------------------------------------------------------------------
+# Turn number helpers
+# ---------------------------------------------------------------------------
+
+def _parse_turn_number(turn_id: str | None) -> int | None:
+    """Extract the numeric part from a turn ID like ``turn-078``.
+
+    Returns ``None`` if the turn_id is missing or not parseable.
+    """
+    if not turn_id:
+        return None
+    m = re.match(r"^turn-(\d+)$", turn_id)
+    return int(m.group(1)) if m else None
+
+
+# ---------------------------------------------------------------------------
+# Entity merge
+# ---------------------------------------------------------------------------
+
 def merge_entity(catalogs: dict, entity: dict) -> None:
     """Merge a single entity into the appropriate catalog.
 
     - New entities: validate and append.
-    - Existing entities: deep-merge attributes, update description, update last_updated_turn.
+    - Existing entities: deep-merge attributes/identity/status, update last_updated_turn.
     """
     entity_id = entity.get("id")
     entity_type = entity.get("type")
@@ -160,7 +346,8 @@ def merge_entity(catalogs: dict, entity: dict) -> None:
         print(f"  WARNING: Entity '{entity_id}' has invalid prefix for type '{entity_type}'. Skipping.")
         return
 
-    catalog_file = TYPE_TO_CATALOG.get(entity_type)
+    # Map type to the V1 filename key used in the catalogs dict
+    catalog_file = TYPE_TO_CATALOG_V1.get(entity_type)
     if not catalog_file or catalog_file not in catalogs:
         return
 
@@ -176,40 +363,86 @@ def merge_entity(catalogs: dict, entity: dict) -> None:
         _update_existing_entity(current, entity)
         catalogs[catalog_file][idx] = current
     else:
-        # Ensure required fields for new entity
-        required = ["id", "name", "type", "description", "first_seen_turn"]
-        if all(entity.get(f) for f in required):
+        # Ensure required fields for new entity (V2: identity; V1: description)
+        required_base = ["id", "name", "type", "first_seen_turn"]
+        has_desc = entity.get("identity") or entity.get("description")
+        if all(entity.get(f) for f in required_base) and has_desc:
             catalogs[catalog_file].append(entity)
         else:
-            missing = [f for f in required if not entity.get(f)]
+            missing = [f for f in required_base if not entity.get(f)]
+            if not has_desc:
+                missing.append("identity/description")
             print(f"  WARNING: New entity '{entity_id}' missing required fields: {missing}. Skipping.")
 
 
 def _update_existing_entity(current: dict, update: dict) -> None:
-    """Update an existing entity with new information."""
-    # Update description if new one adds information
+    """Update an existing entity with new information.
+
+    Supports both V2 (identity/current_status/stable_attributes/volatile_state)
+    and V1 (description/attributes) entity shapes.
+    """
+    # --- V2 fields ---
+    if update.get("identity") and update["identity"] != current.get("identity"):
+        current["identity"] = update["identity"]
+
+    if update.get("current_status"):
+        current["current_status"] = update["current_status"]
+        if update.get("status_updated_turn"):
+            current["status_updated_turn"] = update["status_updated_turn"]
+
+    # Deep-merge stable_attributes
+    if update.get("stable_attributes"):
+        if "stable_attributes" not in current:
+            current["stable_attributes"] = {}
+        for key, value in update["stable_attributes"].items():
+            current["stable_attributes"][key] = value
+
+    # Merge volatile_state
+    if update.get("volatile_state"):
+        if "volatile_state" not in current:
+            current["volatile_state"] = {}
+        for key, value in update["volatile_state"].items():
+            current["volatile_state"][key] = value
+
+    # --- V1 fields (backward compat) ---
     if update.get("description") and update["description"] != current.get("description"):
         current["description"] = update["description"]
 
-    # Deep-merge attributes
     if update.get("attributes"):
         if "attributes" not in current:
             current["attributes"] = {}
         for key, value in update["attributes"].items():
             current["attributes"][key] = value
 
-    # Handle name changes / aliases
+    # Handle name changes / aliases (V2: stable_attributes.aliases; V1: attributes.aliases)
     if update.get("name") and update["name"] != current.get("name"):
         old_name = current["name"]
-        if "attributes" not in current:
-            current["attributes"] = {}
-        existing_aliases = current["attributes"].get("aliases", "")
-        alias_list = [a.strip() for a in existing_aliases.split(",")] if existing_aliases else []
-        if old_name not in alias_list:
-            if existing_aliases:
-                current["attributes"]["aliases"] = f"{existing_aliases}, {old_name}"
+        # V2 path
+        if "stable_attributes" in current:
+            sa = current["stable_attributes"]
+            existing_aliases = sa.get("aliases", {})
+            if isinstance(existing_aliases, dict):
+                val = existing_aliases.get("value", [])
+                if isinstance(val, str):
+                    val = [a.strip() for a in val.split(",") if a.strip()]
+                if old_name not in val:
+                    val.append(old_name)
+                sa["aliases"] = {"value": val, "inference": False,
+                                 "source_turn": update.get("last_updated_turn", "")}
             else:
-                current["attributes"]["aliases"] = old_name
+                sa["aliases"] = {"value": [old_name], "inference": False,
+                                 "source_turn": update.get("last_updated_turn", "")}
+        else:
+            # V1 path
+            if "attributes" not in current:
+                current["attributes"] = {}
+            existing_aliases = current["attributes"].get("aliases", "")
+            alias_list = [a.strip() for a in existing_aliases.split(",")] if existing_aliases else []
+            if old_name not in alias_list:
+                if existing_aliases:
+                    current["attributes"]["aliases"] = f"{existing_aliases}, {old_name}"
+                else:
+                    current["attributes"]["aliases"] = old_name
         current["name"] = update["name"]
 
     # Update last_updated_turn
@@ -220,34 +453,101 @@ def _update_existing_entity(current: dict, update: dict) -> None:
     if update.get("notes"):
         current["notes"] = update["notes"]
 
-    # Merge relationships (dedup by target_id + relationship)
+    # Merge relationships — consolidated per (target_id) pair
     if update.get("relationships"):
         if "relationships" not in current:
             current["relationships"] = []
-        existing_keys = {
-            (r.get("target_id"), r.get("relationship"))
-            for r in current["relationships"]
-        }
-        for rel in update["relationships"]:
-            key = (rel.get("target_id"), rel.get("relationship"))
-            if key not in existing_keys:
-                current["relationships"].append(rel)
-                existing_keys.add(key)
+        _merge_entity_relationships(current["relationships"], update["relationships"])
 
 
 # Public alias for cross-module use (e.g. post-batch dedup in semantic_extraction)
 dedup_merge_entity = _update_existing_entity
 
 
+# ---------------------------------------------------------------------------
+# Relationship consolidation
+# ---------------------------------------------------------------------------
+
+def _merge_entity_relationships(existing_rels: list[dict], new_rels: list[dict]) -> None:
+    """Merge new relationships into existing, consolidating per (target_id) pair.
+
+    If a pair already exists: update current_relationship, push old to history.
+    If a pair is new: append with status=active.
+    """
+    # Build index of existing relationships by target_id
+    by_target: dict[str, int] = {}
+    for idx, rel in enumerate(existing_rels):
+        tid = rel.get("target_id")
+        if tid and tid not in by_target:
+            by_target[tid] = idx
+
+    for new_rel in new_rels:
+        target_id = new_rel.get("target_id")
+        if not target_id:
+            continue
+
+        if target_id in by_target:
+            # Update existing pair
+            existing = existing_rels[by_target[target_id]]
+            _consolidate_relationship(existing, new_rel)
+        else:
+            # New pair — ensure required V2 fields
+            entry = dict(new_rel)
+            entry.setdefault("status", "active")
+            if "current_relationship" not in entry and "relationship" in entry:
+                entry["current_relationship"] = entry.pop("relationship")
+            existing_rels.append(entry)
+            by_target[target_id] = len(existing_rels) - 1
+
+
+def _consolidate_relationship(existing: dict, update: dict) -> None:
+    """Consolidate an update into an existing relationship for the same pair.
+
+    Pushes the old current_relationship into history and updates to the new one.
+    """
+    # Determine the new description
+    new_desc = update.get("current_relationship") or update.get("relationship", "")
+    old_desc = existing.get("current_relationship") or existing.get("relationship", "")
+
+    # Only push to history if the description actually changed
+    if new_desc and new_desc != old_desc and old_desc:
+        if "history" not in existing:
+            existing["history"] = []
+        history_turn = existing.get("last_updated_turn") or existing.get("first_seen_turn", "")
+        existing["history"].append({
+            "turn": history_turn,
+            "description": old_desc,
+        })
+
+    # Update current
+    if new_desc:
+        existing["current_relationship"] = new_desc
+        # Also keep the old field for V1 compat if it exists
+        if "relationship" in existing:
+            existing["relationship"] = new_desc
+
+    # Update other fields
+    if update.get("type"):
+        existing["type"] = update["type"]
+    if update.get("direction"):
+        existing["direction"] = update["direction"]
+    if update.get("confidence") is not None:
+        existing["confidence"] = update["confidence"]
+    if update.get("last_updated_turn"):
+        existing["last_updated_turn"] = update["last_updated_turn"]
+    if update.get("status"):
+        existing["status"] = update["status"]
+
+
 def merge_relationships(catalogs: dict, relationships: list, turn_id: str) -> None:
     """Merge relationship edges into entity catalog entries.
 
-    Deduplicates by (source_id, target_id, relationship).
+    V2: consolidates per (source_id, target_id) pair.
     """
     for rel in relationships:
         source_id = rel.get("source_id")
         target_id = rel.get("target_id")
-        relationship = rel.get("relationship")
+        relationship = rel.get("relationship") or rel.get("current_relationship")
         rel_type = rel.get("type")
         if not source_id or not target_id or not relationship or not rel_type:
             continue
@@ -262,25 +562,32 @@ def merge_relationships(catalogs: dict, relationships: list, turn_id: str) -> No
         if "relationships" not in entity:
             entity["relationships"] = []
 
-        # Check for existing relationship (dedup)
+        # Check for existing relationship by target_id (V2 per-pair dedup)
         existing_rel = None
         for r in entity["relationships"]:
-            if (r.get("target_id") == rel.get("target_id") and
-                    r.get("relationship") == rel.get("relationship")):
+            if r.get("target_id") == target_id:
                 existing_rel = r
                 break
 
         if existing_rel:
-            # Update existing
-            existing_rel["last_updated_turn"] = turn_id
+            # Consolidate into existing pair
+            update_rel = {
+                "current_relationship": relationship,
+                "type": rel_type,
+                "last_updated_turn": turn_id,
+            }
+            if rel.get("direction"):
+                update_rel["direction"] = rel["direction"]
             if rel.get("confidence") is not None:
-                existing_rel["confidence"] = rel["confidence"]
+                update_rel["confidence"] = rel["confidence"]
+            _consolidate_relationship(existing_rel, update_rel)
         else:
             # Add new relationship
             new_rel = {
                 "target_id": target_id,
-                "relationship": relationship,
+                "current_relationship": relationship,
                 "type": rel_type,
+                "status": "active",
             }
             if rel.get("direction"):
                 new_rel["direction"] = rel["direction"]
@@ -290,6 +597,66 @@ def merge_relationships(catalogs: dict, relationships: list, turn_id: str) -> No
             new_rel["last_updated_turn"] = turn_id
             entity["relationships"].append(new_rel)
 
+
+# ---------------------------------------------------------------------------
+# Dormancy marking
+# ---------------------------------------------------------------------------
+
+def mark_dormant_relationships(
+    catalogs: dict,
+    current_turn_id: str,
+    dormancy_threshold: int = DEFAULT_DORMANCY_THRESHOLD,
+) -> int:
+    """Mark relationships as dormant when both source and target are inactive.
+
+    A relationship is marked dormant if:
+    - Its status is ``active``
+    - Neither the source entity nor the target entity has been updated in the
+      last *dormancy_threshold* turns.
+
+    Returns the number of relationships marked dormant.
+    """
+    current_num = _parse_turn_number(current_turn_id)
+    if current_num is None:
+        return 0
+
+    # Build a lookup of entity last_updated_turn numbers
+    last_updated: dict[str, int] = {}
+    for _filename, entities in catalogs.items():
+        for entity in entities:
+            eid = entity.get("id")
+            turn_num = _parse_turn_number(entity.get("last_updated_turn"))
+            if eid and turn_num is not None:
+                last_updated[eid] = turn_num
+
+    marked = 0
+    for _filename, entities in catalogs.items():
+        for entity in entities:
+            source_id = entity.get("id")
+            source_num = last_updated.get(source_id)
+            for rel in entity.get("relationships", []):
+                if rel.get("status") != "active":
+                    continue
+                target_id = rel.get("target_id")
+                target_num = last_updated.get(target_id)
+                # Both source and target must be stale
+                source_stale = (
+                    source_num is not None
+                    and (current_num - source_num) >= dormancy_threshold
+                )
+                target_stale = (
+                    target_num is not None
+                    and (current_num - target_num) >= dormancy_threshold
+                ) if target_num is not None else True  # unknown target = stale
+                if source_stale and target_stale:
+                    rel["status"] = "dormant"
+                    marked += 1
+    return marked
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
 
 def merge_events(events_list: list, new_events: list) -> None:
     """Merge new events into the events list, deduplicating by ID."""

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -30,21 +30,9 @@ from __future__ import annotations
 import json
 import os
 import re
-import sys
 import warnings
-from pathlib import Path
 
-# Map entity type to catalog filename/directory and ID prefix
-TYPE_TO_CATALOG = {
-    "character": "characters",
-    "location": "locations",
-    "faction": "factions",
-    "item": "items",
-    "creature": "characters",  # creatures go to characters catalog
-    "concept": "items",  # concepts go to items catalog
-}
-
-# V1 flat file mapping (for backward compat)
+# V1 flat file mapping (for backward compatibility)
 TYPE_TO_CATALOG_V1 = {
     "character": "characters.json",
     "location": "locations.json",
@@ -79,11 +67,23 @@ DEFAULT_DORMANCY_THRESHOLD = 10
 def detect_format(catalog_dir: str) -> str:
     """Detect whether catalog_dir uses V2 (per-entity dirs) or V1 (flat files).
 
-    Returns ``"v2"`` if any entity-type subdirectory exists, ``"v1"`` otherwise.
+    Returns ``"v2"`` only when the layout is unambiguously V2: either all
+    expected entity-type subdirectories exist, or at least one V2 directory
+    exists and no legacy V1 flat files remain.  Mixed layouts fall back to
+    ``"v1"`` so legacy flat files are still loaded during migration.
     """
-    for dirname in _V2_DIRNAMES:
-        if os.path.isdir(os.path.join(catalog_dir, dirname)):
-            return "v2"
+    existing_v2_dirs = [
+        d for d in _V2_DIRNAMES
+        if os.path.isdir(os.path.join(catalog_dir, d))
+    ]
+    existing_v1_files = [
+        f for f in _V1_FILENAMES
+        if os.path.isfile(os.path.join(catalog_dir, f))
+    ]
+    if len(existing_v2_dirs) == len(_V2_DIRNAMES):
+        return "v2"
+    if existing_v2_dirs and not existing_v1_files:
+        return "v2"
     return "v1"
 
 
@@ -193,6 +193,15 @@ def save_catalogs(catalog_dir: str, catalogs: dict, dry_run: bool = False) -> No
                 print(f"  [DRY RUN] Would write {len(entities)} entities to {entity_dir}/")
                 continue
             os.makedirs(entity_dir, exist_ok=True)
+            # Remove stale per-entity files for entities no longer in memory
+            # (e.g. after dedup merges)
+            live_ids = {e["id"] for e in entities}
+            for fname in os.listdir(entity_dir):
+                if fname == "index.json" or not fname.endswith(".json"):
+                    continue
+                stem = fname[:-5]  # strip .json
+                if stem not in live_ids:
+                    os.remove(os.path.join(entity_dir, fname))
             for entity in entities:
                 _write_v2_entity(entity_dir, entity)
             _generate_index(entity_dir, entities)
@@ -427,11 +436,17 @@ def _update_existing_entity(current: dict, update: dict) -> None:
                     val = [a.strip() for a in val.split(",") if a.strip()]
                 if old_name not in val:
                     val.append(old_name)
+                alias_turn = (update.get("last_updated_turn")
+                              or current.get("last_updated_turn")
+                              or current.get("first_seen_turn", ""))
                 sa["aliases"] = {"value": val, "inference": False,
-                                 "source_turn": update.get("last_updated_turn", "")}
+                                 "source_turn": alias_turn}
             else:
+                alias_turn = (update.get("last_updated_turn")
+                              or current.get("last_updated_turn")
+                              or current.get("first_seen_turn", ""))
                 sa["aliases"] = {"value": [old_name], "inference": False,
-                                 "source_turn": update.get("last_updated_turn", "")}
+                                 "source_turn": alias_turn}
         else:
             # V1 path
             if "attributes" not in current:

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -26,6 +26,7 @@ from catalog_merger import (
     merge_relationships,
     merge_events,
     get_next_event_id,
+    mark_dormant_relationships,
 )
 from llm_client import LLMClient, LLMExtractionError
 
@@ -123,8 +124,8 @@ def _coerce_entity_fields(entity_data) -> dict | None:
         return None
 
     # Top-level string fields that the LLM sometimes wraps in arrays
-    string_fields = ["name", "description", "type", "proposed_id",
-                     "first_seen_turn", "last_updated_turn"]
+    string_fields = ["name", "description", "identity", "current_status",
+                     "type", "proposed_id", "first_seen_turn", "last_updated_turn"]
     for field in string_fields:
         val = entity_data.get(field)
         if isinstance(val, list):
@@ -733,6 +734,12 @@ def extract_semantic_batch(
     print(f"  Semantic extraction complete: {entities_after} entities, {events_after} events")
 
     if not dry_run:
+        # Post-merge dormancy pass
+        last_turn = turn_dicts[-1]["turn_id"] if turn_dicts else ""
+        dormant_count = mark_dormant_relationships(catalogs, last_turn)
+        if dormant_count:
+            print(f"  Marked {dormant_count} relationship(s) as dormant")
+
         save_catalogs(catalog_dir, catalogs)
         save_events(catalog_dir, events_list)
         _save_progress(progress_file, turn_dicts[-1]["turn_id"] if turn_dicts else "",
@@ -786,6 +793,11 @@ def extract_semantic_single(
 
     entities_total = sum(len(v) for v in catalogs.values())
     print(f"  Catalog now has {entities_total} entities, {len(events_list)} events")
+
+    # Post-merge dormancy pass
+    dormant_count = mark_dormant_relationships(catalogs, turn_id)
+    if dormant_count:
+        print(f"  Marked {dormant_count} relationship(s) as dormant")
 
     save_catalogs(catalog_dir, catalogs)
     save_events(catalog_dir, events_list)

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -204,8 +204,7 @@ PLAYER_CHARACTER_SEED = {
     "id": "char-player",
     "name": "Player Character",
     "type": "character",
-    "description": "The player character (referred to as 'you' in DM narration).",
-    "attributes": {},
+    "identity": "The player character (referred to as 'you' in DM narration).",
     "first_seen_turn": "turn-001",
     "last_updated_turn": "turn-001",
 }
@@ -492,12 +491,27 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
         for idx, entity in enumerate(entities):
             # Collect all names this entity is known by
             names = {entity.get("name", "").strip().lower()}
+            # V1: attributes.aliases (string)
             aliases_str = entity.get("attributes", {}).get("aliases", "")
             if aliases_str:
                 for a in aliases_str.split(","):
                     a = a.strip().lower()
                     if a:
                         names.add(a)
+            # V2: stable_attributes.aliases.value (list or string)
+            sa_aliases = entity.get("stable_attributes", {}).get("aliases")
+            if isinstance(sa_aliases, dict):
+                val = sa_aliases.get("value", "")
+                if isinstance(val, list):
+                    for a in val:
+                        a = a.strip().lower()
+                        if a:
+                            names.add(a)
+                elif isinstance(val, str) and val:
+                    for a in val.split(","):
+                        a = a.strip().lower()
+                        if a:
+                            names.add(a)
             for n in names:
                 if n:
                     name_map.setdefault(n, []).append(idx)


### PR DESCRIPTION
## Summary

Rewrite catalog_merger.py for V2 per-entity file layout per docs/design-catalog-v2.md Section 4.1.

## Changes

### Per-entity file I/O
- Read/write individual entity JSON files in type directories
- Format detection: V2 directory vs V1 flat file fallback
- V1 flat format emits deprecation warning
- Index.json generation after each merge

### Relationship consolidation
- Merge by (source, target) pair — no duplicate pairs
- Update current_relationship, push old to history
- V1 relationship field mapped to current_relationship transparently

### Dormancy marking
- mark_dormant_relationships() post-merge pass
- Configurable threshold (default 10 turns)
- Only marks active → dormant; never auto-resolves

### Caller updates
- semantic_extraction.py: V2 player character seed (identity instead of description)
- semantic_extraction.py: V2-aware alias resolution in dedup pass (stable_attributes.aliases.value)

### Tests
- 34 new tests covering format detection, V2 I/O, V1 fallback, relationship consolidation, dormancy marking, index generation
- All 117 tests pass; all 31 schema validations pass

### Backward compatibility
- V1 flat file format still supported as fallback
- Catalogs dict still keyed by V1 filenames for caller compatibility
- All existing public function signatures preserved

Closes #83
