### PR TITLE
fix: V2 pipeline — clean-start format, migration preservation, dedup guards, batch dormancy

### DIFF
--- a/tests/test_catalog_merger_v2.py
+++ b/tests/test_catalog_merger_v2.py
@@ -529,6 +529,14 @@ class TestIndexGeneration:
         index = json.loads(index_path.read_text(encoding="utf-8"))
         assert len(index) == 2
 
+        alpha_idx = next(e for e in index if e["id"] == "char-alpha")
+        assert alpha_idx["name"] == "Alpha"
+        assert alpha_idx["active_relationship_count"] == 0
+        assert alpha_idx["status_summary"] == "Active warrior."
+
+        beta_idx = next(e for e in index if e["id"] == "char-beta")
+        assert beta_idx["active_relationship_count"] == 1  # only 'active' status counted
+
 
 # ---------------------------------------------------------------------------
 # Clean-start V2 defaulting (Issue #96)

--- a/tests/test_catalog_merger_v2.py
+++ b/tests/test_catalog_merger_v2.py
@@ -529,13 +529,89 @@ class TestIndexGeneration:
         index = json.loads(index_path.read_text(encoding="utf-8"))
         assert len(index) == 2
 
-        alpha_idx = next(e for e in index if e["id"] == "char-alpha")
-        assert alpha_idx["name"] == "Alpha"
-        assert alpha_idx["active_relationship_count"] == 0
-        assert alpha_idx["status_summary"] == "Active warrior."
 
-        beta_idx = next(e for e in index if e["id"] == "char-beta")
-        assert beta_idx["active_relationship_count"] == 1  # only 'active' status counted
+# ---------------------------------------------------------------------------
+# Clean-start V2 defaulting (Issue #96)
+# ---------------------------------------------------------------------------
+
+class TestSaveCatalogsCleanStart:
+    def test_clean_start_uses_v2(self, tmp_path):
+        """On a completely clean catalog dir, save_catalogs should default to V2."""
+        catalog_dir = str(tmp_path / "catalogs")
+        os.makedirs(catalog_dir, exist_ok=True)
+        # Write empty flat files (simulating clean extraction start)
+        for name in ["characters.json", "locations.json", "factions.json", "items.json"]:
+            with open(os.path.join(catalog_dir, name), "w") as f:
+                json.dump([], f)
+
+        catalogs = {
+            "characters.json": [{"id": "char-test", "name": "Test", "type": "character",
+                                 "identity": "A test character", "first_seen_turn": "turn-001"}],
+            "locations.json": [],
+            "factions.json": [],
+            "items.json": [],
+        }
+        save_catalogs(catalog_dir, catalogs)
+
+        # Should have created V2 per-entity directory
+        assert os.path.isdir(os.path.join(catalog_dir, "characters"))
+        assert os.path.isfile(os.path.join(catalog_dir, "characters", "char-test.json"))
+        assert os.path.isfile(os.path.join(catalog_dir, "characters", "index.json"))
+
+    def test_empty_dir_uses_v2(self, tmp_path):
+        """On a completely empty catalog dir (no files at all), save_catalogs defaults to V2."""
+        catalog_dir = str(tmp_path / "catalogs")
+        os.makedirs(catalog_dir, exist_ok=True)
+
+        catalogs = {
+            "characters.json": [{"id": "char-test", "name": "Test", "type": "character",
+                                 "identity": "A test character", "first_seen_turn": "turn-001"}],
+            "locations.json": [],
+            "factions.json": [],
+            "items.json": [],
+        }
+        save_catalogs(catalog_dir, catalogs)
+
+        assert os.path.isdir(os.path.join(catalog_dir, "characters"))
+        assert os.path.isfile(os.path.join(catalog_dir, "characters", "char-test.json"))
+
+    def test_real_v1_data_stays_v1(self, tmp_path):
+        """When real V1 data exists, save_catalogs should stay V1 for backward compat."""
+        catalog_dir = str(tmp_path / "catalogs")
+        os.makedirs(catalog_dir, exist_ok=True)
+        # Write V1 flat file with real data
+        with open(os.path.join(catalog_dir, "characters.json"), "w") as f:
+            json.dump([{"id": "char-old", "name": "Old", "type": "character",
+                        "description": "An old format entity"}], f)
+        for name in ["locations.json", "factions.json", "items.json"]:
+            with open(os.path.join(catalog_dir, name), "w") as f:
+                json.dump([], f)
+
+        catalogs = {"characters.json": [{"id": "char-old", "name": "Old", "type": "character",
+                                         "description": "An old format entity"}],
+                    "locations.json": [], "factions.json": [], "items.json": []}
+        save_catalogs(catalog_dir, catalogs)
+
+        # Should NOT have created V2 directory — V1 data exists
+        assert not os.path.isdir(os.path.join(catalog_dir, "characters"))
+
+    def test_prefer_v2_false_stays_v1(self, tmp_path):
+        """When prefer_v2=False, clean start stays V1."""
+        catalog_dir = str(tmp_path / "catalogs")
+        os.makedirs(catalog_dir, exist_ok=True)
+        for name in ["characters.json", "locations.json", "factions.json", "items.json"]:
+            with open(os.path.join(catalog_dir, name), "w") as f:
+                json.dump([], f)
+
+        catalogs = {
+            "characters.json": [{"id": "char-test", "name": "Test", "type": "character",
+                                 "identity": "Test", "first_seen_turn": "turn-001"}],
+            "locations.json": [], "factions.json": [], "items.json": [],
+        }
+        save_catalogs(catalog_dir, catalogs, prefer_v2=False)
+
+        # Should NOT have created V2 directory
+        assert not os.path.isdir(os.path.join(catalog_dir, "characters"))
 
     def test_index_status_summary_truncated(self, tmp_path):
         edir = tmp_path / "characters"

--- a/tests/test_dedup_fuzzy.py
+++ b/tests/test_dedup_fuzzy.py
@@ -1,10 +1,11 @@
 """Tests for fuzzy dedup matching in _dedup_catalogs()."""
+import inspect
 import sys
 import os
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
-from semantic_extraction import _dedup_catalogs
+from semantic_extraction import _dedup_catalogs, extract_semantic_batch, extract_semantic_single
 
 
 def _make_entity(id_, name, turn="turn-001"):
@@ -107,11 +108,93 @@ def test_no_partial_word_substring_merge():
     assert len(catalogs["items.json"]) == 2
 
 
-if __name__ == "__main__":
-    test_token_overlap_merge_spear()
-    test_substring_merge_bowl_group()
-    test_substring_merge_moonpetal()
-    test_no_cross_catalog_merge()
-    test_id_stem_merge()
-    test_no_partial_word_substring_merge()
-    print("All tests passed!")
+def test_no_false_merge_crude_weapons_vs_buckets():
+    """'crude weapons' and 'crude wooden buckets' should NOT merge."""
+    catalogs = {
+        "items.json": [
+            _make_entity("item-crude-weapons", "crude weapons", "turn-001"),
+            _make_entity("item-crude-wooden-buckets", "crude wooden buckets", "turn-002"),
+        ]
+    }
+    count, merge_map = _dedup_catalogs(catalogs)
+    assert count == 0
+    assert len(catalogs["items.json"]) == 2
+
+
+def test_no_false_merge_herb_party_vs_hunting_party():
+    """'herb gathering party' and 'hunting party' should NOT merge."""
+    catalogs = {
+        "factions.json": [
+            _make_entity("faction-herb-gathering-party", "herb gathering party", "turn-001"),
+            _make_entity("faction-hunting-party", "hunting party", "turn-002"),
+        ]
+    }
+    count, merge_map = _dedup_catalogs(catalogs)
+    assert count == 0
+    assert len(catalogs["factions.json"]) == 2
+
+
+def test_no_false_merge_broad_figure_vs_lone_figure():
+    """'broad figure' and 'a lone figure' should NOT merge."""
+    catalogs = {
+        "characters.json": [
+            _make_entity("char-broad-figure", "broad figure", "turn-001"),
+            _make_entity("char-lone-figure", "a lone figure", "turn-002"),
+        ]
+    }
+    count, merge_map = _dedup_catalogs(catalogs)
+    assert count == 0
+    assert len(catalogs["characters.json"]) == 2
+
+
+def test_correct_merge_snow_laden_pines_woods():
+    """'snow-laden pines' and 'snow-laden woods' SHOULD merge (2-token overlap, 100%)."""
+    catalogs = {
+        "locations.json": [
+            _make_entity("loc-snow-laden-pines", "snow-laden pines", "turn-001"),
+            _make_entity("loc-snow-laden-woods", "snow-laden woods", "turn-005"),
+        ]
+    }
+    count, merge_map = _dedup_catalogs(catalogs)
+    # Both have tokens {snow, laden, pines/woods}; after stopword removal,
+    # smaller has 3 tokens, overlap is {snow, laden} = 2/3 = 67% > 50% → merge
+    # Wait — "snow-laden" splits to {snow, laden} and then + pines/woods = 3 tokens each.
+    # overlap = {snow, laden} = 2; smaller = 3; 2/3 < 1.0 threshold for <=2
+    # But smaller is 3, so threshold is 0.5, and 2/3 >= 0.5 → merge!
+    assert count == 1
+    assert len(catalogs["locations.json"]) == 1
+
+
+def test_single_token_bowl_no_merge():
+    """'bowl' (single token) should NOT merge with 'steaming bowl' via subset rule."""
+    catalogs = {
+        "items.json": [
+            _make_entity("item-bowl", "Bowl", "turn-002"),
+            _make_entity("item-steaming-bowl", "Steaming bowl", "turn-005"),
+        ]
+    }
+    count, merge_map = _dedup_catalogs(catalogs)
+    # 'bowl' is a stopword now, so tokens for "bowl" = {} (empty after removing stopword)
+    # This means the token rules won't fire; check if name-map exact match catches it
+    # "bowl" != "steaming bowl" so no exact match either.
+    # Different IDs stem: "bowl" vs "steaming-bowl" — stem subset would catch it.
+    # Actually ID stem: stem_a="bowl", stem_b="steaming-bowl", parts_a={"bowl"} ⊂ parts_b={"steaming","bowl"}
+    # So ID-stem rule will still merge these.
+    assert count == 1
+    assert len(catalogs["items.json"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Batch dormancy skip (Issue #99)
+# ---------------------------------------------------------------------------
+
+def test_batch_extraction_does_not_call_dormancy():
+    """extract_semantic_batch should NOT contain a mark_dormant_relationships call."""
+    source = inspect.getsource(extract_semantic_batch)
+    assert "mark_dormant_relationships" not in source
+
+
+def test_single_turn_extraction_calls_dormancy():
+    """extract_semantic_single should still call mark_dormant_relationships."""
+    source = inspect.getsource(extract_semantic_single)
+    assert "mark_dormant_relationships" in source

--- a/tests/test_dedup_fuzzy.py
+++ b/tests/test_dedup_fuzzy.py
@@ -1,11 +1,11 @@
 """Tests for fuzzy dedup matching in _dedup_catalogs()."""
-import inspect
 import sys
 import os
+from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
-from semantic_extraction import _dedup_catalogs, extract_semantic_batch, extract_semantic_single
+from semantic_extraction import _dedup_catalogs
 
 
 def _make_entity(id_, name, turn="turn-001"):
@@ -37,6 +37,7 @@ def test_token_overlap_merge_spear():
 
 
 def test_substring_merge_bowl_group():
+    """With tighter dedup rules, only closely-related bowls merge."""
     catalogs = {
         "items.json": [
             _make_entity("item-bowl", "Bowl", "turn-002"),
@@ -46,11 +47,15 @@ def test_substring_merge_bowl_group():
         ]
     }
     count, merge_map = _dedup_catalogs(catalogs)
-    # All should merge into the earliest entry
-    assert len(catalogs["items.json"]) == 1
-    survivor = catalogs["items.json"][0]
-    assert survivor["id"] == "item-bowl"
-    assert count == 3
+    # 'bowl' is a stopword → item-bowl has no tokens and 1-segment ID stem → stays separate.
+    # 'steaming bowl' and 'steaming broth bowl' share enough overlap → merge.
+    # 'warm wooden bowl' has no token/stem overlap with steaming variants → stays separate.
+    assert count == 1
+    assert len(catalogs["items.json"]) == 3
+    surviving_ids = {e["id"] for e in catalogs["items.json"]}
+    assert "item-bowl" in surviving_ids
+    assert "item-steaming-bowl" in surviving_ids  # survivor of steaming pair
+    assert "item-warm-wooden-bowl" in surviving_ids
 
 
 def test_substring_merge_moonpetal():
@@ -166,7 +171,7 @@ def test_correct_merge_snow_laden_pines_woods():
 
 
 def test_single_token_bowl_no_merge():
-    """'bowl' (single token) should NOT merge with 'steaming bowl' via subset rule."""
+    """'bowl' should NOT merge with 'steaming bowl' — single-segment ID stem blocked."""
     catalogs = {
         "items.json": [
             _make_entity("item-bowl", "Bowl", "turn-002"),
@@ -174,14 +179,10 @@ def test_single_token_bowl_no_merge():
         ]
     }
     count, merge_map = _dedup_catalogs(catalogs)
-    # 'bowl' is a stopword now, so tokens for "bowl" = {} (empty after removing stopword)
-    # This means the token rules won't fire; check if name-map exact match catches it
-    # "bowl" != "steaming bowl" so no exact match either.
-    # Different IDs stem: "bowl" vs "steaming-bowl" — stem subset would catch it.
-    # Actually ID stem: stem_a="bowl", stem_b="steaming-bowl", parts_a={"bowl"} ⊂ parts_b={"steaming","bowl"}
-    # So ID-stem rule will still merge these.
-    assert count == 1
-    assert len(catalogs["items.json"]) == 1
+    # 'bowl' is a stopword so token rules won't fire,
+    # and the ID-stem guard now requires 2+ segments in the smaller set.
+    assert count == 0
+    assert len(catalogs["items.json"]) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -189,12 +190,32 @@ def test_single_token_bowl_no_merge():
 # ---------------------------------------------------------------------------
 
 def test_batch_extraction_does_not_call_dormancy():
-    """extract_semantic_batch should NOT contain a mark_dormant_relationships call."""
-    source = inspect.getsource(extract_semantic_batch)
-    assert "mark_dormant_relationships" not in source
+    """extract_semantic_batch should NOT invoke mark_dormant_relationships."""
+    with patch("semantic_extraction.mark_dormant_relationships") as mock_dormancy, \
+         patch("semantic_extraction.LLMClient") as mock_llm_cls, \
+         patch("semantic_extraction.load_catalogs", return_value={f: [] for f in ["characters.json","locations.json","factions.json","items.json"]}), \
+         patch("semantic_extraction.load_events", return_value=[]), \
+         patch("semantic_extraction.save_catalogs"), \
+         patch("semantic_extraction.save_events"), \
+         patch("semantic_extraction._save_progress"), \
+         patch("semantic_extraction._ensure_player_character"):
+        mock_llm_cls.return_value = MagicMock()
+        from semantic_extraction import extract_semantic_batch
+        extract_semantic_batch([], "session-test", "framework-test")
+        mock_dormancy.assert_not_called()
 
 
 def test_single_turn_extraction_calls_dormancy():
-    """extract_semantic_single should still call mark_dormant_relationships."""
-    source = inspect.getsource(extract_semantic_single)
-    assert "mark_dormant_relationships" in source
+    """extract_semantic_single should invoke mark_dormant_relationships."""
+    with patch("semantic_extraction.mark_dormant_relationships", return_value=0) as mock_dormancy, \
+         patch("semantic_extraction.LLMClient") as mock_llm_cls, \
+         patch("semantic_extraction.load_catalogs", return_value={f: [] for f in ["characters.json","locations.json","factions.json","items.json"]}), \
+         patch("semantic_extraction.load_events", return_value=[]), \
+         patch("semantic_extraction.save_catalogs"), \
+         patch("semantic_extraction.save_events"), \
+         patch("semantic_extraction._ensure_player_character"), \
+         patch("semantic_extraction.extract_and_merge", return_value=({f: [] for f in ["characters.json","locations.json","factions.json","items.json"]}, [])):
+        mock_llm_cls.return_value = MagicMock()
+        from semantic_extraction import extract_semantic_single
+        extract_semantic_single("turn-001", "dm", "Test text", "session-test", "framework-test")
+        mock_dormancy.assert_called_once()

--- a/tests/test_migrate_catalogs.py
+++ b/tests/test_migrate_catalogs.py
@@ -499,3 +499,62 @@ def test_full_migration_roundtrip(tmp_framework):
     assert len(index) == 1
     assert index[0]["id"] == "char-hero"
     assert index[0]["active_relationship_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# V2 field preservation (Issue #97)
+# ---------------------------------------------------------------------------
+
+
+def test_preserves_existing_v2_identity():
+    """Migration should not overwrite LLM-generated identity."""
+    entity = {
+        "id": "char-test",
+        "name": "Test Character",
+        "type": "character",
+        "identity": "A skilled hunter from the northern tribe",
+        "current_status": "Currently resting at camp after a long hunt",
+        "stable_attributes": {"role": {"value": "hunter", "inference": False}},
+        "volatile_state": {"condition": "tired", "last_updated_turn": "turn-050"},
+        "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-050",
+    }
+    result = convert_entity(entity, max_turn=100)
+    assert result["identity"] == "A skilled hunter from the northern tribe"
+    assert result["current_status"] == "Currently resting at camp after a long hunt"
+    assert result["stable_attributes"]["role"]["value"] == "hunter"
+    assert result["volatile_state"]["condition"] == "tired"
+
+
+def test_converts_v1_only_entity():
+    """Migration should convert a pure V1 entity normally."""
+    entity = {
+        "id": "char-old",
+        "name": "Old Character",
+        "type": "character",
+        "description": "An elder of the tribe",
+        "attributes": {"role": "elder", "condition": "healthy"},
+        "first_seen_turn": "turn-005",
+        "last_updated_turn": "turn-020",
+    }
+    result = convert_entity(entity, max_turn=100)
+    assert result["identity"] == "An elder of the tribe"
+    assert "migrated from V1" in result["current_status"]
+    assert "role" in result["stable_attributes"]
+    assert "condition" in result["volatile_state"]
+
+
+def test_preserves_status_updated_turn_for_v2():
+    """When V2 current_status is preserved, status_updated_turn should be kept."""
+    entity = {
+        "id": "char-test",
+        "name": "Test",
+        "type": "character",
+        "identity": "A hunter",
+        "current_status": "Resting at camp",
+        "status_updated_turn": "turn-045",
+        "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-050",
+    }
+    result = convert_entity(entity, max_turn=100)
+    assert result["status_updated_turn"] == "turn-045"

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -177,13 +177,46 @@ def load_catalogs(catalog_dir: str) -> dict:
     return catalogs
 
 
-def save_catalogs(catalog_dir: str, catalogs: dict, dry_run: bool = False) -> None:
+def _has_real_v1_data(catalog_dir: str) -> bool:
+    """Return True if any V1 flat file contains meaningful data (not just ``[]``)."""
+    for fname in _V1_FILENAMES:
+        fpath = os.path.join(catalog_dir, fname)
+        if not os.path.isfile(fpath):
+            continue
+        try:
+            size = os.path.getsize(fpath)
+        except OSError:
+            continue
+        if size <= 3:
+            # File is empty or just "[]" / "[]\n"
+            continue
+        # Read and check for non-empty array
+        try:
+            with open(fpath, "r", encoding="utf-8-sig") as f:
+                data = json.load(f)
+            if isinstance(data, list) and len(data) > 0:
+                return True
+        except (json.JSONDecodeError, OSError):
+            continue
+    return False
+
+
+def save_catalogs(catalog_dir: str, catalogs: dict, dry_run: bool = False, prefer_v2: bool = True) -> None:
     """Write all catalogs back to disk.
 
     V2 mode: writes per-entity files and regenerates index.json.
     V1 mode: writes flat JSON files.
+
+    When *prefer_v2* is True (default) and ``detect_format()`` returns
+    ``"v1"`` but no flat file contains real data (all empty or just ``[]``),
+    the output format is upgraded to V2 automatically.  This prevents a clean
+    extraction start from defaulting to the deprecated V1 layout.
     """
     fmt = detect_format(catalog_dir)
+
+    # On a clean start (neither V1 nor V2 exist), default to V2 if preferred
+    if fmt == "v1" and prefer_v2 and not _has_real_v1_data(catalog_dir):
+        fmt = "v2"
 
     if fmt == "v2":
         for dirname, filename in zip(_V2_DIRNAMES, _V1_FILENAMES):

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -217,6 +217,12 @@ def save_catalogs(catalog_dir: str, catalogs: dict, dry_run: bool = False, prefe
     # On a clean start (neither V1 nor V2 exist), default to V2 if preferred
     if fmt == "v1" and prefer_v2 and not _has_real_v1_data(catalog_dir):
         fmt = "v2"
+        # Remove empty V1 flat files to avoid a mixed layout
+        if not dry_run:
+            for fname in _V1_FILENAMES:
+                fpath = os.path.join(catalog_dir, fname)
+                if os.path.isfile(fpath):
+                    os.remove(fpath)
 
     if fmt == "v2":
         for dirname, filename in zip(_V2_DIRNAMES, _V1_FILENAMES):

--- a/tools/migrate_catalogs_v2.py
+++ b/tools/migrate_catalogs_v2.py
@@ -312,21 +312,46 @@ def convert_entity(
     max_turn: int,
     entity_last_updated_turns: dict[str, str] | None = None,
 ) -> dict:
-    """Convert a V1 entity dict to V2 per-entity format."""
+    """Convert a V1 entity dict to V2 per-entity format.
+
+    If the entity already carries V2 fields (identity, current_status,
+    stable_attributes, volatile_state), those fields are preserved so that
+    LLM-populated data is not overwritten with migration placeholders.
+    """
     first_seen = entity.get("first_seen_turn")
     last_updated = entity.get("last_updated_turn")
 
-    # Identity / status split
-    description = entity.get("description", "")
-    identity = description if description else entity.get("name", "Unknown entity")
-    current_status = "Status unknown \u2014 migrated from V1 catalog."
+    # Detect existing V2 fields
+    has_v2_identity = bool(entity.get("identity"))
+    has_v2_status = (
+        bool(entity.get("current_status"))
+        and "migrated from V1" not in entity.get("current_status", "")
+    )
+    has_v2_stable = bool(entity.get("stable_attributes"))
+    has_v2_volatile = bool(entity.get("volatile_state"))
 
-    # Attributes
-    raw_attrs = entity.get("attributes", {})
-    stable_attrs, volatile_state = classify_attributes(raw_attrs, first_seen)
+    # Identity / status split — only convert from description when V2 fields absent
+    if has_v2_identity:
+        identity = entity["identity"]
+    else:
+        description = entity.get("description", "")
+        identity = description if description else entity.get("name", "Unknown entity")
+
+    if has_v2_status:
+        current_status = entity["current_status"]
+    else:
+        current_status = "Status unknown \u2014 migrated from V1 catalog."
+
+    # Attributes — only classify from V1 attributes when V2 fields absent
+    if has_v2_stable or has_v2_volatile:
+        stable_attrs = entity.get("stable_attributes", {})
+        volatile_state = entity.get("volatile_state", {})
+    else:
+        raw_attrs = entity.get("attributes", {})
+        stable_attrs, volatile_state = classify_attributes(raw_attrs, first_seen)
 
     # Add last_updated_turn to volatile_state if we have volatile keys
-    if volatile_state and last_updated:
+    if volatile_state and last_updated and not has_v2_volatile:
         volatile_state["last_updated_turn"] = last_updated
 
     # Relationships
@@ -346,7 +371,7 @@ def convert_entity(
     }
 
     if last_updated:
-        v2["status_updated_turn"] = last_updated
+        v2["status_updated_turn"] = entity.get("status_updated_turn") or last_updated
         v2["last_updated_turn"] = last_updated
 
     if stable_attrs:

--- a/tools/migrate_catalogs_v2.py
+++ b/tools/migrate_catalogs_v2.py
@@ -321,14 +321,15 @@ def convert_entity(
     first_seen = entity.get("first_seen_turn")
     last_updated = entity.get("last_updated_turn")
 
-    # Detect existing V2 fields
-    has_v2_identity = bool(entity.get("identity"))
+    # Detect existing V2 fields (use key presence, not truthiness,
+    # so explicitly-present empty dicts/strings are still preserved)
+    has_v2_identity = "identity" in entity
     has_v2_status = (
-        bool(entity.get("current_status"))
+        "current_status" in entity
         and "migrated from V1" not in entity.get("current_status", "")
     )
-    has_v2_stable = bool(entity.get("stable_attributes"))
-    has_v2_volatile = bool(entity.get("volatile_state"))
+    has_v2_stable = "stable_attributes" in entity
+    has_v2_volatile = "volatile_state" in entity
 
     # Identity / status split — only convert from description when V2 fields absent
     if has_v2_identity:

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -746,6 +746,7 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
                         continue
 
                 # Rule 3: ID stem overlap (hyphen-segment containment)
+                # Guard: require smaller stem set to have at least 2 segments
                 id_a = entities[idx_a].get("proposed_id", entities[idx_a].get("id", ""))
                 id_b = entities[idx_b].get("proposed_id", entities[idx_b].get("id", ""))
                 stem_a = id_a.split("-", 1)[1] if "-" in id_a else id_a
@@ -753,7 +754,8 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
                 if stem_a and stem_b:
                     parts_a = set(stem_a.split("-"))
                     parts_b = set(stem_b.split("-"))
-                    if parts_a.issubset(parts_b) or parts_b.issubset(parts_a):
+                    smaller_parts = parts_a if len(parts_a) <= len(parts_b) else parts_b
+                    if len(smaller_parts) >= 2 and (parts_a.issubset(parts_b) or parts_b.issubset(parts_a)):
                         union(idx_a, idx_b)
                         print(f"  DEDUP (id-stem): linking '{name_a}' ({id_a}) and '{name_b}' ({id_b}) as duplicates")
 

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -706,7 +706,12 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
                 union(idxs[0], idxs[i])
 
         # --- Fuzzy pass: substring and token overlap (same catalog only) ---
-        STOPWORDS = {"a", "an", "the", "of", "and", "with", "in", "on", "to"}
+        STOPWORDS = {
+            "a", "an", "the", "of", "and", "with", "in", "on", "to",
+            # RPG-context generic words that cause false dedup
+            "figure", "material", "party", "bowl", "tool", "small", "large",
+            "old", "new", "dark", "light", "some", "other",
+        }
         all_names = [(idx, entity.get("name", "").strip().lower()) for idx, entity in enumerate(entities)]
 
         for i, (idx_a, name_a) in enumerate(all_names):
@@ -723,15 +728,19 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
                 tokens_b = set(name_b.replace("-", " ").split()) - STOPWORDS
                 if tokens_a and tokens_b:
                     # Rule 1: Whole-token subset containment
-                    if tokens_a.issubset(tokens_b) or tokens_b.issubset(tokens_a):
+                    # Guard: require smaller set to have at least 2 tokens
+                    smaller_set = tokens_a if len(tokens_a) <= len(tokens_b) else tokens_b
+                    if len(smaller_set) >= 2 and (tokens_a.issubset(tokens_b) or tokens_b.issubset(tokens_a)):
                         union(idx_a, idx_b)
                         print(f"  DEDUP (substring): linking '{name_a}' and '{name_b}' as duplicates")
                         continue
 
-                    # Rule 2: Token overlap >= 50%
+                    # Rule 2: Token overlap
+                    # Guard: require 100% overlap when smaller set has <= 2 tokens
                     overlap = tokens_a & tokens_b
                     smaller = min(len(tokens_a), len(tokens_b))
-                    if len(overlap) / smaller >= 0.5:
+                    threshold = 1.0 if smaller <= 2 else 0.5
+                    if smaller > 0 and len(overlap) / smaller >= threshold:
                         union(idx_a, idx_b)
                         print(f"  DEDUP (token-overlap): linking '{name_a}' and '{name_b}' as duplicates")
                         continue
@@ -904,12 +913,9 @@ def extract_semantic_batch(
     print(f"  Semantic extraction complete: {entities_after} entities, {events_after} events")
 
     if not dry_run:
-        # Post-merge dormancy pass
-        last_turn = turn_dicts[-1]["turn_id"] if turn_dicts else ""
-        dormant_count = mark_dormant_relationships(catalogs, last_turn)
-        if dormant_count:
-            print(f"  Marked {dormant_count} relationship(s) as dormant")
-
+        # Skip dormancy pass in batch mode — the threshold is too small relative
+        # to a full transcript and would mark all relationships dormant.  Dormancy
+        # is only meaningful during incremental single-turn extraction.
         save_catalogs(catalog_dir, catalogs)
         save_events(catalog_dir, events_list)
         _save_progress(progress_file, turn_dicts[-1]["turn_id"] if turn_dicts else "",


### PR DESCRIPTION
## Summary

Four pipeline fixes from the Run 4 V2 extraction report.

## Issue #96 — save_catalogs defaults to V1 on clean start

When extraction starts from empty catalogs (no V2 directories), save_catalogs now defaults to V2 format instead of V1. A new _has_real_v1_data() helper detects empty flat files (just []) as clean start vs real V1 data. Added prefer_v2 parameter (default True).

## Issue #97 — migrate_catalogs_v2.py preserves V2 fields

convert_entity() now checks for existing V2 fields (identity, current_status, stable_attributes, olatile_state) and preserves them instead of overwriting with migration placeholders. Also preserves status_updated_turn when V2 status is kept.

## Issue #98 — Dedup false positive guards

- Token subset rule requires smaller set to have 2+ tokens (prevents single-word merges like figure, party, bowl)
- Token overlap requires 100% for sets with 2 or fewer tokens
- Expanded stopwords list with RPG-context generic words
- Fixes: crude weapons/buckets, herb/hunting party, broad/lone figure false merges

## Issue #99 — Batch dormancy skip

extract_semantic_batch() no longer runs dormancy marking. Dormancy is only applied during incremental single-turn extraction via extract_semantic_single(). Prevents all relationships being marked dormant after batch import of long transcripts.

Closes #96
Closes #97
Closes #98
Closes #99
