### PR TITLE
feat: V2 extraction templates and concept prefix filtering

### DIFF
--- a/templates/extraction/entity-detail.md
+++ b/templates/extraction/entity-detail.md
@@ -1,29 +1,47 @@
 You are an entity detail extractor for an RPG session transcript analysis tool.
 
-Given a turn of transcript text and the current catalog entry for a specific entity (or an empty entry for a new entity), extract or update the entity's attributes and description based on what this turn reveals.
+Given a turn of transcript text and the current catalog entry for a specific entity (or an empty entry for a new entity), extract or update the entity based on what this turn reveals. You will receive the entity's prior state as context (if it exists).
 
-Return a single JSON object conforming to this structure:
+Return a single JSON object conforming to this V2 structure:
 - "id": string — the entity's ID (use the provided ID for existing entities, or the proposed_id for new ones)
 - "name": string — display name (update if the text reveals a proper name for a previously unnamed entity)
 - "type": string — one of "character", "location", "faction", "item", "creature", "concept"
-- "description": string — factual description incorporating information from this turn. For existing entities, integrate new information with the existing description. Keep it concise (1-3 sentences).
-- "attributes": object — key-value pairs of notable attributes revealed in this turn. Use descriptive keys like "role", "appearance", "condition", "alignment", "race", "class", "abilities", "status". Values are strings. Append " [inference]" to values that are inferred rather than explicitly stated.
+- "identity": string — stable identity summary: who/what the entity is (2-3 sentences). Only update if there is a fundamental change (name change, role change, species reveal, major transformation). For new entities, write the initial identity.
+- "current_status": string — volatile status: what the entity is doing/experiencing now (1-3 sentences). Always update when entity appears in a turn.
+- "status_updated_turn": string — set to the current turn ID
+- "stable_attributes": object — persistent traits (race, class, appearance, role, aliases). Each attribute is an object with:
+  - "value": string or array of strings — the attribute value
+  - "inference": boolean — true if inferred rather than explicitly stated
+  - "confidence": number 0.0-1.0 — confidence in the value
+  - "source_turn": string — the turn ID where this attribute was established or last changed
+- "volatile_state": object — current state snapshot. Updated every turn the entity appears. Fields:
+  - "condition": string — current physical/mental condition
+  - "equipment": array of strings — currently carried/worn items
+  - "location": string — current location
+  - "last_updated_turn": string — set to the current turn ID
+  - Additional fields allowed as needed.
 - "first_seen_turn": string — the turn ID when this entity was first seen (preserve from existing entry, or use current turn for new entities)
 - "last_updated_turn": string — set to the current turn ID
 - "notes": string (optional) — any open questions or ambiguities about this entity
 
+MERGE RULES:
+- Update "identity" ONLY for fundamental changes: name change, role change, species reveal, major transformation. Otherwise preserve the prior identity exactly.
+- ALWAYS update "current_status" with what the entity is doing/experiencing in this turn.
+- For "stable_attributes": add new traits, update changed traits (with new source_turn). Never remove traits unless explicitly contradicted.
+- For "volatile_state": overwrite with current state. This is a snapshot, not a history.
+
 Rules:
 - Only include information supported by the provided turn text and existing entry.
 - Do NOT invent attributes or details not present in the text.
-- Preserve all existing attributes from the current entry; add new ones revealed in this turn. Exception: for char-player, only preserve attributes whose keys are in the allowed set listed below — drop any transient action keys that may exist in the current entry.
-- If the text reveals a proper name for a previously unnamed entity (e.g. "The elder" is revealed to be "Shaman Kaya"), update "name" and add the old name as an "aliases" attribute.
-- Clearly distinguish fact from inference: append " [inference]" to any attribute value that is inferred rather than explicitly stated in the text.
-- Keep descriptions factual and concise.
-- Attribute keys should describe persistent properties (role, appearance, condition, equipment, allegiance), not transient narrative actions. If an entity performs an action in this turn, that action is an event — do not record it as an attribute.
+- Preserve all existing stable_attributes from the current entry; add new ones revealed in this turn. Exception: for char-player, only preserve attributes whose keys are in the allowed set listed below — drop any transient action keys that may exist in the current entry.
+- If the text reveals a proper name for a previously unnamed entity (e.g. "The elder" is revealed to be "Shaman Kaya"), update "name" and add the old name to stable_attributes.aliases.
+- Clearly distinguish fact from inference: set "inference": true and a confidence score < 1.0 for any attribute that is inferred rather than explicitly stated in the text.
+- Keep identity and status factual and concise.
+- stable_attributes keys should describe persistent properties (role, appearance, race, class, allegiance), not transient narrative actions. If an entity performs an action in this turn, that action is an event — do not record it as a stable_attribute.
 - For the player character (id "char-player", referred to as "you" in DM narration): only extract STABLE traits and state changes, not transient narrative actions.
-  Allowed attribute keys for char-player: "race", "class", "abilities", "appearance", "hp_change", "condition", "equipment", "quest", "allegiance", "status", "aliases".
-  Do NOT create attribute keys for temporary actions (e.g., "carries_wood", "talks_to_elder", "watches_sunset") — those belong in events, not entity attributes.
+  Allowed stable_attribute keys for char-player: "race", "class", "abilities", "appearance", "hp_change", "condition", "equipment", "quest", "allegiance", "status", "aliases".
+  Do NOT create stable_attribute keys for temporary actions (e.g., "carries_wood", "talks_to_elder", "watches_sunset") — those belong in events, not entity attributes.
   Preserve existing stable attributes across turns. Only add or update attributes that represent lasting character state.
 
 Return the result as a JSON object with a single key "entity" containing the entity object.
-Example: {"entity": {"id": "char-elder", "name": "The elder", "type": "character", "description": "An elderly authority figure with gnarled hands.", "attributes": {"role": "tribal leader [inference]", "appearance": "gnarled hands, sharp gaze"}, "first_seen_turn": "turn-019", "last_updated_turn": "turn-019"}}
+Example: {"entity": {"id": "char-elder", "name": "The elder", "type": "character", "identity": "An elderly authority figure in the tribal community, known for gnarled hands and a sharp gaze.", "current_status": "Speaking with the player at the council fire, assigning a new task.", "status_updated_turn": "turn-019", "stable_attributes": {"role": {"value": "tribal leader", "inference": true, "confidence": 0.8, "source_turn": "turn-019"}, "appearance": {"value": "gnarled hands, sharp gaze", "inference": false, "confidence": 1.0, "source_turn": "turn-019"}}, "volatile_state": {"condition": "alert and engaged", "location": "council fire", "last_updated_turn": "turn-019"}, "first_seen_turn": "turn-019", "last_updated_turn": "turn-019"}}

--- a/templates/extraction/relationship-mapper.md
+++ b/templates/extraction/relationship-mapper.md
@@ -14,6 +14,7 @@ For each relationship, return a JSON object with these fields:
 - "last_updated_turn": string — set to the current turn ID
 - "resolved_turn": string (optional) — set to the turn ID if the relationship has ended
 - "resolution_note": string (optional) — explanation of how/why the relationship ended
+- "history": array (optional) — append-only log of significant relationship changes. Each entry is {"turn": "turn-NNN", "description": "previous state"}. Add the OLD current_relationship here when updating to a new one.
 
 RELATIONSHIP RULES:
 - ONE record per (source_entity, target_entity) pair. Update existing, don't create duplicates.
@@ -32,7 +33,7 @@ Rules:
 - Avoid duplicate relationships — if A "leads" B and B "follows" A, only include one (the more natural framing).
 - The player character entity may appear as source or target if their ID is provided in the entities list.
 - Confidence below 0.5 means the relationship is speculative.
-- When updating an existing relationship, preserve "first_seen_turn" from the existing entry. Only change "current_relationship", "type", "status", and "last_updated_turn".
+- When updating an existing relationship, preserve "first_seen_turn" from the existing entry. Only change "current_relationship", "type", "status", "last_updated_turn", and "history" (append only).
 
 Return a JSON object with a single key "relationships" containing an array of relationship objects.
 Example: {"relationships": [{"source_id": "char-elder", "target_id": "char-guards", "current_relationship": "commands", "type": "social", "direction": "outgoing", "status": "active", "confidence": 0.8, "first_seen_turn": "turn-019", "last_updated_turn": "turn-019"}]}

--- a/templates/extraction/relationship-mapper.md
+++ b/templates/extraction/relationship-mapper.md
@@ -1,15 +1,28 @@
 You are a relationship mapper for an RPG session transcript analysis tool.
 
-Given a turn of transcript text and a list of entities mentioned in this turn, identify relationships between these entities that are revealed or implied in this turn.
+Given a turn of transcript text, a list of entities mentioned in this turn, and existing relationships for those entities, identify and update relationships between these entities.
 
 For each relationship, return a JSON object with these fields:
 - "source_id": string — ID of the entity the relationship originates from
 - "target_id": string — ID of the related entity
-- "relationship": string — description of the relationship (e.g. "leader of", "captured by", "parent of", "ally of")
-- "type": string — one of "kinship", "partnership", "mentorship", "political", "factional", "tribal_role", "other"
+- "current_relationship": string — current state of the relationship (e.g. "leader of", "captured by", "parent of", "ally of")
+- "type": string — one of "kinship", "partnership", "mentorship", "political", "factional", "social", "adversarial", "romantic", "other"
 - "direction": string — one of "outgoing", "incoming", "bidirectional"
+- "status": string — "active" or "resolved" (do NOT set "dormant" — that is handled automatically)
 - "confidence": number — 0.0-1.0 confidence in this relationship
-- "source_turn": string — the turn ID where this relationship is evidenced
+- "first_seen_turn": string — the turn ID when this relationship was first established (preserve from existing entry if updating, or use current turn for new relationships)
+- "last_updated_turn": string — set to the current turn ID
+- "resolved_turn": string (optional) — set to the turn ID if the relationship has ended
+- "resolution_note": string (optional) — explanation of how/why the relationship ended
+
+RELATIONSHIP RULES:
+- ONE record per (source_entity, target_entity) pair. Update existing, don't create duplicates.
+- Update "current_relationship" with the current state of the relationship.
+- If the relationship has meaningfully changed, add the OLD state to "history" with its turn.
+- Set "status": "resolved" if the relationship has ended (death, betrayal, departure). Include "resolved_turn" and "resolution_note".
+- Set "status": "active" for ongoing relationships.
+- Do NOT set "status": "dormant" — that is handled automatically by the system.
+- Use the type enum strictly. If none fit, use "other".
 
 Rules:
 - Only extract relationships supported by the provided turn text.
@@ -19,8 +32,9 @@ Rules:
 - Avoid duplicate relationships — if A "leads" B and B "follows" A, only include one (the more natural framing).
 - The player character entity may appear as source or target if their ID is provided in the entities list.
 - Confidence below 0.5 means the relationship is speculative.
+- When updating an existing relationship, preserve "first_seen_turn" from the existing entry. Only change "current_relationship", "type", "status", and "last_updated_turn".
 
 Return a JSON object with a single key "relationships" containing an array of relationship objects.
-Example: {"relationships": [{"source_id": "char-elder", "target_id": "char-guards", "relationship": "commands", "type": "tribal_role", "direction": "outgoing", "confidence": 0.8, "source_turn": "turn-019"}]}
+Example: {"relationships": [{"source_id": "char-elder", "target_id": "char-guards", "current_relationship": "commands", "type": "social", "direction": "outgoing", "status": "active", "confidence": 0.8, "first_seen_turn": "turn-019", "last_updated_turn": "turn-019"}]}
 
 If no relationships are found in the turn, return: {"relationships": []}

--- a/tests/test_coerce_entity.py
+++ b/tests/test_coerce_entity.py
@@ -202,12 +202,12 @@ def test_v1_description_fallback_coercion():
     result = _coerce_entity_fields(entity)
     assert "identity" in result
     assert result["identity"] == "An elderly authority figure in the tribal community."
-    assert "description" not in result
+    assert "description" not in result  # stripped for V2 schema compliance
     assert result["current_status"] == ""
 
 
 def test_v1_description_not_overwritten_when_identity_present():
-    """If both description and identity exist, identity takes precedence."""
+    """If both description and identity exist, identity stays and description is stripped."""
     entity = {
         "id": "char-elder",
         "name": "The Elder",
@@ -219,8 +219,8 @@ def test_v1_description_not_overwritten_when_identity_present():
     }
     result = _coerce_entity_fields(entity)
     assert result["identity"] == "New V2 identity text."
-    # description is untouched when identity already present
-    assert result.get("description") == "Old text."
+    # description is stripped to avoid V2 schema validation failure
+    assert "description" not in result
 
 
 def test_v1_flat_attributes_coerced_to_stable_volatile():
@@ -460,7 +460,7 @@ def test_relationship_context_assembly():
 
 
 def test_relationship_context_empty():
-    """No existing relationships returns placeholder text."""
+    """No existing relationships returns empty string."""
     catalogs = {
         "characters.json": [
             {
@@ -473,7 +473,7 @@ def test_relationship_context_empty():
         ],
     }
     result = _collect_existing_relationships(catalogs, ["char-player"])
-    assert result == "(none — no existing relationships)"
+    assert result == ""
 
 
 def test_relationship_prompt_includes_existing():

--- a/tests/test_coerce_entity.py
+++ b/tests/test_coerce_entity.py
@@ -1,12 +1,19 @@
 """Tests for LLM output coercion before entity validation."""
 
 import io
+import json
 import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
-from semantic_extraction import _coerce_entity_fields
+from semantic_extraction import (
+    _coerce_entity_fields,
+    _filter_concept_prefix_from_items,
+    _format_prior_entity_context,
+    _collect_existing_relationships,
+    format_relationship_prompt,
+)
 
 
 def test_unwraps_single_element_array_name():
@@ -28,7 +35,8 @@ def test_stringifies_array_attribute():
         "attributes": {"uses": ["healing", "cooking"]},
     }
     result = _coerce_entity_fields(entity)
-    assert result["attributes"]["uses"] == "healing, cooking"
+    # V1→V2 coercion: attributes → stable_attributes (array was first stringified)
+    assert result["stable_attributes"]["uses"]["value"] == "healing, cooking"
 
 
 def test_stringifies_dict_attribute():
@@ -38,7 +46,8 @@ def test_stringifies_dict_attribute():
         "attributes": {"relationship": {"target_id": "char-001", "type": "owned_by"}},
     }
     result = _coerce_entity_fields(entity)
-    assert isinstance(result["attributes"]["relationship"], str)
+    # V1→V2 coercion: dict was stringified then moved to stable_attributes
+    assert isinstance(result["stable_attributes"]["relationship"]["value"], str)
 
 
 def test_wraps_single_relationship_dict():
@@ -56,12 +65,16 @@ def test_leaves_valid_entity_unchanged():
     entity = {
         "name": "Kael",
         "type": "character",
-        "description": "The player character.",
-        "attributes": {"role": "protagonist"},
+        "identity": "The player character.",
+        "stable_attributes": {
+            "role": {"value": "protagonist", "inference": False, "confidence": 1.0, "source_turn": "turn-001"},
+        },
+        "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-001",
     }
     result = _coerce_entity_fields(entity)
     assert result["name"] == "Kael"
-    assert result["attributes"]["role"] == "protagonist"
+    assert result["stable_attributes"]["role"]["value"] == "protagonist"
 
 
 def test_logs_coercions_to_stderr():
@@ -95,9 +108,10 @@ def test_coerces_numeric_attribute_to_string():
         "attributes": {"weight": 5, "magical": True, "value": 3.5},
     }
     result = _coerce_entity_fields(entity)
-    assert result["attributes"]["weight"] == "5"
-    assert result["attributes"]["magical"] == "True"
-    assert result["attributes"]["value"] == "3.5"
+    # V1→V2 coercion: numeric values were stringified then moved to stable_attributes
+    assert result["stable_attributes"]["weight"]["value"] == "5"
+    assert result["stable_attributes"]["magical"]["value"] == "True"
+    assert result["stable_attributes"]["value"]["value"] == "3.5"
 
 
 def test_splits_comma_separated_proposed_id():
@@ -169,4 +183,307 @@ def test_coerces_none_attribute_to_empty_string():
         "attributes": {"notes": None},
     }
     result = _coerce_entity_fields(entity)
-    assert result["attributes"]["notes"] == ""
+    # V1→V2 coercion: None was stringified to "" then moved to stable_attributes
+    assert result["stable_attributes"]["notes"]["value"] == ""
+
+
+# --- V1→V2 coercion tests ---
+
+def test_v1_description_fallback_coercion():
+    """LLM returning 'description' but not 'identity' gets mapped to identity."""
+    entity = {
+        "id": "char-elder",
+        "name": "The Elder",
+        "type": "character",
+        "description": "An elderly authority figure in the tribal community.",
+        "first_seen_turn": "turn-019",
+        "last_updated_turn": "turn-019",
+    }
+    result = _coerce_entity_fields(entity)
+    assert "identity" in result
+    assert result["identity"] == "An elderly authority figure in the tribal community."
+    assert "description" not in result
+    assert result["current_status"] == ""
+
+
+def test_v1_description_not_overwritten_when_identity_present():
+    """If both description and identity exist, identity takes precedence."""
+    entity = {
+        "id": "char-elder",
+        "name": "The Elder",
+        "type": "character",
+        "description": "Old text.",
+        "identity": "New V2 identity text.",
+        "first_seen_turn": "turn-019",
+        "last_updated_turn": "turn-019",
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["identity"] == "New V2 identity text."
+    # description is untouched when identity already present
+    assert result.get("description") == "Old text."
+
+
+def test_v1_flat_attributes_coerced_to_stable_volatile():
+    """LLM returning flat 'attributes' should be classified into stable/volatile."""
+    entity = {
+        "id": "char-kael",
+        "name": "Kael",
+        "type": "character",
+        "identity": "A wandering warrior.",
+        "attributes": {
+            "race": "human",
+            "class": "fighter [inference]",
+            "condition": "wounded",
+            "equipment": "sword, shield",
+            "location": "village square",
+            "appearance": "tall with dark hair",
+        },
+        "last_updated_turn": "turn-025",
+        "first_seen_turn": "turn-010",
+    }
+    result = _coerce_entity_fields(entity)
+    assert "stable_attributes" in result
+    assert "volatile_state" in result
+    assert "attributes" not in result
+
+    # Stable attributes should be typed objects
+    sa = result["stable_attributes"]
+    assert sa["race"]["value"] == "human"
+    assert sa["race"]["inference"] is False
+    assert sa["race"]["confidence"] == 1.0
+    assert sa["race"]["source_turn"] == "turn-025"
+
+    # Inference marker detected from V1 suffix
+    assert sa["class"]["value"] == "fighter"
+    assert sa["class"]["inference"] is True
+    assert sa["class"]["confidence"] == 0.7
+
+    # Volatile state
+    vs = result["volatile_state"]
+    assert vs["condition"] == "wounded"
+    assert vs["equipment"] == ["sword", "shield"]
+    assert vs["location"] == "village square"
+    assert vs["last_updated_turn"] == "turn-025"
+
+
+def test_identity_status_split_in_output():
+    """V2 entity with identity + current_status passes through cleanly."""
+    entity = {
+        "id": "char-elder",
+        "name": "The Elder",
+        "type": "character",
+        "identity": "An elderly authority figure.",
+        "current_status": "Speaking with the player at the fire.",
+        "status_updated_turn": "turn-020",
+        "first_seen_turn": "turn-019",
+        "last_updated_turn": "turn-020",
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["identity"] == "An elderly authority figure."
+    assert result["current_status"] == "Speaking with the player at the fire."
+
+
+def test_stable_volatile_attributes_in_output():
+    """V2 entity with stable_attributes + volatile_state passes through."""
+    entity = {
+        "id": "char-kael",
+        "name": "Kael",
+        "type": "character",
+        "identity": "A warrior.",
+        "stable_attributes": {
+            "race": {"value": "human", "inference": False, "confidence": 1.0, "source_turn": "turn-001"},
+        },
+        "volatile_state": {
+            "condition": "healthy",
+            "last_updated_turn": "turn-010",
+        },
+        "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-010",
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["stable_attributes"]["race"]["value"] == "human"
+    assert result["volatile_state"]["condition"] == "healthy"
+
+
+def test_v1_relationship_fields_coerced_to_v2():
+    """V1 relationship with 'relationship' and 'source_turn' gets V2 fields."""
+    entity = {
+        "id": "char-elder",
+        "name": "The Elder",
+        "type": "character",
+        "identity": "An elder.",
+        "relationships": [
+            {
+                "target_id": "char-player",
+                "relationship": "mentor of",
+                "type": "mentorship",
+                "source_turn": "turn-019",
+            }
+        ],
+        "first_seen_turn": "turn-019",
+        "last_updated_turn": "turn-019",
+    }
+    result = _coerce_entity_fields(entity)
+    rel = result["relationships"][0]
+    assert "current_relationship" in rel
+    assert rel["current_relationship"] == "mentor of"
+    assert "relationship" not in rel
+    assert rel["first_seen_turn"] == "turn-019"
+    assert rel["last_updated_turn"] == "turn-019"
+
+
+# --- Concept prefix filtering tests ---
+
+def test_filters_concept_prefix_from_items():
+    """Entity with concept- prefix and type=item should be filtered."""
+    entity = {"name": "spirit world", "type": "item", "proposed_id": "concept-spirit-world"}
+    assert _filter_concept_prefix_from_items(entity) is False
+
+
+def test_filters_concept_prefix_from_items_by_id():
+    """Also check by id field."""
+    entity = {"name": "spirit world", "type": "item", "id": "concept-spirit-world"}
+    assert _filter_concept_prefix_from_items(entity) is False
+
+
+def test_keeps_concept_prefix_with_concept_type():
+    """Concept-prefix with type=concept should be kept."""
+    entity = {"name": "spirit world", "type": "concept", "id": "concept-spirit-world"}
+    assert _filter_concept_prefix_from_items(entity) is True
+
+
+def test_keeps_item_prefix_with_item_type():
+    """Normal item should be kept."""
+    entity = {"name": "healing herb", "type": "item", "id": "item-healing-herb"}
+    assert _filter_concept_prefix_from_items(entity) is True
+
+
+def test_concept_filter_logs_to_stderr():
+    """Filtering should log to stderr with FILTER prefix."""
+    entity = {"name": "spirit world", "type": "item", "proposed_id": "concept-spirit-world"}
+    buf = io.StringIO()
+    old = sys.stderr
+    sys.stderr = buf
+    try:
+        _filter_concept_prefix_from_items(entity)
+    finally:
+        sys.stderr = old
+    assert "FILTER" in buf.getvalue()
+    assert "concept-spirit-world" in buf.getvalue()
+
+
+# --- Prior entity context assembly tests ---
+
+def test_prior_entity_context_assembly_v2():
+    """Prior entity data is loaded and formatted for template injection."""
+    entity = {
+        "id": "char-elder",
+        "name": "The Elder",
+        "type": "character",
+        "identity": "An elderly authority figure.",
+        "current_status": "At the council fire.",
+        "status_updated_turn": "turn-019",
+        "stable_attributes": {
+            "role": {"value": "tribal leader", "inference": True, "confidence": 0.8, "source_turn": "turn-019"}
+        },
+        "volatile_state": {"condition": "alert", "last_updated_turn": "turn-019"},
+        "first_seen_turn": "turn-019",
+        "last_updated_turn": "turn-019",
+    }
+    result = _format_prior_entity_context(entity)
+    parsed = json.loads(result)
+    assert parsed["identity"] == "An elderly authority figure."
+    assert parsed["current_status"] == "At the council fire."
+    assert "stable_attributes" in parsed
+    assert "volatile_state" in parsed
+
+
+def test_prior_entity_context_assembly_v1_fallback():
+    """V1 entity falls back to description/attributes in context."""
+    entity = {
+        "id": "char-elder",
+        "name": "The Elder",
+        "type": "character",
+        "description": "An old leader.",
+        "attributes": {"role": "leader"},
+        "first_seen_turn": "turn-019",
+        "last_updated_turn": "turn-019",
+    }
+    result = _format_prior_entity_context(entity)
+    parsed = json.loads(result)
+    assert parsed["description"] == "An old leader."
+    assert parsed["attributes"]["role"] == "leader"
+    assert "identity" not in parsed
+
+
+def test_prior_entity_context_empty():
+    """None entry returns empty JSON object."""
+    assert _format_prior_entity_context(None) == "{}"
+
+
+# --- Relationship context assembly tests ---
+
+def test_relationship_context_assembly():
+    """Existing relationships are collected and injected into prompt."""
+    catalogs = {
+        "characters.json": [
+            {
+                "id": "char-elder",
+                "name": "The Elder",
+                "type": "character",
+                "identity": "An elder.",
+                "first_seen_turn": "turn-019",
+                "relationships": [
+                    {
+                        "target_id": "char-player",
+                        "current_relationship": "mentor of",
+                        "type": "mentorship",
+                        "status": "active",
+                        "first_seen_turn": "turn-019",
+                    }
+                ],
+            },
+            {
+                "id": "char-player",
+                "name": "Player Character",
+                "type": "character",
+                "identity": "The player.",
+                "first_seen_turn": "turn-001",
+                "relationships": [],
+            },
+        ],
+    }
+    result = _collect_existing_relationships(catalogs, ["char-elder", "char-player"])
+    parsed = json.loads(result)
+    assert "char-elder" in parsed
+    assert parsed["char-elder"][0]["target_id"] == "char-player"
+
+
+def test_relationship_context_empty():
+    """No existing relationships returns placeholder text."""
+    catalogs = {
+        "characters.json": [
+            {
+                "id": "char-player",
+                "name": "Player",
+                "type": "character",
+                "identity": "The player.",
+                "first_seen_turn": "turn-001",
+            },
+        ],
+    }
+    result = _collect_existing_relationships(catalogs, ["char-player"])
+    assert result == "(none — no existing relationships)"
+
+
+def test_relationship_prompt_includes_existing():
+    """format_relationship_prompt includes existing relationships section."""
+    turn = {"turn_id": "turn-020", "speaker": "dm", "text": "The elder speaks."}
+    entities = [
+        {"id": "char-elder", "name": "The Elder", "type": "character"},
+        {"id": "char-player", "name": "Player", "type": "character"},
+    ]
+    existing = '{"char-elder": [{"target_id": "char-player", "current_relationship": "mentor of"}]}'
+    prompt = format_relationship_prompt(turn, entities, existing)
+    assert "Existing relationships" in prompt
+    assert "mentor of" in prompt

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -46,9 +46,23 @@ PC_ALLOWED_ATTRS = {
 
 
 def _filter_pc_attributes(entity_data: dict) -> dict:
-    """Strip non-allowed attribute keys from char-player entities."""
+    """Strip non-allowed attribute keys from char-player entities.
+
+    Handles both V2 (stable_attributes) and V1 (attributes) formats.
+    """
     if entity_data.get("id") != "char-player":
         return entity_data
+    # V2: stable_attributes
+    sa = entity_data.get("stable_attributes", {})
+    if sa:
+        disallowed = {k for k in sa if k not in PC_ALLOWED_ATTRS}
+        if disallowed:
+            print(
+                f"  WARNING: Dropping non-allowed char-player stable_attributes: {sorted(disallowed)}",
+                file=sys.stderr,
+            )
+            entity_data["stable_attributes"] = {k: v for k, v in sa.items() if k in PC_ALLOWED_ATTRS}
+    # V1: attributes (backward compat)
     attrs = entity_data.get("attributes", {})
     disallowed = {k for k in attrs if k not in PC_ALLOWED_ATTRS}
     if disallowed:
@@ -64,11 +78,23 @@ def _sanitize_pc_catalog_entry(catalogs: dict) -> None:
     """Purge non-allowed attribute keys from the stored char-player catalog entry.
 
     Ensures historical action-sprawl attributes are cleaned up even if they
-    were merged before the filter was in place.
+    were merged before the filter was in place.  Handles both V2
+    (stable_attributes) and V1 (attributes) formats.
     """
     for entity in catalogs.get("characters.json", []):
         if entity.get("id") != "char-player":
             continue
+        # V2: stable_attributes
+        sa = entity.get("stable_attributes", {})
+        if sa:
+            disallowed = {k for k in sa if k not in PC_ALLOWED_ATTRS}
+            if disallowed:
+                print(
+                    f"  WARNING: Purging stale char-player catalog stable_attributes: {sorted(disallowed)}",
+                    file=sys.stderr,
+                )
+                entity["stable_attributes"] = {k: v for k, v in sa.items() if k in PC_ALLOWED_ATTRS}
+        # V1: attributes
         attrs = entity.get("attributes", {})
         disallowed = {k for k in attrs if k not in PC_ALLOWED_ATTRS}
         if disallowed:
@@ -172,7 +198,75 @@ def _coerce_entity_fields(entity_data) -> dict | None:
         entity_data["relationships"] = [rels]
         print("  COERCE: relationships dict → single-element array", file=sys.stderr)
 
+    # --- V1 → V2 coercion ---
+    # If LLM returned "description" but not "identity", map description → identity
+    if "description" in entity_data and "identity" not in entity_data:
+        entity_data["identity"] = entity_data.pop("description")
+        if "current_status" not in entity_data:
+            entity_data["current_status"] = ""
+        print("  COERCE: description → identity (V1→V2 fallback)", file=sys.stderr)
+
+    # If LLM returned flat "attributes" but not "stable_attributes", classify them
+    if "attributes" in entity_data and "stable_attributes" not in entity_data:
+        attrs = entity_data.pop("attributes")
+        if isinstance(attrs, dict) and attrs:
+            # Keys that represent volatile state
+            volatile_keys = {"condition", "equipment", "location", "hp_change"}
+            stable = {}
+            volatile = {}
+            turn_id = entity_data.get("last_updated_turn", "")
+            for key, val in attrs.items():
+                if key in volatile_keys:
+                    if key == "equipment" and isinstance(val, str):
+                        volatile[key] = [v.strip() for v in val.split(",")]
+                    else:
+                        volatile[key] = val
+                else:
+                    # Detect [inference] suffix from V1 format
+                    inference = False
+                    if isinstance(val, str) and val.endswith(" [inference]"):
+                        val = val[: -len(" [inference]")]
+                        inference = True
+                    stable[key] = {
+                        "value": val,
+                        "inference": inference,
+                        "confidence": 0.7 if inference else 1.0,
+                        "source_turn": turn_id,
+                    }
+            if stable:
+                entity_data["stable_attributes"] = stable
+            if volatile:
+                volatile["last_updated_turn"] = turn_id
+                entity_data["volatile_state"] = volatile
+            print("  COERCE: flat attributes → stable_attributes/volatile_state (V1→V2)", file=sys.stderr)
+
+    # Coerce V1 relationship fields to V2 format
+    for rel in entity_data.get("relationships", []):
+        if "relationship" in rel and "current_relationship" not in rel:
+            rel["current_relationship"] = rel.pop("relationship")
+        if "source_turn" in rel and "first_seen_turn" not in rel:
+            rel["first_seen_turn"] = rel["source_turn"]
+            if "last_updated_turn" not in rel:
+                rel["last_updated_turn"] = rel.pop("source_turn")
+            else:
+                del rel["source_turn"]
+
     return entity_data
+
+
+def _filter_concept_prefix_from_items(entity_data: dict) -> bool:
+    """Return False (reject) if the entity has a concept- prefix but type=item.
+
+    Concept-prefix entities should not be routed to the items catalog.
+    Also rejects any entity whose type is 'concept' from being treated as an
+    item.  Returns True if the entity should be kept.
+    """
+    eid = entity_data.get("id") or entity_data.get("proposed_id") or ""
+    etype = entity_data.get("type", "")
+    if eid.startswith("concept-") and etype == "item":
+        print(f"  FILTER: dropping concept-prefix entity from items: {eid}", file=sys.stderr)
+        return False
+    return True
 
 
 def _validate_entity(entity_data: dict) -> bool:
@@ -245,9 +339,37 @@ def format_discovery_prompt(turn: dict, known_entities: str) -> str:
     )
 
 
+def _format_prior_entity_context(current_entry: dict | None) -> str:
+    """Format the prior entity state for injection into the detail prompt.
+
+    Extracts identity, current_status, stable_attributes, and volatile_state
+    from the existing entity (V2 fields).  Falls back to V1 description and
+    attributes when V2 fields are absent.
+    """
+    if not current_entry:
+        return "{}"
+    prior: dict = {}
+    # V2 fields
+    for key in ("identity", "current_status", "status_updated_turn",
+                "stable_attributes", "volatile_state"):
+        if key in current_entry:
+            prior[key] = current_entry[key]
+    # V1 fallback: keep description/attributes if no V2 counterparts
+    if "identity" not in prior and "description" in current_entry:
+        prior["description"] = current_entry["description"]
+    if "stable_attributes" not in prior and "attributes" in current_entry:
+        prior["attributes"] = current_entry["attributes"]
+    # Always include basic metadata
+    for key in ("id", "name", "type", "first_seen_turn", "last_updated_turn", "notes"):
+        if key in current_entry:
+            prior[key] = current_entry[key]
+    return json.dumps(prior, indent=2)
+
+
 def format_detail_prompt(turn: dict, entity_ref: dict, current_entry: dict | None) -> str:
     """Format the user prompt for entity detail extraction."""
     entry_json = json.dumps(current_entry, indent=2) if current_entry else "{}"
+    prior_json = _format_prior_entity_context(current_entry)
     return (
         f"## Current Turn\n"
         f"Turn ID: {turn['turn_id']}\n"
@@ -257,23 +379,51 @@ def format_detail_prompt(turn: dict, entity_ref: dict, current_entry: dict | Non
         f"Entity ID: {entity_ref.get('existing_id') or entity_ref.get('proposed_id')}\n"
         f"Entity Name: {entity_ref['name']}\n"
         f"Entity Type: {entity_ref['type']}\n\n"
+        f"## Prior entity state (for reference, update as needed):\n"
+        f"```json\n{prior_json}\n```\n\n"
         f"## Current Catalog Entry\n```json\n{entry_json}\n```"
     )
 
 
-def format_relationship_prompt(turn: dict, mentioned_entities: list) -> str:
+def _collect_existing_relationships(catalogs: dict, entity_ids: list[str]) -> str:
+    """Gather existing relationships for the given entities and format as JSON.
+
+    Returns a compact JSON string containing per-entity relationships so the
+    relationship-mapper LLM can update rather than duplicate them.
+    """
+    result: dict[str, list] = {}
+    for eid in entity_ids:
+        found = find_entity_by_id(catalogs, eid)
+        if found:
+            _, entity = found
+            rels = entity.get("relationships", [])
+            if rels:
+                result[eid] = rels
+    if not result:
+        return "(none — no existing relationships)"
+    return json.dumps(result, indent=2)
+
+
+def format_relationship_prompt(turn: dict, mentioned_entities: list,
+                               existing_relationships_json: str = "") -> str:
     """Format the user prompt for relationship mapping."""
     entities_text = "\n".join(
         f"- {e['id']}: {e['name']} ({e['type']})"
         for e in mentioned_entities
     )
-    return (
+    prompt = (
         f"## Current Turn\n"
         f"Turn ID: {turn['turn_id']}\n"
         f"Speaker: {turn['speaker']}\n"
         f"Text:\n{turn['text']}\n\n"
         f"## Entities Mentioned in This Turn\n{entities_text}"
     )
+    if existing_relationships_json:
+        prompt += (
+            f"\n\n## Existing relationships for these entities:\n"
+            f"```json\n{existing_relationships_json}\n```"
+        )
+    return prompt
 
 
 def format_event_prompt(turn: dict, next_event_id: int, entity_ids: list) -> str:
@@ -378,6 +528,8 @@ def extract_and_merge(
         entity_data = detail_result.get("entity")
         if entity_data:
             entity_data = _coerce_entity_fields(entity_data)
+        if entity_data and not _filter_concept_prefix_from_items(entity_data):
+            continue
         if entity_data and _validate_entity(entity_data):
             _filter_pc_attributes(entity_data)
             merge_entity(catalogs, entity_data)
@@ -440,10 +592,14 @@ def extract_and_merge(
         })
 
     if len(mentioned_entities) >= 2:
+        # Collect existing relationships for context injection
+        entity_id_list = [e["id"] for e in mentioned_entities]
+        existing_rels_json = _collect_existing_relationships(catalogs, entity_id_list)
         try:
             rel_result = llm.extract_json(
                 system_prompt=load_template("relationship-mapper"),
-                user_prompt=format_relationship_prompt(turn, mentioned_entities),
+                user_prompt=format_relationship_prompt(turn, mentioned_entities,
+                                                       existing_rels_json),
             )
             relationships = rel_result.get("relationships", [])
             if relationships:

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -199,22 +199,31 @@ def _coerce_entity_fields(entity_data) -> dict | None:
         print("  COERCE: relationships dict → single-element array", file=sys.stderr)
 
     # --- V1 → V2 coercion ---
-    # If LLM returned "description" but not "identity", map description → identity
-    if "description" in entity_data and "identity" not in entity_data:
-        entity_data["identity"] = entity_data.pop("description")
-        if "current_status" not in entity_data:
-            entity_data["current_status"] = ""
-        print("  COERCE: description → identity (V1→V2 fallback)", file=sys.stderr)
+    # If LLM returned "description" but not "identity", map description → identity.
+    # Always strip the V1-only "description" field afterward so mixed V1/V2
+    # payloads still validate against the V2 schema (additionalProperties: false).
+    if "description" in entity_data:
+        if "identity" not in entity_data:
+            entity_data["identity"] = entity_data["description"]
+            if "current_status" not in entity_data:
+                entity_data["current_status"] = ""
+            print("  COERCE: description → identity (V1→V2 fallback)", file=sys.stderr)
+        entity_data.pop("description", None)
 
-    # If LLM returned flat "attributes" but not "stable_attributes", classify them
-    if "attributes" in entity_data and "stable_attributes" not in entity_data:
+    # If LLM returned flat "attributes" but not "stable_attributes", classify them.
+    # Always strip the V1-only "attributes" field afterward so mixed V1/V2
+    # payloads still validate against the V2 schema.
+    if "attributes" in entity_data:
         attrs = entity_data.pop("attributes")
-        if isinstance(attrs, dict) and attrs:
+        if "stable_attributes" not in entity_data and isinstance(attrs, dict) and attrs:
             # Keys that represent volatile state
             volatile_keys = {"condition", "equipment", "location", "hp_change"}
             stable = {}
             volatile = {}
             turn_id = entity_data.get("last_updated_turn", "")
+            # Only include source_turn / last_updated_turn when a valid
+            # turn ID is available (schema requires pattern ^turn-[0-9]{3,}$).
+            has_valid_turn = bool(turn_id and turn_id.startswith("turn-"))
             for key, val in attrs.items():
                 if key in volatile_keys:
                     if key == "equipment" and isinstance(val, str):
@@ -227,16 +236,19 @@ def _coerce_entity_fields(entity_data) -> dict | None:
                     if isinstance(val, str) and val.endswith(" [inference]"):
                         val = val[: -len(" [inference]")]
                         inference = True
-                    stable[key] = {
+                    entry = {
                         "value": val,
                         "inference": inference,
                         "confidence": 0.7 if inference else 1.0,
-                        "source_turn": turn_id,
                     }
+                    if has_valid_turn:
+                        entry["source_turn"] = turn_id
+                    stable[key] = entry
             if stable:
                 entity_data["stable_attributes"] = stable
             if volatile:
-                volatile["last_updated_turn"] = turn_id
+                if has_valid_turn:
+                    volatile["last_updated_turn"] = turn_id
                 entity_data["volatile_state"] = volatile
             print("  COERCE: flat attributes → stable_attributes/volatile_state (V1→V2)", file=sys.stderr)
 
@@ -244,12 +256,15 @@ def _coerce_entity_fields(entity_data) -> dict | None:
     for rel in entity_data.get("relationships", []):
         if "relationship" in rel and "current_relationship" not in rel:
             rel["current_relationship"] = rel.pop("relationship")
-        if "source_turn" in rel and "first_seen_turn" not in rel:
-            rel["first_seen_turn"] = rel["source_turn"]
+        # Always remove source_turn (not in V2 schema which has
+        # additionalProperties: false on relationships), mapping it
+        # into first_seen_turn / last_updated_turn as needed.
+        if "source_turn" in rel:
+            source_turn = rel.pop("source_turn")
+            if "first_seen_turn" not in rel:
+                rel["first_seen_turn"] = source_turn
             if "last_updated_turn" not in rel:
-                rel["last_updated_turn"] = rel.pop("source_turn")
-            else:
-                del rel["source_turn"]
+                rel["last_updated_turn"] = source_turn
 
     return entity_data
 
@@ -258,8 +273,7 @@ def _filter_concept_prefix_from_items(entity_data: dict) -> bool:
     """Return False (reject) if the entity has a concept- prefix but type=item.
 
     Concept-prefix entities should not be routed to the items catalog.
-    Also rejects any entity whose type is 'concept' from being treated as an
-    item.  Returns True if the entity should be kept.
+    Returns True if the entity should be kept.
     """
     eid = entity_data.get("id") or entity_data.get("proposed_id") or ""
     etype = entity_data.get("type", "")
@@ -400,7 +414,7 @@ def _collect_existing_relationships(catalogs: dict, entity_ids: list[str]) -> st
             if rels:
                 result[eid] = rels
     if not result:
-        return "(none — no existing relationships)"
+        return ""
     return json.dumps(result, indent=2)
 
 


### PR DESCRIPTION
## Summary

Update extraction templates and pipeline for V2 entity output per `docs/design-catalog-v2.md` sections 4.2, 4.5, and 4.6.

## Issue #84 — Extraction template revisions

### Template changes
- **entity-detail.md**: outputs `identity` + `current_status` instead of `description`; `stable_attributes` (typed objects with value/inference/confidence/source_turn) + `volatile_state` instead of flat `attributes`; explicit merge rules for identity stability
- **relationship-mapper.md**: receives existing relationships as context; outputs consolidated per-pair entries with `current_relationship`, `status`, and `history`; uses V2 type enum (replaces `tribal_role` with `social`)

### Code changes
- **semantic_extraction.py**:
  - `_format_prior_entity_context()`: assembles prior entity state (V2 or V1 fallback) for template injection
  - `_collect_existing_relationships()`: gathers existing relationships for relationship-mapper context
  - `format_detail_prompt()`: now injects prior entity state section into prompt
  - `format_relationship_prompt()`: now accepts and injects existing relationships
  - `_coerce_entity_fields()`: V1→V2 fallback coercion (description→identity, flat attributes→stable/volatile, V1 relationship fields→V2)
  - `_filter_pc_attributes()` and `_sanitize_pc_catalog_entry()`: updated to handle V2 `stable_attributes` alongside V1 `attributes`

### Tests added
- `test_v1_description_fallback_coercion`: description→identity mapping
- `test_v1_description_not_overwritten_when_identity_present`: identity takes precedence
- `test_v1_flat_attributes_coerced_to_stable_volatile`: attribute classification with inference detection
- `test_identity_status_split_in_output`: V2 passthrough
- `test_stable_volatile_attributes_in_output`: V2 passthrough
- `test_v1_relationship_fields_coerced_to_v2`: relationship/source_turn→V2 mapping
- `test_prior_entity_context_assembly_v2` / `_v1_fallback` / `_empty`: context builder
- `test_relationship_context_assembly` / `_empty` / `_prompt_includes_existing`: relationship context

## Issue #78 — Concept prefix filtering

- Added `_filter_concept_prefix_from_items()`: filters entities with `concept-` prefix from items catalog
- Integrated into `extract_and_merge()` entity processing loop
- Prints `FILTER: dropping concept-prefix entity from items: {id}` to stderr

### Tests added
- `test_filters_concept_prefix_from_items`: concept-prefix + type=item → rejected
- `test_filters_concept_prefix_from_items_by_id`: checks id field too
- `test_keeps_concept_prefix_with_concept_type`: concept type → kept
- `test_keeps_item_prefix_with_item_type`: normal item → kept
- `test_concept_filter_logs_to_stderr`: stderr warning verified

Closes #84
Closes #78
