### PR TITLE
fix: PC self-intro dedup + feat: wiki-style markdown pages

### DIFF
--- a/templates/content/character-sheet.md
+++ b/templates/content/character-sheet.md
@@ -9,49 +9,72 @@ Each character entry should conform to `schemas/entity.schema.json` (V2 format).
 
 ---
 
-## Fields
+## Fields (V2 Schema)
 
 | Field | Required | Notes |
 |---|---|---|
 | `id` | Yes | Stable identifier, e.g. `char-innkeeper-thornhaven`. Never change after first use. |
 | `name` | Yes | Canonical name or best-known name |
-| `aliases` | No | Other names or titles observed in the transcript |
-| `entity_type` | Yes | Always `character` for this template |
-| `description` | Yes | Factual summary from explicit transcript evidence only |
-| `current_status` | Yes | e.g. `active`, `deceased`, `unknown`, `ally`, `hostile` |
-| `attributes` | No | Key/value pairs for notable traits. Tag inferences with `(inferred)` |
-| `relationships` | No | Map of related entity IDs to relationship description |
+| `type` | Yes | Always `character` for this template |
+| `identity` | Yes | Factual one-sentence summary based on explicit transcript evidence |
+| `current_status` | Yes | Prose description of what the character is currently doing |
+| `status_updated_turn` | No | Turn ID when `current_status` was last changed |
+| `stable_attributes` | No | Dict of attribute objects, each with `value`, `inference`, `confidence`, `source_turn` |
+| `volatile_state` | No | Dict with `condition`, `equipment`, `location`, `last_updated_turn` |
+| `relationships` | No | Array of relationship objects with `target_id`, `current_relationship`, `type`, `status`, `history` |
 | `first_seen_turn` | Yes | Turn ID when this character first appeared |
 | `last_updated_turn` | Yes | Most recent turn that changed this entry |
-| `confidence` | Yes | 0.0–1.0; use 1.0 only for directly stated facts |
-| `source_refs` | Yes | List of turn IDs that support this entry |
 
 ---
 
-## Example entry
+## Example entry (V2)
 
 ```json
 {
   "id": "char-innkeeper-thornhaven",
   "name": "Unknown innkeeper",
-  "aliases": ["the woman at the bar", "heavy-set woman"],
-  "entity_type": "character",
-  "description": "A heavyset woman with grey-streaked hair. Runs The Broken Wheel inn in Thornhaven. Watchful and guarded; did not offer her name.",
-  "current_status": "active",
-  "attributes": {
-    "occupation": "innkeeper",
+  "type": "character",
+  "identity": "A heavyset woman with grey-streaked hair running The Broken Wheel inn. Watchful and guarded.",
+  "current_status": "Serving drinks behind the bar, keeping a wary eye on newcomers.",
+  "status_updated_turn": "turn-006",
+  "stable_attributes": {
+    "aliases": {
+      "value": ["the woman at the bar", "heavy-set woman"],
+      "inference": false,
+      "confidence": 1.0,
+      "source_turn": "turn-002"
+    },
+    "occupation": {
+      "value": "innkeeper",
+      "inference": false,
+      "confidence": 1.0,
+      "source_turn": "turn-002"
+    },
+    "disposition_toward_player": {
+      "value": "neutral-guarded",
+      "inference": true,
+      "confidence": 0.7,
+      "source_turn": "turn-004"
+    }
+  },
+  "volatile_state": {
+    "condition": "alert",
+    "equipment": ["bar towel"],
     "location": "The Broken Wheel, Thornhaven",
-    "disposition_toward_player": "neutral-guarded",
-    "hiding_something": "(inferred, confidence 0.7) Grip tightened when scholar was mentioned"
+    "last_updated_turn": "turn-006"
   },
-  "relationships": {
-    "loc-the-broken-wheel": "proprietor",
-    "loc-thornhaven": "resident"
-  },
+  "relationships": [
+    {
+      "target_id": "loc-the-broken-wheel",
+      "current_relationship": "proprietor",
+      "type": "professional",
+      "status": "active",
+      "first_seen_turn": "turn-002",
+      "last_updated_turn": "turn-002"
+    }
+  ],
   "first_seen_turn": "turn-002",
-  "last_updated_turn": "turn-006",
-  "confidence": 0.9,
-  "source_refs": ["turn-002", "turn-004", "turn-006"]
+  "last_updated_turn": "turn-006"
 }
 ```
 

--- a/templates/content/character-sheet.md
+++ b/templates/content/character-sheet.md
@@ -1,7 +1,11 @@
 # Character Sheet Template
 
-Use this as a reference for catalog entries in `framework/catalogs/characters.json`.
-Each character entry should conform to `schemas/entity.schema.json`.
+Use this as a reference for catalog entries in `framework/catalogs/characters/`.
+Each character entry should conform to `schemas/entity.schema.json` (V2 format).
+
+> **Note:** Human-readable wiki-style markdown pages are generated automatically
+> by `tools/generate_wiki_pages.py` alongside each per-entity JSON file.
+> Do not edit `.md` files in catalog directories manually.
 
 ---
 

--- a/templates/extraction/entity-detail.md
+++ b/templates/extraction/entity-detail.md
@@ -24,6 +24,11 @@ Return a single JSON object conforming to this V2 structure:
 - "last_updated_turn": string — set to the current turn ID
 - "notes": string (optional) — any open questions or ambiguities about this entity
 
+PLAYER CHARACTER NAME:
+- If the turn reveals the player character's name, add it to `char-player`'s 
+  `stable_attributes.aliases` and optionally update `char-player.name` to the revealed name.
+- Do NOT create a separate entity for the player character's name.
+
 MERGE RULES:
 - Update "identity" ONLY for fundamental changes: name change, role change, species reveal, major transformation. Otherwise preserve the prior identity exactly.
 - ALWAYS update "current_status" with what the entity is doing/experiencing in this turn.

--- a/templates/extraction/entity-discovery.md
+++ b/templates/extraction/entity-discovery.md
@@ -12,6 +12,15 @@ For each entity, return a JSON object with these fields:
 - "confidence": 0.0-1.0 confidence that this is a distinct, nameable entity worth cataloging
 - "source_turn": the turn ID provided in the input
 
+PLAYER CHARACTER RULE:
+- The player character is ALWAYS referred to as "you" in DM narration.
+- The player character's entity ID is ALWAYS `char-player`.
+- When the player character reveals their name (e.g., "you introduce yourself as [Name]"), 
+  do NOT create a new entity. Instead, note this as an alias update for `char-player`.
+- ANY entity whose description indicates it IS the player character (e.g., "introduces 
+  themselves", "points to self", first-person actions) must be mapped to `char-player`, 
+  not given a new ID.
+
 Rules:
 - Only extract entities that appear in or are directly referenced in the provided turn text.
 - Do NOT invent entities not mentioned in the text.

--- a/templates/extraction/entity-discovery.md
+++ b/templates/extraction/entity-discovery.md
@@ -17,9 +17,12 @@ PLAYER CHARACTER RULE:
 - The player character's entity ID is ALWAYS `char-player`.
 - When the player character reveals their name (e.g., "you introduce yourself as [Name]"), 
   do NOT create a new entity. Instead, note this as an alias update for `char-player`.
-- ANY entity whose description indicates it IS the player character (e.g., "introduces 
-  themselves", "points to self", first-person actions) must be mapped to `char-player`, 
-  not given a new ID.
+- ONLY map a mention to `char-player` when the text explicitly indicates the player
+  character, such as second-person references ("you", "yourself", "you introduce
+  yourself") or explicit PC labels ("the player character").
+- Do NOT use generic self-introduction language ("introduces themselves", "points to self")
+  as a PC signal — NPCs introduce themselves too. The key differentiator is second-person
+  narration ("you") vs third-person narration ("he/she/they").
 
 Rules:
 - Only extract entities that appear in or are directly referenced in the provided turn text.

--- a/tests/test_pc_dedup.py
+++ b/tests/test_pc_dedup.py
@@ -6,7 +6,6 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
 from semantic_extraction import _check_pc_duplicate, _merge_into_pc
-from catalog_merger import find_entity_by_id
 
 
 def test_self_intro_entity_detected_as_pc():

--- a/tests/test_pc_dedup.py
+++ b/tests/test_pc_dedup.py
@@ -1,0 +1,167 @@
+"""Tests for player character duplicate detection and merge."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from semantic_extraction import _check_pc_duplicate, _merge_into_pc
+from catalog_merger import find_entity_by_id
+
+
+def test_self_intro_entity_detected_as_pc():
+    """Entity with self-introduction identity should be flagged as PC duplicate."""
+    entity = {
+        "id": "char-fenouille-moonwind",
+        "name": "Fenouille Moonwind",
+        "type": "character",
+        "identity": "A character who introduces themselves as Fenouille Moonwind",
+    }
+    result = _check_pc_duplicate(entity, {})
+    assert result == "char-player"
+
+
+def test_pointing_to_self_detected_as_pc():
+    """Entity that 'points to self' should be flagged as PC duplicate."""
+    entity = {
+        "id": "char-some-name",
+        "name": "Some Name",
+        "type": "character",
+        "identity": "A figure pointing to self and stating their name",
+    }
+    result = _check_pc_duplicate(entity, {})
+    assert result == "char-player"
+
+
+def test_non_pc_entity_not_flagged():
+    """Normal NPC entity should not be flagged as PC."""
+    entity = {
+        "id": "char-elder",
+        "name": "The Elder",
+        "type": "character",
+        "identity": "The village elder who leads the tribe",
+    }
+    result = _check_pc_duplicate(entity, {})
+    assert result is None
+
+
+def test_pc_entity_not_flagged():
+    """char-player itself should not be flagged."""
+    entity = {
+        "id": "char-player",
+        "name": "Player Character",
+        "type": "character",
+        "identity": "The player character",
+    }
+    result = _check_pc_duplicate(entity, {})
+    assert result is None
+
+
+def test_merge_into_pc_adds_alias():
+    """Merging a duplicate should add its name as an alias on char-player."""
+    catalogs = {
+        "characters.json": [
+            {
+                "id": "char-player",
+                "name": "Player Character",
+                "type": "character",
+                "identity": "The player character.",
+                "first_seen_turn": "turn-001",
+                "last_updated_turn": "turn-050",
+                "stable_attributes": {},
+            }
+        ]
+    }
+    duplicate = {
+        "id": "char-fenouille-moonwind",
+        "name": "Fenouille Moonwind",
+        "type": "character",
+        "identity": "A character who introduces themselves as Fenouille Moonwind",
+        "last_updated_turn": "turn-059",
+        "stable_attributes": {},
+    }
+    _merge_into_pc(catalogs, duplicate)
+
+    pc = catalogs["characters.json"][0]
+    assert pc["name"] == "Fenouille Moonwind"
+    aliases = pc["stable_attributes"]["aliases"]["value"]
+    assert "Fenouille Moonwind" in aliases
+    assert pc["last_updated_turn"] == "turn-059"
+
+
+def test_merge_into_pc_preserves_existing_name():
+    """If PC already has a proper name, keep it and add duplicate as alias."""
+    catalogs = {
+        "characters.json": [
+            {
+                "id": "char-player",
+                "name": "Fenouille Moonwind",
+                "type": "character",
+                "identity": "The player character.",
+                "first_seen_turn": "turn-001",
+                "last_updated_turn": "turn-059",
+                "stable_attributes": {
+                    "aliases": {
+                        "value": ["Player Character"],
+                        "inference": False,
+                        "confidence": 1.0,
+                        "source_turn": "turn-059",
+                    }
+                },
+            }
+        ]
+    }
+    duplicate = {
+        "id": "char-fen",
+        "name": "Fen",
+        "type": "character",
+        "identity": "A character who introduces themselves",
+        "last_updated_turn": "turn-060",
+        "stable_attributes": {},
+    }
+    _merge_into_pc(catalogs, duplicate)
+
+    pc = catalogs["characters.json"][0]
+    # Name stays as the already-proper name
+    assert pc["name"] == "Fenouille Moonwind"
+    aliases = pc["stable_attributes"]["aliases"]["value"]
+    assert "Fen" in aliases
+    assert "Player Character" in aliases
+
+
+def test_merge_into_pc_adds_new_attributes():
+    """Merging should bring over new stable attributes from the duplicate."""
+    catalogs = {
+        "characters.json": [
+            {
+                "id": "char-player",
+                "name": "Player Character",
+                "type": "character",
+                "identity": "The player character.",
+                "first_seen_turn": "turn-001",
+                "last_updated_turn": "turn-050",
+                "stable_attributes": {
+                    "race": {"value": "Elf", "inference": True,
+                             "confidence": 0.95, "source_turn": "turn-019"},
+                },
+            }
+        ]
+    }
+    duplicate = {
+        "id": "char-fenouille-moonwind",
+        "name": "Fenouille Moonwind",
+        "type": "character",
+        "identity": "A character who introduces themselves",
+        "last_updated_turn": "turn-059",
+        "stable_attributes": {
+            "appearance": {"value": "Tall with silver hair", "inference": False,
+                           "confidence": 1.0, "source_turn": "turn-059"},
+        },
+    }
+    _merge_into_pc(catalogs, duplicate)
+
+    pc = catalogs["characters.json"][0]
+    assert "appearance" in pc["stable_attributes"]
+    assert pc["stable_attributes"]["appearance"]["value"] == "Tall with silver hair"
+    # Existing race attribute preserved
+    assert pc["stable_attributes"]["race"]["value"] == "Elf"

--- a/tests/test_pc_dedup.py
+++ b/tests/test_pc_dedup.py
@@ -9,24 +9,36 @@ from semantic_extraction import _check_pc_duplicate, _merge_into_pc
 
 
 def test_self_intro_entity_detected_as_pc():
-    """Entity with self-introduction identity should be flagged as PC duplicate."""
+    """Entity with explicit PC self-introduction identity should be flagged as PC duplicate."""
     entity = {
         "id": "char-fenouille-moonwind",
         "name": "Fenouille Moonwind",
         "type": "character",
-        "identity": "A character who introduces themselves as Fenouille Moonwind",
+        "identity": "You introduce yourself as Fenouille Moonwind",
+    }
+    result = _check_pc_duplicate(entity, {})
+    assert result == "char-player"
+
+
+def test_player_character_label_detected_as_pc():
+    """Entity described as 'the player character' should be flagged."""
+    entity = {
+        "id": "char-fenouille-moonwind",
+        "name": "Fenouille Moonwind",
+        "type": "character",
+        "identity": "The player character, known as Fenouille Moonwind",
     }
     result = _check_pc_duplicate(entity, {})
     assert result == "char-player"
 
 
 def test_pointing_to_self_detected_as_pc():
-    """Entity that 'points to self' should be flagged as PC duplicate."""
+    """Entity using second-person self-reference should be flagged as PC duplicate."""
     entity = {
         "id": "char-some-name",
         "name": "Some Name",
         "type": "character",
-        "identity": "A figure pointing to self and stating their name",
+        "identity": "You point to yourself and state your name",
     }
     result = _check_pc_duplicate(entity, {})
     assert result == "char-player"
@@ -39,6 +51,18 @@ def test_non_pc_entity_not_flagged():
         "name": "The Elder",
         "type": "character",
         "identity": "The village elder who leads the tribe",
+    }
+    result = _check_pc_duplicate(entity, {})
+    assert result is None
+
+
+def test_npc_self_intro_not_flagged():
+    """NPC who introduces themselves should NOT be flagged as PC."""
+    entity = {
+        "id": "char-kael",
+        "name": "Kael",
+        "type": "character",
+        "identity": "A young hunter who introduces themselves to the group",
     }
     result = _check_pc_duplicate(entity, {})
     assert result is None
@@ -86,6 +110,59 @@ def test_merge_into_pc_adds_alias():
     aliases = pc["stable_attributes"]["aliases"]["value"]
     assert "Fenouille Moonwind" in aliases
     assert pc["last_updated_turn"] == "turn-059"
+    # source_turn should be set since last_updated_turn is valid
+    assert pc["stable_attributes"]["aliases"]["source_turn"] == "turn-059"
+
+
+def test_merge_into_pc_returns_dup_id():
+    """Merge should return the duplicate entity ID."""
+    catalogs = {
+        "characters.json": [
+            {
+                "id": "char-player",
+                "name": "Player Character",
+                "type": "character",
+                "identity": "The player character.",
+                "first_seen_turn": "turn-001",
+                "last_updated_turn": "turn-050",
+                "stable_attributes": {},
+            }
+        ]
+    }
+    duplicate = {
+        "id": "char-fenouille-moonwind",
+        "name": "Fenouille Moonwind",
+        "type": "character",
+        "last_updated_turn": "turn-059",
+    }
+    result = _merge_into_pc(catalogs, duplicate)
+    assert result == "char-fenouille-moonwind"
+
+
+def test_merge_into_pc_omits_invalid_source_turn():
+    """source_turn should be omitted when last_updated_turn is not a valid turn ID."""
+    catalogs = {
+        "characters.json": [
+            {
+                "id": "char-player",
+                "name": "Player Character",
+                "type": "character",
+                "identity": "The player character.",
+                "first_seen_turn": "turn-001",
+                "last_updated_turn": "turn-050",
+                "stable_attributes": {},
+            }
+        ]
+    }
+    duplicate = {
+        "id": "char-fen",
+        "name": "Fen",
+        "type": "character",
+        # No last_updated_turn or first_seen_turn
+    }
+    _merge_into_pc(catalogs, duplicate)
+    pc = catalogs["characters.json"][0]
+    assert "source_turn" not in pc["stable_attributes"]["aliases"]
 
 
 def test_merge_into_pc_preserves_existing_name():

--- a/tests/test_wiki_pages.py
+++ b/tests/test_wiki_pages.py
@@ -14,7 +14,6 @@ from generate_wiki_pages import (
     generate_item_page,
     generate_index_page,
     generate_wiki_pages,
-    _build_name_index,
 )
 
 

--- a/tests/test_wiki_pages.py
+++ b/tests/test_wiki_pages.py
@@ -1,0 +1,351 @@
+"""Tests for wiki-style markdown page generation."""
+
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from generate_wiki_pages import (
+    generate_character_page,
+    generate_location_page,
+    generate_faction_page,
+    generate_item_page,
+    generate_index_page,
+    generate_wiki_pages,
+    _build_name_index,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_CHARACTER = {
+    "id": "char-elder",
+    "name": "The Elder",
+    "type": "character",
+    "identity": "An elderly authority figure in the tribal community.",
+    "current_status": "Watching over the camp activities.",
+    "status_updated_turn": "turn-061",
+    "stable_attributes": {
+        "race": {
+            "value": "Human",
+            "inference": True,
+            "confidence": 0.9,
+            "source_turn": "turn-019",
+        },
+        "appearance": {
+            "value": ["grizzled man", "eyes like chips of flint"],
+            "inference": False,
+            "confidence": 1.0,
+            "source_turn": "turn-019",
+        },
+    },
+    "volatile_state": {
+        "condition": "alert and observant",
+        "equipment": ["walking stick"],
+        "location": "central spot in the camp",
+        "last_updated_turn": "turn-061",
+    },
+    "first_seen_turn": "turn-016",
+    "last_updated_turn": "turn-061",
+    "relationships": [
+        {
+            "target_id": "char-player",
+            "current_relationship": "commanding",
+            "type": "social",
+            "status": "active",
+            "first_seen_turn": "turn-017",
+            "last_updated_turn": "turn-045",
+            "history": [
+                {"turn": "turn-017", "description": "first meeting"},
+                {"turn": "turn-045", "description": "issuing orders"},
+            ],
+        }
+    ],
+}
+
+SAMPLE_LOCATION = {
+    "id": "loc-camp-dwelling",
+    "name": "the camp",
+    "type": "location",
+    "identity": "A tribal encampment where various activities take place.",
+    "current_status": "The camp is busy with daily tasks.",
+    "status_updated_turn": "turn-085",
+    "stable_attributes": {
+        "aliases": {
+            "value": ["camp or dwelling"],
+            "inference": False,
+            "source_turn": "turn-085",
+        }
+    },
+    "first_seen_turn": "turn-013",
+    "last_updated_turn": "turn-085",
+    "relationships": [
+        {
+            "target_id": "char-elder",
+            "current_relationship": "home of",
+            "type": "location",
+        }
+    ],
+}
+
+SAMPLE_FACTION = {
+    "id": "faction-two-figures",
+    "name": "figures",
+    "type": "faction",
+    "identity": "Unidentified individuals who captured the player.",
+    "current_status": "Capturing the player.",
+    "status_updated_turn": "turn-014",
+    "stable_attributes": {
+        "role": {
+            "value": ["captors"],
+            "inference": True,
+            "confidence": 0.95,
+            "source_turn": "turn-007",
+        }
+    },
+    "first_seen_turn": "turn-007",
+    "last_updated_turn": "turn-014",
+}
+
+SAMPLE_ITEM = {
+    "id": "item-your-staff",
+    "name": "your staff",
+    "type": "item",
+    "identity": "A personal weapon and tool.",
+    "current_status": "Resting at your side.",
+    "status_updated_turn": "turn-045",
+    "stable_attributes": {},
+    "volatile_state": {
+        "condition": "securely resting",
+        "location": "at your side",
+        "last_updated_turn": "turn-045",
+    },
+    "first_seen_turn": "turn-045",
+    "last_updated_turn": "turn-045",
+}
+
+NAME_INDEX = {
+    "char-player": ("Player Character", "../characters/char-player.md"),
+    "char-elder": ("The Elder", "../characters/char-elder.md"),
+    "loc-camp-dwelling": ("the camp", "../locations/loc-camp-dwelling.md"),
+    "faction-two-figures": ("figures", "../factions/faction-two-figures.md"),
+    "item-your-staff": ("your staff", "../items/item-your-staff.md"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Character page tests
+# ---------------------------------------------------------------------------
+
+def test_character_page_has_infobox():
+    """Generated character markdown contains name, race, appearance in table."""
+    md = generate_character_page(SAMPLE_CHARACTER, NAME_INDEX)
+    assert "# The Elder" in md
+    assert "| **Type** | Character |" in md
+    assert "| **Race** | Human |" in md
+    assert "turn-016" in md
+
+
+def test_character_page_has_relationships():
+    """Relationships rendered as table with resolved target names."""
+    md = generate_character_page(SAMPLE_CHARACTER, NAME_INDEX)
+    assert "## Relationships" in md
+    assert "commanding" in md
+    assert "social" in md
+    assert "active" in md
+
+
+def test_character_page_has_history():
+    """Relationship history entries rendered."""
+    md = generate_character_page(SAMPLE_CHARACTER, NAME_INDEX)
+    assert "### Relationship History" in md
+    assert "**turn-017:**" in md
+    assert "first meeting" in md
+    assert "**turn-045:**" in md
+
+
+def test_character_page_has_current_state():
+    """Volatile state section rendered."""
+    md = generate_character_page(SAMPLE_CHARACTER, NAME_INDEX)
+    assert "**Condition:** alert and observant" in md
+    assert "**Equipment:** walking stick" in md
+    assert "**Location:** central spot in the camp" in md
+
+
+# ---------------------------------------------------------------------------
+# Location page tests
+# ---------------------------------------------------------------------------
+
+def test_location_page_format():
+    """Location page has appropriate sections."""
+    md = generate_location_page(SAMPLE_LOCATION, NAME_INDEX)
+    assert "# the camp" in md
+    assert "| **Type** | Location |" in md
+    assert "## Current Status" in md
+    assert "## Connected Entities" in md
+    assert "home of" in md
+
+
+# ---------------------------------------------------------------------------
+# Faction page tests
+# ---------------------------------------------------------------------------
+
+def test_faction_page_format():
+    """Faction page has appropriate sections."""
+    md = generate_faction_page(SAMPLE_FACTION, NAME_INDEX)
+    assert "# figures" in md
+    assert "| **Type** | Faction |" in md
+    assert "## Attributes" in md
+    assert "captors" in md
+
+
+# ---------------------------------------------------------------------------
+# Item page tests
+# ---------------------------------------------------------------------------
+
+def test_item_page_format():
+    """Item page has appropriate sections."""
+    md = generate_item_page(SAMPLE_ITEM, NAME_INDEX)
+    assert "# your staff" in md
+    assert "| **Type** | Item |" in md
+    assert "## Current State" in md
+    assert "**Condition:** securely resting" in md
+
+
+# ---------------------------------------------------------------------------
+# Index page tests
+# ---------------------------------------------------------------------------
+
+def test_index_page_links():
+    """README.md contains links to all entity pages."""
+    entities = [SAMPLE_CHARACTER, {
+        "id": "char-player",
+        "name": "Player Character",
+        "type": "character",
+        "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-054",
+        "current_status": "Leaning against the warrior.",
+    }]
+    md = generate_index_page("characters", entities, NAME_INDEX)
+    assert "# Characters" in md
+    assert "[The Elder](char-elder.md)" in md
+    assert "[Player Character](char-player.md)" in md
+    # Player appears first (turn-001 < turn-016)
+    player_pos = md.index("char-player.md")
+    elder_pos = md.index("char-elder.md")
+    assert player_pos < elder_pos
+
+
+def test_index_page_truncates_status():
+    """Long status is truncated to ~60 chars."""
+    entity = {
+        "id": "char-test",
+        "name": "Test",
+        "type": "character",
+        "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-001",
+        "current_status": "A" * 100,
+    }
+    md = generate_index_page("characters", [entity], {})
+    # Should contain truncated status with ...
+    assert "..." in md
+    # Full 100-char string should NOT appear
+    assert "A" * 100 not in md
+
+
+# ---------------------------------------------------------------------------
+# Target ID resolution tests
+# ---------------------------------------------------------------------------
+
+def test_target_id_resolved_to_name():
+    """Relationship target_id resolved to entity name from index."""
+    md = generate_character_page(SAMPLE_CHARACTER, NAME_INDEX)
+    # char-player should be resolved to a link with name
+    assert "[Player Character]" in md
+
+
+def test_missing_target_graceful():
+    """Unknown target_id rendered as raw ID without crash."""
+    entity = dict(SAMPLE_CHARACTER)
+    entity["relationships"] = [
+        {
+            "target_id": "char-unknown-npc",
+            "current_relationship": "met once",
+            "type": "social",
+            "status": "dormant",
+        }
+    ]
+    md = generate_character_page(entity, NAME_INDEX)
+    assert "char-unknown-npc" in md
+
+
+# ---------------------------------------------------------------------------
+# Empty catalog tests
+# ---------------------------------------------------------------------------
+
+def test_empty_catalog_graceful():
+    """Empty entity type directory produces empty index page."""
+    md = generate_index_page("characters", [], {})
+    assert "# Characters" in md
+    assert "No entities cataloged yet" in md
+
+
+# ---------------------------------------------------------------------------
+# Integration: generate to temp dir
+# ---------------------------------------------------------------------------
+
+def test_generate_wiki_pages_integration():
+    """Full generation writes .md files alongside .json files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Set up V2 catalog structure
+        char_dir = os.path.join(tmpdir, "characters")
+        loc_dir = os.path.join(tmpdir, "locations")
+        faction_dir = os.path.join(tmpdir, "factions")
+        items_dir = os.path.join(tmpdir, "items")
+        for d in (char_dir, loc_dir, faction_dir, items_dir):
+            os.makedirs(d)
+
+        # Write sample entity files
+        with open(os.path.join(char_dir, "char-elder.json"), "w") as f:
+            json.dump(SAMPLE_CHARACTER, f)
+        with open(os.path.join(loc_dir, "loc-camp-dwelling.json"), "w") as f:
+            json.dump(SAMPLE_LOCATION, f)
+        with open(os.path.join(faction_dir, "faction-two-figures.json"), "w") as f:
+            json.dump(SAMPLE_FACTION, f)
+        with open(os.path.join(items_dir, "item-your-staff.json"), "w") as f:
+            json.dump(SAMPLE_ITEM, f)
+
+        stats = generate_wiki_pages(tmpdir)
+
+        # Check that .md files were created
+        assert os.path.exists(os.path.join(char_dir, "char-elder.md"))
+        assert os.path.exists(os.path.join(char_dir, "README.md"))
+        assert os.path.exists(os.path.join(loc_dir, "loc-camp-dwelling.md"))
+        assert os.path.exists(os.path.join(loc_dir, "README.md"))
+        assert os.path.exists(os.path.join(faction_dir, "faction-two-figures.md"))
+        assert os.path.exists(os.path.join(items_dir, "item-your-staff.md"))
+
+        # Verify stats
+        assert stats["characters"] == 2  # 1 entity + 1 README
+        assert stats["locations"] == 2
+        assert stats["factions"] == 2
+        assert stats["items"] == 2
+
+
+def test_generate_wiki_pages_index_only():
+    """--index-only only creates README.md, not entity .md files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        char_dir = os.path.join(tmpdir, "characters")
+        os.makedirs(char_dir)
+        with open(os.path.join(char_dir, "char-elder.json"), "w") as f:
+            json.dump(SAMPLE_CHARACTER, f)
+
+        stats = generate_wiki_pages(tmpdir, entity_types=["characters"], index_only=True)
+
+        assert os.path.exists(os.path.join(char_dir, "README.md"))
+        assert not os.path.exists(os.path.join(char_dir, "char-elder.md"))
+        assert stats["characters"] == 1  # Only README

--- a/tests/test_wiki_pages.py
+++ b/tests/test_wiki_pages.py
@@ -229,7 +229,7 @@ def test_index_page_links():
         "last_updated_turn": "turn-054",
         "current_status": "Leaning against the warrior.",
     }]
-    md = generate_index_page("characters", entities, NAME_INDEX)
+    md = generate_index_page("characters", entities)
     assert "# Characters" in md
     assert "[The Elder](char-elder.md)" in md
     assert "[Player Character](char-player.md)" in md
@@ -249,7 +249,7 @@ def test_index_page_truncates_status():
         "last_updated_turn": "turn-001",
         "current_status": "A" * 100,
     }
-    md = generate_index_page("characters", [entity], {})
+    md = generate_index_page("characters", [entity])
     # Should contain truncated status with ...
     assert "..." in md
     # Full 100-char string should NOT appear
@@ -288,7 +288,7 @@ def test_missing_target_graceful():
 
 def test_empty_catalog_graceful():
     """Empty entity type directory produces empty index page."""
-    md = generate_index_page("characters", [], {})
+    md = generate_index_page("characters", [])
     assert "# Characters" in md
     assert "No entities cataloged yet" in md
 
@@ -348,3 +348,88 @@ def test_generate_wiki_pages_index_only():
         assert os.path.exists(os.path.join(char_dir, "README.md"))
         assert not os.path.exists(os.path.join(char_dir, "char-elder.md"))
         assert stats["characters"] == 1  # Only README
+
+
+# ---------------------------------------------------------------------------
+# Table escaping tests
+# ---------------------------------------------------------------------------
+
+def test_pipe_in_value_escaped():
+    """Pipe characters in attribute values are escaped in table output."""
+    entity = dict(SAMPLE_CHARACTER)
+    entity["stable_attributes"] = {
+        "catch_phrase": {
+            "value": "yes | no | maybe",
+            "inference": False,
+            "confidence": 1.0,
+            "source_turn": "turn-020",
+        }
+    }
+    md = generate_character_page(entity, NAME_INDEX)
+    # Pipes in the value should be escaped
+    assert "yes \\| no \\| maybe" in md
+    # Should not break the table (no bare | inside cell content)
+
+
+def test_newline_in_value_escaped():
+    """Newlines in attribute values are replaced with spaces."""
+    entity = dict(SAMPLE_CHARACTER)
+    entity["stable_attributes"] = {
+        "bio": {
+            "value": "Line one\nLine two",
+            "inference": False,
+            "confidence": 1.0,
+            "source_turn": "turn-020",
+        }
+    }
+    md = generate_character_page(entity, NAME_INDEX)
+    assert "Line one Line two" in md
+    assert "Line one\nLine two" not in md
+
+
+# ---------------------------------------------------------------------------
+# Entity type label tests
+# ---------------------------------------------------------------------------
+
+def test_creature_type_label():
+    """Creature entities in characters catalog show 'Creature' not 'Character'."""
+    entity = dict(SAMPLE_CHARACTER)
+    entity["type"] = "creature"
+    entity["id"] = "creature-wolf"
+    md = generate_character_page(entity, NAME_INDEX)
+    assert "| **Type** | Creature |" in md
+
+
+def test_concept_type_label():
+    """Concept entities in items catalog show 'Concept' not 'Item'."""
+    entity = dict(SAMPLE_ITEM)
+    entity["type"] = "concept"
+    entity["id"] = "concept-fate"
+    md = generate_item_page(entity, NAME_INDEX)
+    assert "| **Type** | Concept |" in md
+
+
+# ---------------------------------------------------------------------------
+# Stale page pruning tests
+# ---------------------------------------------------------------------------
+
+def test_stale_md_pruned():
+    """Wiki generation removes .md files for entities no longer in JSON catalog."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        char_dir = os.path.join(tmpdir, "characters")
+        os.makedirs(char_dir)
+
+        # Write one entity JSON
+        with open(os.path.join(char_dir, "char-elder.json"), "w") as f:
+            json.dump(SAMPLE_CHARACTER, f)
+        # Write a stale .md for a deleted entity
+        stale_md = os.path.join(char_dir, "char-deleted-npc.md")
+        with open(stale_md, "w") as f:
+            f.write("# Old NPC\n")
+
+        generate_wiki_pages(tmpdir, entity_types=["characters"])
+
+        # Stale page should be removed
+        assert not os.path.exists(stale_md)
+        # Valid page should exist
+        assert os.path.exists(os.path.join(char_dir, "char-elder.md"))

--- a/tools/generate_wiki_pages.py
+++ b/tools/generate_wiki_pages.py
@@ -1,0 +1,652 @@
+#!/usr/bin/env python3
+"""
+generate_wiki_pages.py — Generate human-readable wiki-style markdown pages
+from per-entity JSON catalog files.
+
+Reads V2 per-entity JSON files and produces:
+- Individual .md pages alongside each entity JSON file
+- Index README.md pages per entity type directory
+
+Usage:
+    python tools/generate_wiki_pages.py --framework framework-local/
+    python tools/generate_wiki_pages.py --framework framework/ --type characters
+    python tools/generate_wiki_pages.py --framework framework-local/ --index-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+
+# Entity type directories
+ENTITY_TYPES = ["characters", "locations", "factions", "items"]
+
+# Display labels for entity types
+TYPE_LABELS = {
+    "characters": "Character",
+    "locations": "Location",
+    "factions": "Faction",
+    "items": "Item",
+}
+
+
+def _load_entity(filepath: str) -> dict | None:
+    """Load a single entity JSON file."""
+    try:
+        with open(filepath, "r", encoding="utf-8-sig") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _load_all_entities(catalog_dir: str) -> dict[str, list[dict]]:
+    """Load all entities from all type directories."""
+    all_entities: dict[str, list[dict]] = {}
+    for entity_type in ENTITY_TYPES:
+        type_dir = os.path.join(catalog_dir, entity_type)
+        entities = []
+        if os.path.isdir(type_dir):
+            for fname in sorted(os.listdir(type_dir)):
+                if fname == "index.json" or not fname.endswith(".json"):
+                    continue
+                entity = _load_entity(os.path.join(type_dir, fname))
+                if entity:
+                    entities.append(entity)
+        all_entities[entity_type] = entities
+    return all_entities
+
+
+def _build_name_index(all_entities: dict[str, list[dict]]) -> dict[str, tuple[str, str]]:
+    """Build a mapping from entity ID to (name, relative_md_path).
+
+    The path is relative from any entity-type directory (e.g. ../characters/char-player.md).
+    """
+    index: dict[str, tuple[str, str]] = {}
+    for entity_type, entities in all_entities.items():
+        for entity in entities:
+            eid = entity.get("id", "")
+            name = entity.get("name", eid)
+            md_path = f"../{entity_type}/{eid}.md"
+            index[eid] = (name, md_path)
+    return index
+
+
+def _resolve_target(target_id: str, name_index: dict[str, tuple[str, str]],
+                    current_type: str) -> str:
+    """Resolve a target_id to a markdown link or raw ID."""
+    if target_id in name_index:
+        name, md_path = name_index[target_id]
+        # If same directory, use simple relative path
+        target_type = _infer_type_from_id(target_id)
+        if target_type == current_type:
+            return f"[{name}]({target_id}.md)"
+        return f"[{name}]({md_path})"
+    return target_id
+
+
+def _infer_type_from_id(entity_id: str) -> str:
+    """Infer entity type directory from ID prefix."""
+    prefix_map = {
+        "char-": "characters",
+        "loc-": "locations",
+        "faction-": "factions",
+        "item-": "items",
+        "creature-": "characters",
+        "concept-": "items",
+    }
+    for prefix, etype in prefix_map.items():
+        if entity_id.startswith(prefix):
+            return etype
+    return ""
+
+
+def _format_attr_value(value) -> str:
+    """Format an attribute value for display."""
+    if isinstance(value, list):
+        return ", ".join(str(v) for v in value)
+    return str(value)
+
+
+def _parse_turn_number(turn_id: str) -> int:
+    """Extract numeric part from turn ID for sorting."""
+    m = re.match(r"^turn-(\d+)$", turn_id or "")
+    return int(m.group(1)) if m else 0
+
+
+# ---------------------------------------------------------------------------
+# Character page
+# ---------------------------------------------------------------------------
+
+def generate_character_page(entity: dict, name_index: dict[str, tuple[str, str]]) -> str:
+    """Generate a wiki-style markdown page for a character entity."""
+    eid = entity.get("id", "")
+    name = entity.get("name", eid)
+    identity = entity.get("identity", "")
+    first_seen = entity.get("first_seen_turn", "")
+    last_updated = entity.get("last_updated_turn", "")
+    current_status = entity.get("current_status", "")
+    status_turn = entity.get("status_updated_turn", last_updated)
+    stable_attrs = entity.get("stable_attributes", {})
+    volatile = entity.get("volatile_state", {})
+    relationships = entity.get("relationships", [])
+
+    lines = []
+    lines.append(f"# {name}\n")
+    if identity:
+        lines.append(f"> {identity}\n")
+
+    # Infobox
+    lines.append("| | |")
+    lines.append("|---|---|")
+    lines.append(f"| **Type** | Character |")
+    lines.append(f"| **First Seen** | {first_seen} |")
+    lines.append(f"| **Last Updated** | {last_updated} |")
+    # Add simple stable attributes to infobox
+    for key, attr in stable_attrs.items():
+        if key == "aliases":
+            continue  # shown separately
+        if isinstance(attr, dict):
+            val = attr.get("value", "")
+        else:
+            val = attr
+        display_val = _format_attr_value(val)
+        if len(display_val) <= 80:
+            lines.append(f"| **{key.replace('_', ' ').title()}** | {display_val} |")
+    lines.append("")
+
+    # Current Status
+    if current_status:
+        lines.append("## Current Status\n")
+        lines.append(f"*As of {status_turn}:*\n")
+        lines.append(f"{current_status}\n")
+
+    # Attributes section
+    if stable_attrs:
+        lines.append("## Attributes\n")
+        lines.append("### Stable Traits\n")
+        lines.append("| Trait | Value | Source | Confidence |")
+        lines.append("|---|---|---|---|")
+        for key, attr in stable_attrs.items():
+            if isinstance(attr, dict):
+                val = _format_attr_value(attr.get("value", ""))
+                source = attr.get("source_turn", "")
+                confidence = attr.get("confidence", "")
+                inference = attr.get("inference", False)
+                conf_str = f"{confidence}"
+                if inference:
+                    conf_str += " (inferred)"
+            else:
+                val = _format_attr_value(attr)
+                source = ""
+                conf_str = ""
+            lines.append(f"| {key} | {val} | {source} | {conf_str} |")
+        lines.append("")
+
+    # Current State
+    if volatile:
+        lines.append("### Current State\n")
+        condition = volatile.get("condition", "")
+        equipment = volatile.get("equipment", [])
+        location = volatile.get("location", "")
+        if condition:
+            lines.append(f"- **Condition:** {condition}")
+        if equipment:
+            equip_str = ", ".join(equipment) if isinstance(equipment, list) else str(equipment)
+            lines.append(f"- **Equipment:** {equip_str}")
+        if location:
+            lines.append(f"- **Location:** {location}")
+        lines.append("")
+
+    # Relationships
+    if relationships:
+        lines.append("## Relationships\n")
+        lines.append("| Entity | Relationship | Type | Status |")
+        lines.append("|---|---|---|---|")
+        for rel in relationships:
+            target_id = rel.get("target_id", "")
+            target_display = _resolve_target(target_id, name_index, "characters")
+            cur_rel = rel.get("current_relationship", "")
+            rel_type = rel.get("type", "")
+            status = rel.get("status", "")
+            lines.append(f"| {target_display} | {cur_rel} | {rel_type} | {status} |")
+        lines.append("")
+
+        # Relationship history
+        rels_with_history = [r for r in relationships if r.get("history")]
+        if rels_with_history:
+            lines.append("### Relationship History\n")
+            for rel in rels_with_history:
+                target_id = rel.get("target_id", "")
+                target_display = _resolve_target(target_id, name_index, "characters")
+                rel_type = rel.get("type", "")
+                lines.append(f"#### → {target_display} ({rel_type})\n")
+                for entry in rel["history"]:
+                    turn = entry.get("turn", "")
+                    desc = entry.get("description", "")
+                    lines.append(f"- **{turn}:** {desc}")
+                lines.append("")
+
+    # Footer
+    lines.append("---")
+    lines.append(f"*Generated from [{eid}.json]({eid}.json) — do not edit manually.*")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Location page
+# ---------------------------------------------------------------------------
+
+def generate_location_page(entity: dict, name_index: dict[str, tuple[str, str]]) -> str:
+    """Generate a wiki-style markdown page for a location entity."""
+    eid = entity.get("id", "")
+    name = entity.get("name", eid)
+    identity = entity.get("identity", "")
+    first_seen = entity.get("first_seen_turn", "")
+    last_updated = entity.get("last_updated_turn", "")
+    current_status = entity.get("current_status", "")
+    stable_attrs = entity.get("stable_attributes", {})
+    relationships = entity.get("relationships", [])
+
+    lines = []
+    lines.append(f"# {name}\n")
+    if identity:
+        lines.append(f"> {identity}\n")
+
+    # Infobox
+    lines.append("| | |")
+    lines.append("|---|---|")
+    lines.append(f"| **Type** | Location |")
+    lines.append(f"| **First Seen** | {first_seen} |")
+    lines.append(f"| **Last Updated** | {last_updated} |")
+    for key, attr in stable_attrs.items():
+        if key == "aliases":
+            continue
+        if isinstance(attr, dict):
+            val = attr.get("value", "")
+        else:
+            val = attr
+        display_val = _format_attr_value(val)
+        if len(display_val) <= 80:
+            lines.append(f"| **{key.replace('_', ' ').title()}** | {display_val} |")
+    lines.append("")
+
+    # Current Status
+    if current_status:
+        lines.append("## Current Status\n")
+        lines.append(f"{current_status}\n")
+
+    # Notable Features
+    if stable_attrs:
+        lines.append("## Notable Features\n")
+        lines.append("| Feature | Value | Source | Confidence |")
+        lines.append("|---|---|---|---|")
+        for key, attr in stable_attrs.items():
+            if isinstance(attr, dict):
+                val = _format_attr_value(attr.get("value", ""))
+                source = attr.get("source_turn", "")
+                confidence = attr.get("confidence", "")
+                inference = attr.get("inference", False)
+                conf_str = f"{confidence}"
+                if inference:
+                    conf_str += " (inferred)"
+            else:
+                val = _format_attr_value(attr)
+                source = ""
+                conf_str = ""
+            lines.append(f"| {key} | {val} | {source} | {conf_str} |")
+        lines.append("")
+
+    # Connected Entities
+    if relationships:
+        lines.append("## Connected Entities\n")
+        lines.append("| Entity | Relationship | Type |")
+        lines.append("|---|---|---|")
+        for rel in relationships:
+            target_id = rel.get("target_id", "")
+            target_display = _resolve_target(target_id, name_index, "locations")
+            cur_rel = rel.get("current_relationship", "")
+            rel_type = rel.get("type", "")
+            lines.append(f"| {target_display} | {cur_rel} | {rel_type} |")
+        lines.append("")
+
+    # Footer
+    lines.append("---")
+    lines.append(f"*Generated from [{eid}.json]({eid}.json) — do not edit manually.*")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Faction page
+# ---------------------------------------------------------------------------
+
+def generate_faction_page(entity: dict, name_index: dict[str, tuple[str, str]]) -> str:
+    """Generate a wiki-style markdown page for a faction entity."""
+    eid = entity.get("id", "")
+    name = entity.get("name", eid)
+    identity = entity.get("identity", "")
+    first_seen = entity.get("first_seen_turn", "")
+    last_updated = entity.get("last_updated_turn", "")
+    current_status = entity.get("current_status", "")
+    stable_attrs = entity.get("stable_attributes", {})
+    relationships = entity.get("relationships", [])
+
+    lines = []
+    lines.append(f"# {name}\n")
+    if identity:
+        lines.append(f"> {identity}\n")
+
+    # Infobox
+    lines.append("| | |")
+    lines.append("|---|---|")
+    lines.append(f"| **Type** | Faction |")
+    lines.append(f"| **First Seen** | {first_seen} |")
+    lines.append(f"| **Last Updated** | {last_updated} |")
+    for key, attr in stable_attrs.items():
+        if key == "aliases":
+            continue
+        if isinstance(attr, dict):
+            val = attr.get("value", "")
+        else:
+            val = attr
+        display_val = _format_attr_value(val)
+        if len(display_val) <= 80:
+            lines.append(f"| **{key.replace('_', ' ').title()}** | {display_val} |")
+    lines.append("")
+
+    # Current Status
+    if current_status:
+        lines.append("## Current Status\n")
+        lines.append(f"{current_status}\n")
+
+    # Members / attributes
+    if stable_attrs:
+        lines.append("## Attributes\n")
+        lines.append("| Attribute | Value | Source | Confidence |")
+        lines.append("|---|---|---|---|")
+        for key, attr in stable_attrs.items():
+            if isinstance(attr, dict):
+                val = _format_attr_value(attr.get("value", ""))
+                source = attr.get("source_turn", "")
+                confidence = attr.get("confidence", "")
+                inference = attr.get("inference", False)
+                conf_str = f"{confidence}"
+                if inference:
+                    conf_str += " (inferred)"
+            else:
+                val = _format_attr_value(attr)
+                source = ""
+                conf_str = ""
+            lines.append(f"| {key} | {val} | {source} | {conf_str} |")
+        lines.append("")
+
+    # Relationships
+    if relationships:
+        lines.append("## Relationships\n")
+        lines.append("| Entity | Relationship | Type | Status |")
+        lines.append("|---|---|---|---|")
+        for rel in relationships:
+            target_id = rel.get("target_id", "")
+            target_display = _resolve_target(target_id, name_index, "factions")
+            cur_rel = rel.get("current_relationship", "")
+            rel_type = rel.get("type", "")
+            status = rel.get("status", "")
+            lines.append(f"| {target_display} | {cur_rel} | {rel_type} | {status} |")
+        lines.append("")
+
+    # Footer
+    lines.append("---")
+    lines.append(f"*Generated from [{eid}.json]({eid}.json) — do not edit manually.*")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Item page
+# ---------------------------------------------------------------------------
+
+def generate_item_page(entity: dict, name_index: dict[str, tuple[str, str]]) -> str:
+    """Generate a wiki-style markdown page for an item entity."""
+    eid = entity.get("id", "")
+    name = entity.get("name", eid)
+    identity = entity.get("identity", "")
+    first_seen = entity.get("first_seen_turn", "")
+    last_updated = entity.get("last_updated_turn", "")
+    current_status = entity.get("current_status", "")
+    stable_attrs = entity.get("stable_attributes", {})
+    volatile = entity.get("volatile_state", {})
+    relationships = entity.get("relationships", [])
+
+    lines = []
+    lines.append(f"# {name}\n")
+    if identity:
+        lines.append(f"> {identity}\n")
+
+    # Infobox
+    lines.append("| | |")
+    lines.append("|---|---|")
+    lines.append(f"| **Type** | Item |")
+    lines.append(f"| **First Seen** | {first_seen} |")
+    lines.append(f"| **Last Updated** | {last_updated} |")
+    for key, attr in stable_attrs.items():
+        if key == "aliases":
+            continue
+        if isinstance(attr, dict):
+            val = attr.get("value", "")
+        else:
+            val = attr
+        display_val = _format_attr_value(val)
+        if len(display_val) <= 80:
+            lines.append(f"| **{key.replace('_', ' ').title()}** | {display_val} |")
+    lines.append("")
+
+    # Current Status
+    if current_status:
+        lines.append("## Current Status\n")
+        lines.append(f"{current_status}\n")
+
+    # Properties
+    if stable_attrs:
+        lines.append("## Properties\n")
+        lines.append("| Property | Value | Source | Confidence |")
+        lines.append("|---|---|---|---|")
+        for key, attr in stable_attrs.items():
+            if isinstance(attr, dict):
+                val = _format_attr_value(attr.get("value", ""))
+                source = attr.get("source_turn", "")
+                confidence = attr.get("confidence", "")
+                inference = attr.get("inference", False)
+                conf_str = f"{confidence}"
+                if inference:
+                    conf_str += " (inferred)"
+            else:
+                val = _format_attr_value(attr)
+                source = ""
+                conf_str = ""
+            lines.append(f"| {key} | {val} | {source} | {conf_str} |")
+        lines.append("")
+
+    # Current holder / location
+    if volatile:
+        holder_info = []
+        condition = volatile.get("condition", "")
+        location = volatile.get("location", "")
+        if condition:
+            holder_info.append(f"- **Condition:** {condition}")
+        if location:
+            holder_info.append(f"- **Location:** {location}")
+        if holder_info:
+            lines.append("## Current State\n")
+            lines.extend(holder_info)
+            lines.append("")
+
+    # Relationships
+    if relationships:
+        lines.append("## Relationships\n")
+        lines.append("| Entity | Relationship | Type |")
+        lines.append("|---|---|---|")
+        for rel in relationships:
+            target_id = rel.get("target_id", "")
+            target_display = _resolve_target(target_id, name_index, "items")
+            cur_rel = rel.get("current_relationship", "")
+            rel_type = rel.get("type", "")
+            lines.append(f"| {target_display} | {cur_rel} | {rel_type} |")
+        lines.append("")
+
+    # Footer
+    lines.append("---")
+    lines.append(f"*Generated from [{eid}.json]({eid}.json) — do not edit manually.*")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Page generator dispatch
+# ---------------------------------------------------------------------------
+
+PAGE_GENERATORS = {
+    "characters": generate_character_page,
+    "locations": generate_location_page,
+    "factions": generate_faction_page,
+    "items": generate_item_page,
+}
+
+
+# ---------------------------------------------------------------------------
+# Index page
+# ---------------------------------------------------------------------------
+
+def generate_index_page(entity_type: str, entities: list[dict],
+                        name_index: dict[str, tuple[str, str]]) -> str:
+    """Generate a README.md index page for an entity type directory."""
+    label = TYPE_LABELS.get(entity_type, entity_type.title())
+    title = f"{label}s" if not label.endswith("s") else label
+
+    # Sort by first_seen_turn
+    sorted_entities = sorted(entities, key=lambda e: _parse_turn_number(e.get("first_seen_turn", "")))
+
+    lines = []
+    lines.append(f"# {title}\n")
+
+    if not sorted_entities:
+        lines.append("*No entities cataloged yet.*\n")
+        return "\n".join(lines) + "\n"
+
+    lines.append("| Name | Current Status | First Seen | Last Updated | Relationships |")
+    lines.append("|---|---|---|---|---|")
+
+    for entity in sorted_entities:
+        eid = entity.get("id", "")
+        name = entity.get("name", eid)
+        status = entity.get("current_status", "")
+        # Truncate status to 60 chars
+        if len(status) > 60:
+            status = status[:57] + "..."
+        first_seen = entity.get("first_seen_turn", "")
+        last_updated = entity.get("last_updated_turn", "")
+        rel_count = len(entity.get("relationships", []))
+        lines.append(f"| [{name}]({eid}.md) | {status} | {first_seen} | {last_updated} | {rel_count} |")
+
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Main generation logic
+# ---------------------------------------------------------------------------
+
+def generate_wiki_pages(catalog_dir: str, entity_types: list[str] | None = None,
+                        index_only: bool = False) -> dict[str, int]:
+    """Generate wiki-style markdown pages for entities in catalog_dir.
+
+    Args:
+        catalog_dir: Path to the catalogs directory (e.g. framework-local/catalogs/).
+        entity_types: Optional list of types to generate (e.g. ["characters"]).
+                      Defaults to all types.
+        index_only: If True, only regenerate index pages.
+
+    Returns:
+        Dict mapping entity type to number of pages generated.
+    """
+    types_to_process = entity_types or ENTITY_TYPES
+    all_entities = _load_all_entities(catalog_dir)
+    name_index = _build_name_index(all_entities)
+    stats: dict[str, int] = {}
+
+    for entity_type in types_to_process:
+        if entity_type not in ENTITY_TYPES:
+            print(f"  WARNING: Unknown entity type '{entity_type}', skipping", file=sys.stderr)
+            continue
+
+        type_dir = os.path.join(catalog_dir, entity_type)
+        if not os.path.isdir(type_dir):
+            stats[entity_type] = 0
+            continue
+
+        entities = all_entities.get(entity_type, [])
+        page_count = 0
+
+        # Generate individual entity pages
+        if not index_only:
+            generator = PAGE_GENERATORS.get(entity_type)
+            if generator:
+                for entity in entities:
+                    eid = entity.get("id", "")
+                    if not eid:
+                        continue
+                    md_content = generator(entity, name_index)
+                    md_path = os.path.join(type_dir, f"{eid}.md")
+                    with open(md_path, "w", encoding="utf-8") as f:
+                        f.write(md_content)
+                    page_count += 1
+
+        # Generate index page
+        index_content = generate_index_page(entity_type, entities, name_index)
+        readme_path = os.path.join(type_dir, "README.md")
+        with open(readme_path, "w", encoding="utf-8") as f:
+            f.write(index_content)
+        page_count += 1
+
+        stats[entity_type] = page_count
+        print(f"  {entity_type}: {page_count} pages generated")
+
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate wiki-style markdown pages from per-entity JSON catalogs."
+    )
+    parser.add_argument(
+        "--framework", required=True,
+        help="Path to the framework directory (e.g. framework-local/)"
+    )
+    parser.add_argument(
+        "--type", dest="entity_type",
+        choices=ENTITY_TYPES,
+        help="Limit generation to one entity type"
+    )
+    parser.add_argument(
+        "--index-only", action="store_true",
+        help="Only regenerate index pages, not individual entity pages"
+    )
+    args = parser.parse_args()
+
+    catalog_dir = os.path.join(args.framework, "catalogs")
+    if not os.path.isdir(catalog_dir):
+        print(f"ERROR: Catalog directory not found: {catalog_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    types = [args.entity_type] if args.entity_type else None
+    stats = generate_wiki_pages(catalog_dir, entity_types=types, index_only=args.index_only)
+
+    total = sum(stats.values())
+    print(f"\nTotal: {total} wiki pages generated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/generate_wiki_pages.py
+++ b/tools/generate_wiki_pages.py
@@ -104,16 +104,38 @@ def _infer_type_from_id(entity_id: str) -> str:
 
 
 def _format_attr_value(value) -> str:
-    """Format an attribute value for display."""
+    """Format an attribute value for display in a markdown table cell."""
     if isinstance(value, list):
-        return ", ".join(str(v) for v in value)
-    return str(value)
+        raw = ", ".join(str(v) for v in value)
+    else:
+        raw = str(value)
+    return _escape_table_cell(raw)
+
+
+def _escape_table_cell(text: str) -> str:
+    """Escape text for safe inclusion in a markdown table cell."""
+    text = str(text)
+    text = text.replace("|", "\\|")
+    text = text.replace("\n", " ")
+    text = text.replace("\r", "")
+    return text
 
 
 def _parse_turn_number(turn_id: str) -> int:
     """Extract numeric part from turn ID for sorting."""
     m = re.match(r"^turn-(\d+)$", turn_id or "")
     return int(m.group(1)) if m else 0
+
+
+def _type_label(entity: dict, fallback: str) -> str:
+    """Return a display label for the entity type.
+
+    Uses the entity's own ``type`` field so that creature-* and concept-*
+    entries get the correct label instead of always showing the catalog
+    directory name.
+    """
+    raw = entity.get("type", fallback).lower()
+    return raw.replace("_", " ").title()
 
 
 # ---------------------------------------------------------------------------
@@ -141,7 +163,7 @@ def generate_character_page(entity: dict, name_index: dict[str, tuple[str, str]]
     # Infobox
     lines.append("| | |")
     lines.append("|---|---|")
-    lines.append(f"| **Type** | Character |")
+    lines.append(f"| **Type** | {_type_label(entity, 'Character')} |")
     lines.append(f"| **First Seen** | {first_seen} |")
     lines.append(f"| **Last Updated** | {last_updated} |")
     # Add simple stable attributes to infobox
@@ -208,9 +230,9 @@ def generate_character_page(entity: dict, name_index: dict[str, tuple[str, str]]
         for rel in relationships:
             target_id = rel.get("target_id", "")
             target_display = _resolve_target(target_id, name_index, "characters")
-            cur_rel = rel.get("current_relationship", "")
-            rel_type = rel.get("type", "")
-            status = rel.get("status", "")
+            cur_rel = _escape_table_cell(rel.get("current_relationship", ""))
+            rel_type = _escape_table_cell(rel.get("type", ""))
+            status = _escape_table_cell(rel.get("status", ""))
             lines.append(f"| {target_display} | {cur_rel} | {rel_type} | {status} |")
         lines.append("")
 
@@ -258,7 +280,7 @@ def generate_location_page(entity: dict, name_index: dict[str, tuple[str, str]])
     # Infobox
     lines.append("| | |")
     lines.append("|---|---|")
-    lines.append(f"| **Type** | Location |")
+    lines.append(f"| **Type** | {_type_label(entity, 'Location')} |")
     lines.append(f"| **First Seen** | {first_seen} |")
     lines.append(f"| **Last Updated** | {last_updated} |")
     for key, attr in stable_attrs.items():
@@ -307,8 +329,8 @@ def generate_location_page(entity: dict, name_index: dict[str, tuple[str, str]])
         for rel in relationships:
             target_id = rel.get("target_id", "")
             target_display = _resolve_target(target_id, name_index, "locations")
-            cur_rel = rel.get("current_relationship", "")
-            rel_type = rel.get("type", "")
+            cur_rel = _escape_table_cell(rel.get("current_relationship", ""))
+            rel_type = _escape_table_cell(rel.get("type", ""))
             lines.append(f"| {target_display} | {cur_rel} | {rel_type} |")
         lines.append("")
 
@@ -341,7 +363,7 @@ def generate_faction_page(entity: dict, name_index: dict[str, tuple[str, str]]) 
     # Infobox
     lines.append("| | |")
     lines.append("|---|---|")
-    lines.append(f"| **Type** | Faction |")
+    lines.append(f"| **Type** | {_type_label(entity, 'Faction')} |")
     lines.append(f"| **First Seen** | {first_seen} |")
     lines.append(f"| **Last Updated** | {last_updated} |")
     for key, attr in stable_attrs.items():
@@ -390,9 +412,9 @@ def generate_faction_page(entity: dict, name_index: dict[str, tuple[str, str]]) 
         for rel in relationships:
             target_id = rel.get("target_id", "")
             target_display = _resolve_target(target_id, name_index, "factions")
-            cur_rel = rel.get("current_relationship", "")
-            rel_type = rel.get("type", "")
-            status = rel.get("status", "")
+            cur_rel = _escape_table_cell(rel.get("current_relationship", ""))
+            rel_type = _escape_table_cell(rel.get("type", ""))
+            status = _escape_table_cell(rel.get("status", ""))
             lines.append(f"| {target_display} | {cur_rel} | {rel_type} | {status} |")
         lines.append("")
 
@@ -426,7 +448,7 @@ def generate_item_page(entity: dict, name_index: dict[str, tuple[str, str]]) -> 
     # Infobox
     lines.append("| | |")
     lines.append("|---|---|")
-    lines.append(f"| **Type** | Item |")
+    lines.append(f"| **Type** | {_type_label(entity, 'Item')} |")
     lines.append(f"| **First Seen** | {first_seen} |")
     lines.append(f"| **Last Updated** | {last_updated} |")
     for key, attr in stable_attrs.items():
@@ -489,8 +511,8 @@ def generate_item_page(entity: dict, name_index: dict[str, tuple[str, str]]) -> 
         for rel in relationships:
             target_id = rel.get("target_id", "")
             target_display = _resolve_target(target_id, name_index, "items")
-            cur_rel = rel.get("current_relationship", "")
-            rel_type = rel.get("type", "")
+            cur_rel = _escape_table_cell(rel.get("current_relationship", ""))
+            rel_type = _escape_table_cell(rel.get("type", ""))
             lines.append(f"| {target_display} | {cur_rel} | {rel_type} |")
         lines.append("")
 
@@ -516,8 +538,7 @@ PAGE_GENERATORS = {
 # Index page
 # ---------------------------------------------------------------------------
 
-def generate_index_page(entity_type: str, entities: list[dict],
-                        name_index: dict[str, tuple[str, str]]) -> str:
+def generate_index_page(entity_type: str, entities: list[dict]) -> str:
     """Generate a README.md index page for an entity type directory."""
     label = TYPE_LABELS.get(entity_type, entity_type.title())
     title = f"{label}s" if not label.endswith("s") else label
@@ -537,8 +558,8 @@ def generate_index_page(entity_type: str, entities: list[dict],
 
     for entity in sorted_entities:
         eid = entity.get("id", "")
-        name = entity.get("name", eid)
-        status = entity.get("current_status", "")
+        name = _escape_table_cell(entity.get("name", eid))
+        status = _escape_table_cell(entity.get("current_status", ""))
         # Truncate status to 60 chars
         if len(status) > 60:
             status = status[:57] + "..."
@@ -584,6 +605,7 @@ def generate_wiki_pages(catalog_dir: str, entity_types: list[str] | None = None,
             continue
 
         entities = all_entities.get(entity_type, [])
+        live_ids = {e.get("id") for e in entities if e.get("id")}
         page_count = 0
 
         # Generate individual entity pages
@@ -600,8 +622,18 @@ def generate_wiki_pages(catalog_dir: str, entity_types: list[str] | None = None,
                         f.write(md_content)
                     page_count += 1
 
+            # Prune stale .md files whose entity JSON no longer exists
+            for fname in os.listdir(type_dir):
+                if fname == "README.md" or not fname.endswith(".md"):
+                    continue
+                stem = fname[:-3]  # strip .md
+                if stem not in live_ids:
+                    stale_path = os.path.join(type_dir, fname)
+                    os.remove(stale_path)
+                    print(f"  Pruned stale wiki page: {fname}", file=sys.stderr)
+
         # Generate index page
-        index_content = generate_index_page(entity_type, entities, name_index)
+        index_content = generate_index_page(entity_type, entities)
         readme_path = os.path.join(type_dir, "README.md")
         with open(readme_path, "w", encoding="utf-8") as f:
             f.write(index_content)

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -13,6 +13,7 @@ Works in both batch (bootstrap) and incremental (ingest) modes.
 
 import json
 import os
+import re
 import sys
 
 from catalog_merger import (
@@ -292,31 +293,45 @@ def _check_pc_duplicate(entity: dict, catalogs: dict) -> str | None:
     if eid == "char-player":
         return None  # Already the PC
 
-    # Check if identity/description mentions self-introduction
+    # Check if identity/description explicitly identifies this as the PC.
+    # Only match phrases that unambiguously refer to the player character;
+    # generic self-introduction language ("introduces themselves") is too
+    # broad because NPCs introduce themselves too.
     identity = (entity.get("identity") or entity.get("description") or "").lower()
 
     pc_indicators = [
-        "introduces themselves",
-        "introducing themselves",
-        "points to self",
-        "pointing to self",
-        "points to oneself",
-        "pointing to oneself",
         "the player character",
         "player character",
+        "you introduce yourself",
+        "you point to yourself",
+        "you state your name",
+        "you give your name",
+        "you reveal your name",
     ]
 
     if any(indicator in identity for indicator in pc_indicators):
         return "char-player"
 
+    # Also match second-person self-introduction patterns
+    second_person_intro = re.search(
+        r"\byou\b.*\b(?:introduc|point(?:s|ing)?\s+to\s+(?:your)?self|stat(?:e|ing)\s+(?:your|their)\s+name)",
+        identity,
+    )
+    if second_person_intro:
+        return "char-player"
+
     return None
 
 
-def _merge_into_pc(catalogs: dict, duplicate: dict) -> None:
-    """Merge a duplicate entity's data into char-player."""
+def _merge_into_pc(catalogs: dict, duplicate: dict) -> str | None:
+    """Merge a duplicate entity's data into char-player.
+
+    Returns the duplicate entity ID if the merge succeeded (so the caller
+    can remove it from catalogs), or None if char-player was not found.
+    """
     pc_result = find_entity_by_id(catalogs, "char-player")
     if not pc_result:
-        return
+        return None
     _, pc_entity = pc_result
 
     dup_name = duplicate.get("name", "")
@@ -332,9 +347,12 @@ def _merge_into_pc(catalogs: dict, duplicate: dict) -> None:
         val = []
     if dup_name and dup_name not in val:
         val.append(dup_name)
-    alias_turn = duplicate.get("last_updated_turn", pc_entity.get("last_updated_turn", ""))
-    sa["aliases"] = {"value": val, "inference": False, "confidence": 1.0,
-                     "source_turn": alias_turn}
+    # Only include source_turn when we have a valid turn-NNN value
+    alias_turn = duplicate.get("last_updated_turn") or duplicate.get("first_seen_turn") or ""
+    alias_entry: dict = {"value": val, "inference": False, "confidence": 1.0}
+    if re.match(r"^turn-\d+$", alias_turn):
+        alias_entry["source_turn"] = alias_turn
+    sa["aliases"] = alias_entry
 
     # Update PC name if still generic
     if pc_entity.get("name") in ("Player Character", "player character") and dup_name:
@@ -354,6 +372,7 @@ def _merge_into_pc(catalogs: dict, duplicate: dict) -> None:
 
     print(f"  PC-DEDUP: merged '{dup_name}' ({duplicate.get('id')}) into char-player",
           file=sys.stderr)
+    return duplicate.get("id", "")
 
 
 def _validate_entity(entity_data: dict) -> bool:
@@ -621,7 +640,15 @@ def extract_and_merge(
             # Check if this entity is actually the player character
             pc_target = _check_pc_duplicate(entity_data, catalogs)
             if pc_target:
-                _merge_into_pc(catalogs, entity_data)
+                dup_id = _merge_into_pc(catalogs, entity_data)
+                # Remove the duplicate entity from catalogs so it isn't
+                # written back to disk by save_catalogs().
+                if dup_id:
+                    for cat_key, cat_list in catalogs.items():
+                        catalogs[cat_key] = [
+                            e for e in cat_list
+                            if e.get("id") != dup_id
+                        ]
                 llm.delay()
                 continue
             _filter_pc_attributes(entity_data)

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -283,6 +283,79 @@ def _filter_concept_prefix_from_items(entity_data: dict) -> bool:
     return True
 
 
+def _check_pc_duplicate(entity: dict, catalogs: dict) -> str | None:
+    """Check if an entity is actually the player character under a different name.
+
+    Returns 'char-player' if this entity should be merged into the PC, else None.
+    """
+    eid = entity.get("id", entity.get("proposed_id", ""))
+    if eid == "char-player":
+        return None  # Already the PC
+
+    # Check if identity/description mentions self-introduction
+    identity = (entity.get("identity") or entity.get("description") or "").lower()
+
+    pc_indicators = [
+        "introduces themselves",
+        "introducing themselves",
+        "points to self",
+        "pointing to self",
+        "points to oneself",
+        "pointing to oneself",
+        "the player character",
+        "player character",
+    ]
+
+    if any(indicator in identity for indicator in pc_indicators):
+        return "char-player"
+
+    return None
+
+
+def _merge_into_pc(catalogs: dict, duplicate: dict) -> None:
+    """Merge a duplicate entity's data into char-player."""
+    pc_result = find_entity_by_id(catalogs, "char-player")
+    if not pc_result:
+        return
+    _, pc_entity = pc_result
+
+    dup_name = duplicate.get("name", "")
+
+    # Add duplicate's name as alias of char-player
+    sa = pc_entity.setdefault("stable_attributes", {})
+    existing_aliases = sa.get("aliases", {})
+    if isinstance(existing_aliases, dict):
+        val = existing_aliases.get("value", [])
+        if isinstance(val, str):
+            val = [a.strip() for a in val.split(",") if a.strip()]
+    else:
+        val = []
+    if dup_name and dup_name not in val:
+        val.append(dup_name)
+    alias_turn = duplicate.get("last_updated_turn", pc_entity.get("last_updated_turn", ""))
+    sa["aliases"] = {"value": val, "inference": False, "confidence": 1.0,
+                     "source_turn": alias_turn}
+
+    # Update PC name if still generic
+    if pc_entity.get("name") in ("Player Character", "player character") and dup_name:
+        pc_entity["name"] = dup_name
+
+    # Merge stable attributes (except aliases which we handled above)
+    for key, attr in duplicate.get("stable_attributes", {}).items():
+        if key == "aliases":
+            continue
+        if key not in sa:
+            sa[key] = attr
+
+    # Update last_updated_turn
+    dup_turn = duplicate.get("last_updated_turn")
+    if dup_turn:
+        pc_entity["last_updated_turn"] = dup_turn
+
+    print(f"  PC-DEDUP: merged '{dup_name}' ({duplicate.get('id')}) into char-player",
+          file=sys.stderr)
+
+
 def _validate_entity(entity_data: dict) -> bool:
     """Validate an entity dict against entity.schema.json. Returns True if valid."""
     schema = _load_schema("entity.schema.json")
@@ -545,6 +618,12 @@ def extract_and_merge(
         if entity_data and not _filter_concept_prefix_from_items(entity_data):
             continue
         if entity_data and _validate_entity(entity_data):
+            # Check if this entity is actually the player character
+            pc_target = _check_pc_duplicate(entity_data, catalogs)
+            if pc_target:
+                _merge_into_pc(catalogs, entity_data)
+                llm.delay()
+                continue
             _filter_pc_attributes(entity_data)
             merge_entity(catalogs, entity_data)
             # If this was char-player, also purge stale keys from catalog


### PR DESCRIPTION
## Summary

Fix player character duplicate entity bug and add human-readable wiki-style markdown generation.

## Issue #101 — PC self-introduction duplicate

When the player character reveals their name (e.g., turn-059 self-introduction as "Fenouille Moonwind"), the extraction pipeline created a separate entity instead of recognizing it as char-player.

### Changes
- entity-discovery.md: explicit PLAYER CHARACTER RULE preventing new entity creation for self-introduction
- entity-detail.md: guidance for adding revealed name as alias to char-player
- semantic_extraction.py: _check_pc_duplicate() guard that detects self-introduction entities and merges into char-player
- tests/test_pc_dedup.py: 7 tests covering detection and merge logic

## Issue #102 — Wiki-style markdown pages

New tool that generates human-readable markdown files alongside per-entity JSON files, styled like fandom wiki character pages.

### Changes
- New tools/generate_wiki_pages.py with per-entity-type page templates
- Character pages: infobox, identity, status, attributes, relationships, history
- Location pages: identity, features, connected entities
- Faction pages: attributes, relationships
- Item pages: properties, current state
- Index pages (README.md) per entity type with links to all entity pages
- Relationship target IDs resolved to names with cross-links
- tests/test_wiki_pages.py: 14 tests covering all page types, resolution, and edge cases

Closes #101
Closes #102
