### PR TITLE
feat: add synthesis data assembly layer for wiki narrative generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
             echo "OK: $f"
           done
 
+      - name: Run tests
+        run: python -m pytest tests/ -v
+
       - name: Validate schemas and framework files
         run: python tools/validate.py --all
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jsonschema>=4.0.0
+pytest>=7.0.0

--- a/tests/test_synthesis_core.py
+++ b/tests/test_synthesis_core.py
@@ -66,56 +66,63 @@ SAMPLE_EVENTS = [
 ]
 
 
-# Relationships modeled on char-player's data: multiple entries for same target
+# Relationships modeled on char-player's data: multiple entries for same target.
+# V2 schema: history items are {turn, description} only — no per-entry type.
+# The parent relationship object carries the type.
 SAMPLE_RELATIONSHIPS = [
     {
         "target_id": "char-broad-figure",
         "current_relationship": "communicating with",
         "type": "social",
+        "last_updated_turn": "turn-035",
         "history": [
-            {"turn": "turn-012", "type": "social", "description": "communicating with"},
-            {"turn": "turn-035", "type": "social", "description": "working alongside"},
+            {"turn": "turn-012", "description": "communicating with"},
+            {"turn": "turn-035", "description": "working alongside"},
         ],
     },
     {
         "target_id": "char-Kael",
         "current_relationship": "Life partner",
         "type": "romantic",
+        "last_updated_turn": "turn-108",
         "history": [
-            {"turn": "turn-051", "type": "social", "description": "helping maintain fire with"},
-            {"turn": "turn-056", "type": "social", "description": "friendship with"},
-            {"turn": "turn-078", "type": "romantic", "description": "laying a good luck kiss"},
-            {"turn": "turn-108", "type": "romantic", "description": "seeking alliance"},
+            {"turn": "turn-051", "description": "helping maintain fire with"},
+            {"turn": "turn-056", "description": "friendship with"},
+            {"turn": "turn-078", "description": "laying a good luck kiss"},
+            {"turn": "turn-108", "description": "seeking alliance"},
         ],
     },
     {
         "target_id": "char-kael",
         "current_relationship": "Co-leader",
         "type": "romantic",
+        "last_updated_turn": "turn-340",
         "history": [
-            {"turn": "turn-194", "type": "romantic", "description": "trusting with leadership"},
-            {"turn": "turn-210", "type": "romantic", "description": "sharing closeness"},
-            {"turn": "turn-286", "type": "leadership", "description": "overseeing perimeter"},
-            {"turn": "turn-326", "type": "romantic", "description": "feeling fourth child"},
-            {"turn": "turn-340", "type": "leadership", "description": "winter council report"},
+            {"turn": "turn-194", "description": "trusting with leadership"},
+            {"turn": "turn-210", "description": "sharing closeness"},
+            {"turn": "turn-286", "description": "overseeing perimeter"},
+            {"turn": "turn-326", "description": "feeling fourth child"},
+            {"turn": "turn-340", "description": "winter council report"},
         ],
     },
     {
         "target_id": "char-elder",
         "current_relationship": "Respected elder",
         "type": "social",
+        "last_updated_turn": "turn-340",
         "history": [
-            {"turn": "turn-015", "type": "social", "description": "acceptance ritual"},
-            {"turn": "turn-029", "type": "social", "description": "offered broth"},
-            {"turn": "turn-340", "type": "social", "description": "spiritual counsel"},
+            {"turn": "turn-015", "description": "acceptance ritual"},
+            {"turn": "turn-029", "description": "offered broth"},
+            {"turn": "turn-340", "description": "spiritual counsel"},
         ],
     },
     {
         "target_id": "char-Elder",
         "current_relationship": "Moral anchor",
         "type": "social",
+        "last_updated_turn": "turn-015",
         "history": [
-            {"turn": "turn-015", "type": "social", "description": "ritual begins"},
+            {"turn": "turn-015", "description": "ritual begins"},
         ],
     },
 ]
@@ -305,7 +312,7 @@ class TestPhaseSegmentation:
             else:
                 turn += 1
 
-        phases = segment_phases(events, "character", "char-player")
+        phases = segment_phases(events, "char-player")
         assert 4 <= len(phases) <= 8, f"Expected 4–8 phases, got {len(phases)}"
 
         # All events accounted for
@@ -327,13 +334,13 @@ class TestPhaseSegmentation:
                 f"NPC event {i}",
             ))
 
-        phases = segment_phases(events, "character", "char-npc")
+        phases = segment_phases(events, "char-npc")
         assert 2 <= len(phases) <= 4, f"Expected 2–4 phases, got {len(phases)}"
 
     def test_minor_entity_single_phase(self):
         """NPC with 5 events → 1 phase."""
         events = _make_events_range(100, 104, "char-minor")
-        phases = segment_phases(events, "character", "char-minor")
+        phases = segment_phases(events, "char-minor")
         assert len(phases) == 1
         assert phases[0]["event_count"] == 5
 
@@ -346,25 +353,25 @@ class TestPhaseSegmentation:
         # Cluster B: turns 30–45
         events.extend(_make_events_range(30, 45, "char-test"))
 
-        phases = segment_phases(events, "character", "char-test")
+        phases = segment_phases(events, "char-test")
         # Should be 2+ phases due to the gap
         assert len(phases) >= 2
 
     def test_single_turn_entity(self):
         """Entity with a single event produces a single phase."""
         events = [_make_event("evt-solo", ["turn-042"], ["char-one"], "encounter")]
-        phases = segment_phases(events, "character", "char-one")
+        phases = segment_phases(events, "char-one")
         assert len(phases) == 1
         assert phases[0]["event_count"] == 1
 
     def test_empty_events(self):
-        phases = segment_phases([], "character", "char-empty")
+        phases = segment_phases([], "char-empty")
         assert phases == []
 
     def test_phase_structure(self):
         """Each phase has the required fields."""
         events = _make_events_range(1, 5, "char-struct")
-        phases = segment_phases(events, "character", "char-struct")
+        phases = segment_phases(events, "char-struct")
         phase = phases[0]
         assert "name" in phase
         assert "turn_range" in phase
@@ -376,7 +383,7 @@ class TestPhaseSegmentation:
     def test_all_events_accounted_for(self):
         """No events should be lost in segmentation."""
         events = _make_events_range(1, 50, "char-player")
-        phases = segment_phases(events, "character", "char-player")
+        phases = segment_phases(events, "char-player")
         total = sum(p["event_count"] for p in phases)
         assert total == 50
 
@@ -394,8 +401,11 @@ class TestRelationshipMerger:
         merged = merge_relationship_histories(SAMPLE_RELATIONSHIPS)
         # char-broad-figure → char-kael, char-Kael → char-kael, char-kael → char-kael
         assert "char-kael" in merged
-        # 2 from char-broad-figure + 4 from char-Kael + 5 from char-kael = 11
-        # minus turn-015 dedup (elder has it, not kael) = 11
+        # History entries plus synthesized "current" entries, after dedup.
+        # Broad-figure: 2 hist + 1 current(turn-035 deduped) = 2
+        # char-Kael: 4 hist + 1 current(turn-108 deduped) = 4
+        # char-kael: 5 hist + 1 current(turn-340 deduped) = 5
+        # Total unique turns: 11
         kael_history = merged["char-kael"]
         assert len(kael_history) == 11
 
@@ -418,26 +428,62 @@ class TestRelationshipMerger:
         rels = [
             {
                 "target_id": "char-test",
+                "type": "social",
                 "history": [
-                    {"turn": "turn-010", "type": "social", "description": "short"},
-                    {"turn": "turn-020", "type": "social", "description": "unique"},
+                    {"turn": "turn-010", "description": "short"},
+                    {"turn": "turn-020", "description": "unique"},
                 ],
             },
             {
                 "target_id": "char-test",
+                "type": "social",
                 "history": [
-                    {"turn": "turn-010", "type": "social", "description": "much longer description here"},
+                    {"turn": "turn-010", "description": "much longer description here"},
                 ],
             },
         ]
         merged = merge_relationship_histories(rels)
-        assert merged["char-test"][0]["description"] == "much longer description here"
+        turn_010 = [e for e in merged["char-test"] if e["turn"] == "turn-010"]
+        assert turn_010[0]["description"] == "much longer description here"
 
     def test_sorts_chronologically(self):
         merged = merge_relationship_histories(SAMPLE_RELATIONSHIPS)
         for target_id, history in merged.items():
             turns = [int(e["turn"].split("-")[1]) for e in history]
             assert turns == sorted(turns), f"{target_id} history not sorted"
+
+    def test_entries_enriched_with_type(self):
+        """Merged history entries should have type from parent relationship."""
+        merged = merge_relationship_histories(SAMPLE_RELATIONSHIPS)
+        kael_history = merged["char-kael"]
+        # All entries should have a type field
+        for entry in kael_history:
+            assert "type" in entry, f"Entry missing type: {entry}"
+        # The broad-figure entries should have social type
+        turn_012 = [e for e in kael_history if e["turn"] == "turn-012"]
+        assert turn_012[0]["type"] == "social"
+
+    def test_current_state_synthesized(self):
+        """Synthesized current entries should appear in merged timeline."""
+        rels = [
+            {
+                "target_id": "char-ally",
+                "current_relationship": "trusted friend",
+                "type": "social",
+                "last_updated_turn": "turn-200",
+                "history": [
+                    {"turn": "turn-050", "description": "first met"},
+                    {"turn": "turn-100", "description": "worked together"},
+                ],
+            },
+        ]
+        merged = merge_relationship_histories(rels)
+        ally_hist = merged["char-ally"]
+        # Should have 3 entries: 2 history + 1 synthesized current
+        assert len(ally_hist) == 3
+        # Last entry should be the synthesized current
+        assert ally_hist[-1]["turn"] == "turn-200"
+        assert ally_hist[-1]["description"] == "trusted friend"
 
     def test_empty_relationships(self):
         merged = merge_relationship_histories([])
@@ -453,6 +499,7 @@ class TestArcChunking:
     """Test rule-based relationship arc chunking (Step 5, Phase A)."""
 
     def test_chunks_by_type_transition(self):
+        # Enriched entries (as produced by merge_relationship_histories)
         history = [
             {"turn": "turn-012", "type": "social", "description": "met"},
             {"turn": "turn-020", "type": "social", "description": "worked together"},
@@ -466,6 +513,7 @@ class TestArcChunking:
         assert chunks[-1]["type"] == "romantic"
 
     def test_clusters_same_type_within_20_turns(self):
+        # Enriched entries — same type throughout but with a temporal gap
         history = [
             {"turn": "turn-010", "type": "social", "description": "met"},
             {"turn": "turn-015", "type": "social", "description": "talked"},
@@ -646,7 +694,7 @@ class TestArcSummarizerIntegration:
             assert "generated_at" in loaded
 
     def test_current_relationship_preserved(self):
-        """current_relationship from the latest relationship entry is preserved."""
+        """current_relationship from the relationship with latest last_updated_turn is used."""
         result = summarize_relationship_arcs(
             source_id="char-player",
             source_name="Fenouille",
@@ -654,9 +702,10 @@ class TestArcSummarizerIntegration:
             llm_client=None,
         )
         if "char-kael" in result["arcs"]:
-            # The latest entry for char-kael has "Co-leader"
+            # char-kael (last_updated_turn=turn-340) has "Co-leader" which is
+            # chronologically the latest
             cur = result["arcs"]["char-kael"]["current_relationship"]
-            assert cur in ("Life partner", "Co-leader")
+            assert cur == "Co-leader"
 
     def test_skips_sparse_relationships(self):
         """Relationships with ≤ 3 interactions are skipped."""
@@ -665,9 +714,10 @@ class TestArcSummarizerIntegration:
                 "target_id": "char-stranger",
                 "current_relationship": "acquaintance",
                 "type": "social",
+                "last_updated_turn": "turn-200",
                 "history": [
-                    {"turn": "turn-100", "type": "social", "description": "met once"},
-                    {"turn": "turn-200", "type": "social", "description": "met twice"},
+                    {"turn": "turn-100", "description": "met once"},
+                    {"turn": "turn-200", "description": "met twice"},
                 ],
             },
         ]

--- a/tests/test_synthesis_core.py
+++ b/tests/test_synthesis_core.py
@@ -19,8 +19,6 @@ from synthesis import (
     write_arc_sidecar,
     _infer_name_from_id,
     _infer_type_from_id,
-    _count_event_types,
-    _extract_co_occurrences,
     _fallback_arc_summaries,
 )
 

--- a/tests/test_synthesis_core.py
+++ b/tests/test_synthesis_core.py
@@ -1,0 +1,749 @@
+"""Tests for the synthesis data assembly layer (tools/synthesis.py)."""
+
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from synthesis import (
+    build_event_derived_profile,
+    chunk_relationship_arcs,
+    group_events_by_entity,
+    load_events,
+    merge_relationship_histories,
+    resolve_entity_id,
+    segment_phases,
+    summarize_relationship_arcs,
+    write_arc_sidecar,
+    _infer_name_from_id,
+    _infer_type_from_id,
+    _count_event_types,
+    _extract_co_occurrences,
+    _fallback_arc_summaries,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — modeled on actual Run 4 data patterns
+# ---------------------------------------------------------------------------
+
+
+def _make_event(event_id, turns, related, etype="decision", desc="Test event"):
+    """Convenience factory for event fixtures."""
+    return {
+        "id": event_id,
+        "source_turns": turns,
+        "type": etype,
+        "description": desc,
+        "related_entities": related,
+    }
+
+
+# Events designed to exercise grouping, ID aliases, and sorting
+SAMPLE_EVENTS = [
+    _make_event("evt-001", ["turn-001"], ["char-player"], "encounter", "Awakens in snow"),
+    _make_event("evt-002", ["turn-005"], ["char-player", "char-Kael"], "encounter", "Triggers snare"),
+    _make_event("evt-003", ["turn-015"], ["char-player", "char-elder"], "ritual", "Acceptance ritual"),
+    _make_event("evt-004", ["turn-050"], ["char-player", "char-broad-figure"], "encounter", "Sits near fire"),
+    _make_event("evt-005", ["turn-079"], ["char-player", "char-broad-figure"], "encounter", "Good-luck kiss"),
+    _make_event("evt-006", ["turn-108"], ["char-player", "char-kael", "char-elder"], "decision", "Council"),
+    _make_event("evt-007", ["turn-121"], ["char-player"], "discovery", "Pregnancy discovered"),
+    _make_event("evt-008", ["turn-141"], ["char-player", "char-kael"], "birth", "Lyrawyn born"),
+    _make_event("evt-009", ["turn-194"], ["char-player", "char-kael"], "decision", "Kael appointed"),
+    _make_event("evt-010", ["turn-225"], ["char-player", "entity-healer"], "encounter", "Traveler arrives"),
+    _make_event("evt-011", ["turn-252"], ["char-player", "char-anya"], "decision", "Plague resolved"),
+    _make_event("evt-012", ["turn-291"], ["char-player"], "decision", "Names Quiet Weave"),
+    _make_event("evt-013", ["turn-306"], ["char-player", "char-kael"], "birth", "Rune born"),
+    _make_event("evt-014", ["turn-340"], ["char-player", "char-kael", "char-elder", "char-gorok"], "decision", "Winter council"),
+    _make_event("evt-015", ["turn-169"], ["char-player", "char-kael"], "decision", "Water barrels"),
+    _make_event("evt-016", ["turn-210"], ["char-player", "char-kael"], "decision", "Selects hunters"),
+    _make_event("evt-017", ["turn-286"], ["char-player", "char-kael", "char-anya"], "decision", "Disruption fields"),
+    _make_event("evt-018", ["turn-301"], ["char-player", "char-kael"], "decision", "Delegates leadership"),
+    _make_event("evt-019", ["turn-326"], ["char-player", "char-kael"], "encounter", "Feels fourth child"),
+    _make_event("evt-020", ["turn-343"], ["char-player", "char-kael", "char-gorok"], "decision", "Dual forces"),
+    _make_event("evt-021", ["turn-100"], ["char-ananya"], "encounter", "Anya early event"),
+    _make_event("evt-022", ["turn-200"], ["npc-ananya", "char-player"], "encounter", "Anya later event"),
+    _make_event("evt-023", ["turn-332"], ["char-player", "faction-warrior-chief-gorok"], "encounter", "Gorok via faction ID"),
+]
+
+
+# Relationships modeled on char-player's data: multiple entries for same target
+SAMPLE_RELATIONSHIPS = [
+    {
+        "target_id": "char-broad-figure",
+        "current_relationship": "communicating with",
+        "type": "social",
+        "history": [
+            {"turn": "turn-012", "type": "social", "description": "communicating with"},
+            {"turn": "turn-035", "type": "social", "description": "working alongside"},
+        ],
+    },
+    {
+        "target_id": "char-Kael",
+        "current_relationship": "Life partner",
+        "type": "romantic",
+        "history": [
+            {"turn": "turn-051", "type": "social", "description": "helping maintain fire with"},
+            {"turn": "turn-056", "type": "social", "description": "friendship with"},
+            {"turn": "turn-078", "type": "romantic", "description": "laying a good luck kiss"},
+            {"turn": "turn-108", "type": "romantic", "description": "seeking alliance"},
+        ],
+    },
+    {
+        "target_id": "char-kael",
+        "current_relationship": "Co-leader",
+        "type": "romantic",
+        "history": [
+            {"turn": "turn-194", "type": "romantic", "description": "trusting with leadership"},
+            {"turn": "turn-210", "type": "romantic", "description": "sharing closeness"},
+            {"turn": "turn-286", "type": "leadership", "description": "overseeing perimeter"},
+            {"turn": "turn-326", "type": "romantic", "description": "feeling fourth child"},
+            {"turn": "turn-340", "type": "leadership", "description": "winter council report"},
+        ],
+    },
+    {
+        "target_id": "char-elder",
+        "current_relationship": "Respected elder",
+        "type": "social",
+        "history": [
+            {"turn": "turn-015", "type": "social", "description": "acceptance ritual"},
+            {"turn": "turn-029", "type": "social", "description": "offered broth"},
+            {"turn": "turn-340", "type": "social", "description": "spiritual counsel"},
+        ],
+    },
+    {
+        "target_id": "char-Elder",
+        "current_relationship": "Moral anchor",
+        "type": "social",
+        "history": [
+            {"turn": "turn-015", "type": "social", "description": "ritual begins"},
+        ],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# 1. Event Grouping Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEventGrouping:
+    """Test event-entity grouping (Step 1)."""
+
+    def test_groups_events_by_entity(self):
+        grouped = group_events_by_entity(SAMPLE_EVENTS)
+        assert "char-player" in grouped
+        # char-player appears in most events
+        assert len(grouped["char-player"]) >= 15
+
+    def test_applies_case_insensitive_matching(self):
+        """char-Kael and char-kael should resolve to the same key."""
+        grouped = group_events_by_entity(SAMPLE_EVENTS)
+        # Both char-Kael (evt-002) and char-kael (evt-006) should be under char-kael
+        assert "char-kael" in grouped
+        assert "char-Kael" not in grouped
+
+    def test_applies_id_aliases(self):
+        """char-broad-figure should resolve to char-kael via alias."""
+        grouped = group_events_by_entity(SAMPLE_EVENTS)
+        kael_events = grouped["char-kael"]
+        # evt-004 and evt-005 have char-broad-figure, evt-002 has char-Kael,
+        # evt-006/008/009 have char-kael — all should be merged
+        event_ids = {e["id"] for e in kael_events}
+        assert "evt-002" in event_ids  # char-Kael
+        assert "evt-004" in event_ids  # char-broad-figure
+        assert "evt-006" in event_ids  # char-kael
+
+    def test_alias_ananya_to_anya(self):
+        """char-ananya and npc-ananya should both resolve to char-anya."""
+        grouped = group_events_by_entity(SAMPLE_EVENTS)
+        assert "char-anya" in grouped
+        anya_events = grouped["char-anya"]
+        event_ids = {e["id"] for e in anya_events}
+        assert "evt-021" in event_ids  # char-ananya
+        assert "evt-022" in event_ids  # npc-ananya
+        assert "evt-011" in event_ids  # char-anya direct
+        assert "evt-017" in event_ids  # char-anya direct
+
+    def test_alias_gorok_faction_to_char(self):
+        """faction-warrior-chief-gorok should resolve to char-gorok."""
+        grouped = group_events_by_entity(SAMPLE_EVENTS)
+        assert "char-gorok" in grouped
+        gorok_events = grouped["char-gorok"]
+        event_ids = {e["id"] for e in gorok_events}
+        assert "evt-023" in event_ids  # faction-warrior-chief-gorok
+        assert "evt-014" in event_ids  # char-gorok direct
+
+    def test_entity_healer_alias(self):
+        """entity-healer should resolve to char-healer."""
+        grouped = group_events_by_entity(SAMPLE_EVENTS)
+        assert "char-healer" in grouped
+        healer_events = grouped["char-healer"]
+        event_ids = {e["id"] for e in healer_events}
+        assert "evt-010" in event_ids
+
+    def test_sorts_events_by_turn_number(self):
+        grouped = group_events_by_entity(SAMPLE_EVENTS)
+        kael_events = grouped["char-kael"]
+        turns = []
+        for e in kael_events:
+            t = e.get("source_turns", [""])[0]
+            if t:
+                turns.append(int(t.split("-")[1]))
+        assert turns == sorted(turns), f"Kael events not sorted: {turns}"
+
+    def test_empty_events(self):
+        grouped = group_events_by_entity([])
+        assert grouped == {}
+
+    def test_event_without_related_entities(self):
+        events = [{"id": "evt-999", "source_turns": ["turn-001"],
+                    "type": "other", "description": "Orphan"}]
+        grouped = group_events_by_entity(events)
+        assert grouped == {}
+
+
+# ---------------------------------------------------------------------------
+# 2. Event-Derived Profile Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEventDerivedProfiles:
+    """Test event-derived entity profiles (Step 2)."""
+
+    def test_infer_name_from_id(self):
+        assert _infer_name_from_id("char-kael") == "Kael"
+        assert _infer_name_from_id("loc-the-settlement") == "The Settlement"
+        assert _infer_name_from_id("faction-quiet-weave") == "Quiet Weave"
+        assert _infer_name_from_id("item-arcane-fragment") == "Arcane Fragment"
+
+    def test_infer_type_from_prefix(self):
+        assert _infer_type_from_id("char-kael") == "character"
+        assert _infer_type_from_id("loc-settlement") == "location"
+        assert _infer_type_from_id("faction-tribe") == "faction"
+        assert _infer_type_from_id("item-sword") == "item"
+        assert _infer_type_from_id("npc-guard") == "character"
+        assert _infer_type_from_id("unknown-thing") == "unknown"
+
+    def test_counts_events_and_co_occurrences(self):
+        grouped = group_events_by_entity(SAMPLE_EVENTS)
+        kael_events = grouped["char-kael"]
+        profile = build_event_derived_profile("char-kael", kael_events)
+
+        assert profile["id"] == "char-kael"
+        assert profile["name"] == "Kael"
+        assert profile["type"] == "character"
+        assert profile["source"] == "events_only"
+        assert profile["event_count"] == len(kael_events)
+        assert "char-player" in profile["co_occurring_entities"]
+        assert isinstance(profile["event_types"], dict)
+
+    def test_single_event_entity(self):
+        events = [_make_event("evt-100", ["turn-050"], ["char-solo"], "encounter", "Solo event")]
+        grouped = group_events_by_entity(events)
+        solo_events = grouped["char-solo"]
+        profile = build_event_derived_profile("char-solo", solo_events)
+
+        assert profile["event_count"] == 1
+        assert profile["first_event_turn"] == "turn-050"
+        assert profile["last_event_turn"] == "turn-050"
+        assert profile["co_occurring_entities"] == []
+
+    def test_empty_events(self):
+        profile = build_event_derived_profile("char-nobody", [])
+        assert profile["event_count"] == 0
+        assert profile["first_event_turn"] == ""
+        assert profile["last_event_turn"] == ""
+
+    def test_event_types_counted(self):
+        events = [
+            _make_event("e1", ["turn-001"], ["char-x"], "decision"),
+            _make_event("e2", ["turn-002"], ["char-x"], "decision"),
+            _make_event("e3", ["turn-003"], ["char-x"], "encounter"),
+        ]
+        profile = build_event_derived_profile("char-x", events)
+        assert profile["event_types"] == {"decision": 2, "encounter": 1}
+
+
+# ---------------------------------------------------------------------------
+# 3. Phase Segmentation Tests
+# ---------------------------------------------------------------------------
+
+
+def _make_events_range(start, end, entity_id="char-player", etype="decision"):
+    """Generate a sequence of events over a turn range."""
+    events = []
+    for i, turn in enumerate(range(start, end + 1)):
+        events.append(_make_event(
+            f"evt-{i:03d}",
+            [f"turn-{turn:03d}"],
+            [entity_id],
+            etype,
+            f"Event at turn {turn}",
+        ))
+    return events
+
+
+class TestPhaseSegmentation:
+    """Test phase segmentation (Step 3)."""
+
+    def test_pc_many_events_produces_4_to_8_phases(self):
+        """PC with ~277 events should produce 4–8 phases."""
+        # Generate 277 events with some gaps
+        events = []
+        turn = 1
+        for i in range(277):
+            events.append(_make_event(
+                f"evt-{i:03d}",
+                [f"turn-{turn:03d}"],
+                ["char-player"],
+                "decision" if i % 3 != 0 else "encounter",
+                f"PC event {i}",
+            ))
+            # Add occasional gaps
+            if i in (40, 90, 140, 180, 220, 260):
+                turn += 15  # 15-turn gap
+            else:
+                turn += 1
+
+        phases = segment_phases(events, "character", "char-player")
+        assert 4 <= len(phases) <= 8, f"Expected 4–8 phases, got {len(phases)}"
+
+        # All events accounted for
+        total_events = sum(p["event_count"] for p in phases)
+        assert total_events == 277
+
+    def test_major_npc_15_events(self):
+        """NPC with 15 events → 2–4 phases."""
+        events = []
+        turns = [10, 15, 20, 25, 30,  # cluster 1
+                 80, 85, 90, 95, 100,  # cluster 2 (gap of 50)
+                 200, 205, 210, 215, 220]  # cluster 3 (gap of 100)
+        for i, t in enumerate(turns):
+            events.append(_make_event(
+                f"evt-{i:03d}",
+                [f"turn-{t:03d}"],
+                ["char-npc"],
+                "encounter",
+                f"NPC event {i}",
+            ))
+
+        phases = segment_phases(events, "character", "char-npc")
+        assert 2 <= len(phases) <= 4, f"Expected 2–4 phases, got {len(phases)}"
+
+    def test_minor_entity_single_phase(self):
+        """NPC with 5 events → 1 phase."""
+        events = _make_events_range(100, 104, "char-minor")
+        phases = segment_phases(events, "character", "char-minor")
+        assert len(phases) == 1
+        assert phases[0]["event_count"] == 5
+
+    def test_detects_gaps_as_phase_boundaries(self):
+        """Gaps of 10+ turns should create phase boundaries."""
+        events = []
+        # Cluster A: turns 1–10
+        events.extend(_make_events_range(1, 10, "char-test"))
+        # Gap: turns 10–30 (20-turn gap)
+        # Cluster B: turns 30–45
+        events.extend(_make_events_range(30, 45, "char-test"))
+
+        phases = segment_phases(events, "character", "char-test")
+        # Should be 2+ phases due to the gap
+        assert len(phases) >= 2
+
+    def test_single_turn_entity(self):
+        """Entity with a single event produces a single phase."""
+        events = [_make_event("evt-solo", ["turn-042"], ["char-one"], "encounter")]
+        phases = segment_phases(events, "character", "char-one")
+        assert len(phases) == 1
+        assert phases[0]["event_count"] == 1
+
+    def test_empty_events(self):
+        phases = segment_phases([], "character", "char-empty")
+        assert phases == []
+
+    def test_phase_structure(self):
+        """Each phase has the required fields."""
+        events = _make_events_range(1, 5, "char-struct")
+        phases = segment_phases(events, "character", "char-struct")
+        phase = phases[0]
+        assert "name" in phase
+        assert "turn_range" in phase
+        assert isinstance(phase["turn_range"], list)
+        assert len(phase["turn_range"]) == 2
+        assert "events" in phase
+        assert "event_count" in phase
+
+    def test_all_events_accounted_for(self):
+        """No events should be lost in segmentation."""
+        events = _make_events_range(1, 50, "char-player")
+        phases = segment_phases(events, "character", "char-player")
+        total = sum(p["event_count"] for p in phases)
+        assert total == 50
+
+
+# ---------------------------------------------------------------------------
+# 4. Relationship Merger Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRelationshipMerger:
+    """Test relationship history merger (Step 4)."""
+
+    def test_merges_same_target_entries(self):
+        """char-broad-figure and char-Kael and char-kael all resolve to char-kael."""
+        merged = merge_relationship_histories(SAMPLE_RELATIONSHIPS)
+        # char-broad-figure → char-kael, char-Kael → char-kael, char-kael → char-kael
+        assert "char-kael" in merged
+        # 2 from char-broad-figure + 4 from char-Kael + 5 from char-kael = 11
+        # minus turn-015 dedup (elder has it, not kael) = 11
+        kael_history = merged["char-kael"]
+        assert len(kael_history) == 11
+
+    def test_case_insensitive_target_matching(self):
+        """char-Elder and char-elder should merge."""
+        merged = merge_relationship_histories(SAMPLE_RELATIONSHIPS)
+        assert "char-elder" in merged
+        assert "char-Elder" not in merged
+
+    def test_deduplicates_same_turn_entries(self):
+        """Entries at the same turn should be deduplicated."""
+        # char-Elder has turn-015 and char-elder also has turn-015
+        merged = merge_relationship_histories(SAMPLE_RELATIONSHIPS)
+        elder_history = merged["char-elder"]
+        turn_015_entries = [e for e in elder_history if e["turn"] == "turn-015"]
+        assert len(turn_015_entries) == 1
+
+    def test_keeps_more_detailed_entry_on_dedup(self):
+        """When deduplicating, keep the entry with longer description."""
+        rels = [
+            {
+                "target_id": "char-test",
+                "history": [
+                    {"turn": "turn-010", "type": "social", "description": "short"},
+                    {"turn": "turn-020", "type": "social", "description": "unique"},
+                ],
+            },
+            {
+                "target_id": "char-test",
+                "history": [
+                    {"turn": "turn-010", "type": "social", "description": "much longer description here"},
+                ],
+            },
+        ]
+        merged = merge_relationship_histories(rels)
+        assert merged["char-test"][0]["description"] == "much longer description here"
+
+    def test_sorts_chronologically(self):
+        merged = merge_relationship_histories(SAMPLE_RELATIONSHIPS)
+        for target_id, history in merged.items():
+            turns = [int(e["turn"].split("-")[1]) for e in history]
+            assert turns == sorted(turns), f"{target_id} history not sorted"
+
+    def test_empty_relationships(self):
+        merged = merge_relationship_histories([])
+        assert merged == {}
+
+
+# ---------------------------------------------------------------------------
+# 5. Arc Chunking Tests (rule-based part)
+# ---------------------------------------------------------------------------
+
+
+class TestArcChunking:
+    """Test rule-based relationship arc chunking (Step 5, Phase A)."""
+
+    def test_chunks_by_type_transition(self):
+        history = [
+            {"turn": "turn-012", "type": "social", "description": "met"},
+            {"turn": "turn-020", "type": "social", "description": "worked together"},
+            {"turn": "turn-030", "type": "social", "description": "shared meal"},
+            {"turn": "turn-050", "type": "romantic", "description": "first kiss"},
+            {"turn": "turn-060", "type": "romantic", "description": "declared love"},
+        ]
+        chunks = chunk_relationship_arcs(history)
+        assert len(chunks) >= 2
+        assert chunks[0]["type"] == "social"
+        assert chunks[-1]["type"] == "romantic"
+
+    def test_clusters_same_type_within_20_turns(self):
+        history = [
+            {"turn": "turn-010", "type": "social", "description": "met"},
+            {"turn": "turn-015", "type": "social", "description": "talked"},
+            {"turn": "turn-020", "type": "social", "description": "helped"},
+            {"turn": "turn-025", "type": "social", "description": "bonded"},
+            # Gap of 50 turns, same type
+            {"turn": "turn-075", "type": "social", "description": "reunited"},
+            {"turn": "turn-080", "type": "social", "description": "worked again"},
+        ]
+        chunks = chunk_relationship_arcs(history)
+        # Should split into 2 chunks: turns 10-25 and turns 75-80
+        assert len(chunks) == 2
+        assert chunks[0]["turn_range"] == ["turn-010", "turn-025"]
+        assert chunks[1]["turn_range"] == ["turn-075", "turn-080"]
+
+    def test_skips_three_or_fewer_interactions(self):
+        history = [
+            {"turn": "turn-010", "type": "social", "description": "met"},
+            {"turn": "turn-020", "type": "social", "description": "talked"},
+            {"turn": "turn-030", "type": "social", "description": "helped"},
+        ]
+        chunks = chunk_relationship_arcs(history)
+        assert chunks == []
+
+    def test_skips_two_interactions(self):
+        history = [
+            {"turn": "turn-010", "type": "social", "description": "met"},
+            {"turn": "turn-020", "type": "social", "description": "talked"},
+        ]
+        chunks = chunk_relationship_arcs(history)
+        assert chunks == []
+
+    def test_skips_empty_history(self):
+        assert chunk_relationship_arcs([]) == []
+
+    def test_combined_type_and_temporal_splitting(self):
+        """Type change + temporal gap in another segment."""
+        history = [
+            {"turn": "turn-010", "type": "social", "description": "met"},
+            {"turn": "turn-015", "type": "social", "description": "talked"},
+            {"turn": "turn-020", "type": "romantic", "description": "kiss"},
+            {"turn": "turn-025", "type": "romantic", "description": "love"},
+            # Gap of 50 turns, same type
+            {"turn": "turn-080", "type": "romantic", "description": "reunion"},
+        ]
+        chunks = chunk_relationship_arcs(history)
+        # social chunk, romantic chunk (20-25), romantic chunk (80)
+        assert len(chunks) == 3
+
+    def test_fallback_arc_summaries(self):
+        chunks = [
+            {"turn_range": ["turn-010", "turn-030"], "type": "social", "entries": []},
+            {"turn_range": ["turn-050", "turn-080"], "type": "romantic", "entries": []},
+        ]
+        summaries = _fallback_arc_summaries(chunks)
+        assert len(summaries) == 2
+        assert summaries[0]["phase"] == "Phase 1"
+        assert summaries[1]["phase"] == "Phase 2"
+        assert summaries[0]["type"] == "social"
+        assert summaries[1]["type"] == "romantic"
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration: Arc Summarizer with Mock LLM
+# ---------------------------------------------------------------------------
+
+
+class MockLLMClient:
+    """Mock LLM client that returns predictable JSON responses."""
+
+    def __init__(self, response=None, should_fail=False):
+        self.response = response
+        self.should_fail = should_fail
+        self.calls = []
+
+    def extract_json(self, system_prompt, user_prompt, **kwargs):
+        self.calls.append({"system_prompt": system_prompt, "user_prompt": user_prompt})
+        if self.should_fail:
+            raise RuntimeError("Mock LLM failure")
+        if self.response is not None:
+            return self.response
+        # Default: return a wrapped array (simulating json_object mode)
+        return {
+            "phases": [
+                {
+                    "phase": "First Contact",
+                    "turn_range": ["turn-012", "turn-035"],
+                    "type": "social",
+                    "summary": "Initial encounters through shared labor.",
+                    "key_turns": ["turn-012"],
+                },
+                {
+                    "phase": "Growing Bond",
+                    "turn_range": ["turn-051", "turn-108"],
+                    "type": "romantic",
+                    "summary": "Friendship deepened into romance.",
+                    "key_turns": ["turn-078"],
+                },
+            ]
+        }
+
+
+class TestArcSummarizerIntegration:
+    """Integration tests for the full arc summarization pipeline."""
+
+    def test_full_pipeline_with_mock_llm(self):
+        """merge → chunk → LLM → parse → store produces valid output."""
+        mock_llm = MockLLMClient()
+        result = summarize_relationship_arcs(
+            source_id="char-player",
+            source_name="Fenouille",
+            relationships=SAMPLE_RELATIONSHIPS,
+            llm_client=mock_llm,
+        )
+
+        assert result["entity_id"] == "char-player"
+        assert "generated_at" in result
+        assert "arcs" in result
+
+        # char-kael should have arcs (11 merged interactions > 3 threshold)
+        if "char-kael" in result["arcs"]:
+            kael_arc = result["arcs"]["char-kael"]
+            assert "arc_summary" in kael_arc
+            assert "interaction_count" in kael_arc
+            assert kael_arc["interaction_count"] == 11
+
+    def test_graceful_fallback_on_llm_failure(self):
+        """When LLM fails, fall back to rule-based naming."""
+        mock_llm = MockLLMClient(should_fail=True)
+        result = summarize_relationship_arcs(
+            source_id="char-player",
+            source_name="Fenouille",
+            relationships=SAMPLE_RELATIONSHIPS,
+            llm_client=mock_llm,
+        )
+
+        # Should still produce output
+        assert result["entity_id"] == "char-player"
+        assert "arcs" in result
+
+        # Arcs should use fallback names
+        if "char-kael" in result["arcs"]:
+            kael_arc = result["arcs"]["char-kael"]
+            for phase in kael_arc["arc_summary"]:
+                assert phase["phase"].startswith("Phase ")
+
+    def test_no_llm_produces_fallback(self):
+        """Without LLM client, produces fallback arc summaries."""
+        result = summarize_relationship_arcs(
+            source_id="char-player",
+            source_name="Fenouille",
+            relationships=SAMPLE_RELATIONSHIPS,
+            llm_client=None,
+        )
+        assert result["entity_id"] == "char-player"
+        # Should still have arcs with fallback names
+        if "char-kael" in result["arcs"]:
+            for phase in result["arcs"]["char-kael"]["arc_summary"]:
+                assert phase["phase"].startswith("Phase ")
+
+    def test_sidecar_file_format(self):
+        """Sidecar file is valid JSON with correct structure."""
+        mock_llm = MockLLMClient()
+        arc_data = summarize_relationship_arcs(
+            source_id="char-player",
+            source_name="Fenouille",
+            relationships=SAMPLE_RELATIONSHIPS,
+            llm_client=mock_llm,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = write_arc_sidecar(arc_data, tmpdir)
+            assert os.path.basename(path) == "char-player.arcs.json"
+            with open(path, "r", encoding="utf-8") as f:
+                loaded = json.load(f)
+            assert loaded["entity_id"] == "char-player"
+            assert "arcs" in loaded
+            assert "generated_at" in loaded
+
+    def test_current_relationship_preserved(self):
+        """current_relationship from the latest relationship entry is preserved."""
+        result = summarize_relationship_arcs(
+            source_id="char-player",
+            source_name="Fenouille",
+            relationships=SAMPLE_RELATIONSHIPS,
+            llm_client=None,
+        )
+        if "char-kael" in result["arcs"]:
+            # The latest entry for char-kael has "Co-leader"
+            cur = result["arcs"]["char-kael"]["current_relationship"]
+            assert cur in ("Life partner", "Co-leader")
+
+    def test_skips_sparse_relationships(self):
+        """Relationships with ≤ 3 interactions are skipped."""
+        sparse_rels = [
+            {
+                "target_id": "char-stranger",
+                "current_relationship": "acquaintance",
+                "type": "social",
+                "history": [
+                    {"turn": "turn-100", "type": "social", "description": "met once"},
+                    {"turn": "turn-200", "type": "social", "description": "met twice"},
+                ],
+            },
+        ]
+        result = summarize_relationship_arcs(
+            source_id="char-player",
+            source_name="Fenouille",
+            relationships=sparse_rels,
+            llm_client=None,
+        )
+        assert "char-stranger" not in result["arcs"]
+
+
+# ---------------------------------------------------------------------------
+# 7. Load Events
+# ---------------------------------------------------------------------------
+
+
+class TestLoadEvents:
+    """Test events loading utility."""
+
+    def test_loads_valid_events(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cat_dir = os.path.join(tmpdir, "catalogs")
+            os.makedirs(cat_dir)
+            events = [
+                {"id": "evt-001", "source_turns": ["turn-001"], "type": "encounter",
+                 "description": "Test", "related_entities": ["char-player"]},
+            ]
+            with open(os.path.join(cat_dir, "events.json"), "w") as f:
+                json.dump(events, f)
+
+            loaded = load_events(tmpdir)
+            assert len(loaded) == 1
+            assert loaded[0]["id"] == "evt-001"
+
+    def test_returns_empty_on_missing_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            loaded = load_events(tmpdir)
+            assert loaded == []
+
+    def test_returns_empty_on_invalid_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cat_dir = os.path.join(tmpdir, "catalogs")
+            os.makedirs(cat_dir)
+            with open(os.path.join(cat_dir, "events.json"), "w") as f:
+                f.write("not valid json")
+            loaded = load_events(tmpdir)
+            assert loaded == []
+
+
+# ---------------------------------------------------------------------------
+# 8. Resolve Entity ID
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEntityId:
+    """Test the entity ID resolution function."""
+
+    def test_lowercase(self):
+        assert resolve_entity_id("char-Kael") == "char-kael"
+
+    def test_alias_broad_figure(self):
+        assert resolve_entity_id("char-broad-figure") == "char-kael"
+
+    def test_alias_faction_gorok(self):
+        assert resolve_entity_id("faction-warrior-chief-gorok") == "char-gorok"
+
+    def test_alias_ananya_variants(self):
+        assert resolve_entity_id("char-ananya") == "char-anya"
+        assert resolve_entity_id("char-anxa") == "char-anya"
+        assert resolve_entity_id("npc-ananya") == "char-anya"
+
+    def test_passthrough(self):
+        assert resolve_entity_id("char-player") == "char-player"
+
+    def test_empty_string(self):
+        assert resolve_entity_id("") == ""

--- a/tools/synthesis.py
+++ b/tools/synthesis.py
@@ -564,10 +564,10 @@ def _make_arc_chunk(entries: list[dict], rel_type: str) -> dict:
 def _build_arc_prompt(source_name: str, target_name: str, chunks: list[dict]) -> str:
     """Build the LLM prompt for arc naming and summarization."""
     lines = [
-        f"Given these interaction phases for the relationship between "
-        f"{source_name} and {target_name},",
-        "name each phase and write a 1-2 sentence summary. "
-        "Merge or split phases if the narrative warrants it.",
+        (f"Given these interaction phases for the relationship between "
+         f"{source_name} and {target_name},"),
+        ("name each phase and write a 1-2 sentence summary. "
+         "Merge or split phases if the narrative warrants it."),
         "",
     ]
     for i, chunk in enumerate(chunks, 1):

--- a/tools/synthesis.py
+++ b/tools/synthesis.py
@@ -1,0 +1,770 @@
+#!/usr/bin/env python3
+"""
+synthesis.py — Data assembly layer for wiki narrative synthesis.
+
+Provides the foundation components for transforming raw extraction data
+(events, entity catalogs, relationships) into structured inputs suitable
+for LLM-powered narrative generation.
+
+Components:
+  1. Event-entity grouping with ID alias resolution
+  2. Event-derived entity profiles for catalog-less entities
+  3. Phase segmentation for narrative biography generation
+  4. Relationship history merger (dedup + consolidate)
+  5. Relationship arc summarizer (rule-based chunking + LLM naming)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+
+# ---------------------------------------------------------------------------
+# ID Alias mapping — pragmatic bridge until #108 normalization
+# ---------------------------------------------------------------------------
+
+ID_ALIASES: dict[str, str] = {
+    "char-Kael": "char-kael",
+    "char-broad-figure": "char-kael",
+    "faction-warrior-chief-gorok": "char-gorok",
+    "char-ananya": "char-anya",
+    "char-anxa": "char-anya",
+    "npc-ananya": "char-anya",
+    "entity-healer": "char-healer",
+}
+
+# Build a case-insensitive version for quick lookup
+_ALIAS_LOWER: dict[str, str] = {k.lower(): v for k, v in ID_ALIASES.items()}
+
+# Prefix-to-type mapping
+_PREFIX_TYPE_MAP: dict[str, str] = {
+    "char": "character",
+    "npc": "character",
+    "loc": "location",
+    "faction": "faction",
+    "item": "item",
+    "creature": "creature",
+    "concept": "concept",
+    "entity": "unknown",
+}
+
+
+# ---------------------------------------------------------------------------
+# Turn-number helpers
+# ---------------------------------------------------------------------------
+
+def _parse_turn_number(turn_id: str) -> int:
+    """Extract numeric part from a turn ID like ``turn-078``.
+
+    Returns 0 if not parseable.
+    """
+    m = re.search(r"(\d+)", turn_id or "")
+    return int(m.group(1)) if m else 0
+
+
+def _sort_key_turn(turn_id: str) -> int:
+    return _parse_turn_number(turn_id)
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Event-Entity Grouping
+# ---------------------------------------------------------------------------
+
+def resolve_entity_id(raw_id: str) -> str:
+    """Resolve an entity ID through the alias table with case-insensitive matching.
+
+    If a ``normalize_entity_id`` function is available from catalog_merger,
+    that is preferred for full fuzzy matching. This function provides the
+    lightweight fallback described in design-synthesis-layer.md §4.2.
+    """
+    if not raw_id:
+        return raw_id
+    # Check alias table (case-insensitive)
+    lowered = raw_id.lower()
+    if lowered in _ALIAS_LOWER:
+        return _ALIAS_LOWER[lowered]
+    # Default: lowercase the ID
+    return lowered
+
+
+def group_events_by_entity(events: list[dict]) -> dict[str, list[dict]]:
+    """Group events by resolved entity ID.
+
+    For each event, iterates over ``related_entities`` and builds a mapping
+    from canonical entity ID to the list of events referencing that entity.
+    Each entity's events are sorted by ``source_turns[0]``.
+
+    Args:
+        events: List of event dicts (matching event.schema.json).
+
+    Returns:
+        Mapping of ``entity_id → [events]``, sorted by first source turn.
+    """
+    grouped: dict[str, list[dict]] = defaultdict(list)
+
+    for event in events:
+        related = event.get("related_entities", [])
+        for raw_id in related:
+            canonical = resolve_entity_id(raw_id)
+            grouped[canonical].append(event)
+
+    # Sort each entity's events by their first source turn
+    for entity_id in grouped:
+        grouped[entity_id].sort(
+            key=lambda e: _sort_key_turn(
+                e.get("source_turns", [""])[0] if e.get("source_turns") else ""
+            )
+        )
+
+    return dict(grouped)
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Event-Derived Entity Profiles
+# ---------------------------------------------------------------------------
+
+def _infer_name_from_id(entity_id: str) -> str:
+    """Infer a display name from an entity ID.
+
+    Strips the type prefix, replaces hyphens with spaces, and title-cases.
+    ``"char-kael"`` → ``"Kael"``
+    ``"loc-the-settlement"`` → ``"The Settlement"``
+    """
+    # Remove known prefixes
+    for prefix in ("char-", "npc-", "loc-", "faction-", "item-",
+                   "creature-", "concept-", "entity-"):
+        if entity_id.startswith(prefix):
+            stem = entity_id[len(prefix):]
+            return stem.replace("-", " ").title()
+    # Fallback: just title-case the whole thing
+    return entity_id.replace("-", " ").title()
+
+
+def _infer_type_from_id(entity_id: str) -> str:
+    """Infer entity type from the ID prefix.
+
+    ``"char-kael"`` → ``"character"``
+    ``"loc-settlement"`` → ``"location"``
+    """
+    for prefix, entity_type in _PREFIX_TYPE_MAP.items():
+        if entity_id.startswith(prefix + "-"):
+            return entity_type
+    return "unknown"
+
+
+def _extract_co_occurrences(entity_id: str, events: list[dict]) -> list[str]:
+    """Collect all other resolved entity IDs that appear in the same events."""
+    co_ids: set[str] = set()
+    for event in events:
+        for raw_id in event.get("related_entities", []):
+            canonical = resolve_entity_id(raw_id)
+            if canonical != entity_id:
+                co_ids.add(canonical)
+    return sorted(co_ids)
+
+
+def _count_event_types(events: list[dict]) -> dict[str, int]:
+    """Count events by their ``type`` field."""
+    counter: Counter[str] = Counter()
+    for event in events:
+        counter[event.get("type", "other")] += 1
+    return dict(counter)
+
+
+def build_event_derived_profile(entity_id: str, events: list[dict]) -> dict:
+    """Build a minimal entity profile from event data alone.
+
+    For entities that exist in events but have no catalog JSON file.
+
+    Args:
+        entity_id: The canonical entity ID.
+        events: List of events referencing this entity (pre-sorted).
+
+    Returns:
+        A derived profile dict.
+    """
+    first_turn = ""
+    last_turn = ""
+    if events:
+        first_turns = events[0].get("source_turns", [])
+        last_turns = events[-1].get("source_turns", [])
+        first_turn = first_turns[0] if first_turns else ""
+        last_turn = last_turns[0] if last_turns else ""
+
+    return {
+        "id": entity_id,
+        "name": _infer_name_from_id(entity_id),
+        "type": _infer_type_from_id(entity_id),
+        "source": "events_only",
+        "first_event_turn": first_turn,
+        "last_event_turn": last_turn,
+        "event_count": len(events),
+        "co_occurring_entities": _extract_co_occurrences(entity_id, events),
+        "event_types": _count_event_types(events),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Phase Segmentation
+# ---------------------------------------------------------------------------
+
+def segment_phases(events: list[dict], entity_type: str, entity_id: str) -> list[dict]:
+    """Divide an entity's event timeline into narrative phases.
+
+    Rules (from design-synthesis-layer.md §3.3):
+      - PC (char-player): Target 4–8 phases using gap/density detection, fallback
+        to equal chunks of ~40 events.
+      - Major NPCs (10+ events): 2–4 phases, split at largest event gaps.
+      - Minor entities (<10 events): Single phase, no segmentation.
+
+    Args:
+        events: Sorted list of events for this entity.
+        entity_type: ``"character"``, ``"location"``, etc.
+        entity_id: The entity's canonical ID (used to detect PC).
+
+    Returns:
+        List of phase dicts with ``name``, ``turn_range``, ``events``, ``event_count``.
+    """
+    if not events:
+        return []
+
+    # Minor entities or non-characters with few events: single phase
+    if len(events) < 10:
+        return [_make_phase(events)]
+
+    is_pc = entity_id == "char-player"
+
+    if is_pc:
+        return _segment_pc_phases(events)
+    else:
+        return _segment_npc_phases(events)
+
+
+def _get_event_turn(event: dict) -> str:
+    """Get the first source turn from an event."""
+    turns = event.get("source_turns", [])
+    return turns[0] if turns else ""
+
+
+def _make_phase(events: list[dict], name: str | None = None) -> dict:
+    """Create a phase dict from a list of events."""
+    first_turn = _get_event_turn(events[0]) if events else ""
+    last_turn = _get_event_turn(events[-1]) if events else ""
+    return {
+        "name": name,
+        "turn_range": [first_turn, last_turn],
+        "events": events,
+        "event_count": len(events),
+    }
+
+
+def _find_gap_indices(events: list[dict], min_gap: int = 10) -> list[tuple[int, int]]:
+    """Find indices where there are gaps of min_gap+ turns between consecutive events.
+
+    Returns list of ``(index, gap_size)`` — the gap is between events[index] and events[index+1].
+    """
+    gaps: list[tuple[int, int]] = []
+    for i in range(len(events) - 1):
+        t1 = _parse_turn_number(_get_event_turn(events[i]))
+        t2 = _parse_turn_number(_get_event_turn(events[i + 1]))
+        gap = t2 - t1
+        if gap >= min_gap:
+            gaps.append((i, gap))
+    return gaps
+
+
+def _detect_type_shift_indices(events: list[dict]) -> list[int]:
+    """Find indices where the dominant event type changes.
+
+    Looks at rolling windows of 5 events and detects shifts in the most
+    common event type.
+    """
+    if len(events) < 10:
+        return []
+
+    shifts: list[int] = []
+    window = 5
+    prev_dominant = None
+
+    for i in range(0, len(events) - window + 1, window):
+        chunk = events[i : i + window]
+        types = [e.get("type", "other") for e in chunk]
+        dominant = Counter(types).most_common(1)[0][0]
+        if prev_dominant is not None and dominant != prev_dominant:
+            shifts.append(i)
+        prev_dominant = dominant
+
+    return shifts
+
+
+def _segment_pc_phases(events: list[dict]) -> list[dict]:
+    """Segment PC events into 4–8 narrative phases."""
+    # Collect potential breakpoints from gap detection and type shifts
+    gap_indices = _find_gap_indices(events, min_gap=10)
+    type_shifts = _detect_type_shift_indices(events)
+
+    # Combine breakpoint candidates (index after which to split)
+    # Gap indices are the split-after points; type shifts are split-at points
+    breakpoints: set[int] = set()
+    for idx, _gap in gap_indices:
+        breakpoints.add(idx + 1)  # Split after this event
+    for idx in type_shifts:
+        breakpoints.add(idx)
+
+    sorted_bps = sorted(breakpoints)
+
+    if sorted_bps:
+        # Filter breakpoints to get 4–8 phases
+        phases = _split_at_breakpoints(events, sorted_bps, target_min=4, target_max=8)
+    else:
+        # Fallback: equal chunks of ~40 events
+        phases = _split_equal_chunks(events, chunk_size=40)
+
+    # Ensure we're in the 4–8 range
+    if len(phases) < 4:
+        # Not enough natural breakpoints; fallback to equal chunks
+        phases = _split_equal_chunks(events, chunk_size=max(1, len(events) // 6))
+    elif len(phases) > 8:
+        # Too many breakpoints; merge smallest adjacent phases
+        phases = _merge_to_target(phases, target=7)
+
+    return phases
+
+
+def _segment_npc_phases(events: list[dict]) -> list[dict]:
+    """Segment major NPC events into 2–4 phases."""
+    gap_indices = _find_gap_indices(events, min_gap=10)
+
+    if not gap_indices:
+        # No large gaps: split in half or keep as one
+        if len(events) >= 20:
+            mid = len(events) // 2
+            return [
+                _make_phase(events[:mid]),
+                _make_phase(events[mid:]),
+            ]
+        return [_make_phase(events)]
+
+    # Sort gaps by size (largest first) and use the top 1–3
+    gap_indices.sort(key=lambda x: x[1], reverse=True)
+    split_points = sorted([idx + 1 for idx, _gap in gap_indices[:3]])
+
+    phases = _split_at_breakpoints(events, split_points, target_min=2, target_max=4)
+
+    if len(phases) > 4:
+        phases = _merge_to_target(phases, target=3)
+
+    return phases
+
+
+def _split_at_breakpoints(
+    events: list[dict],
+    breakpoints: list[int],
+    target_min: int,
+    target_max: int,
+) -> list[dict]:
+    """Split events at the given breakpoint indices into phases."""
+    # Filter breakpoints that are within bounds
+    valid_bps = [bp for bp in breakpoints if 0 < bp < len(events)]
+
+    if not valid_bps:
+        return [_make_phase(events)]
+
+    # If too many breakpoints, select evenly spaced ones
+    if len(valid_bps) + 1 > target_max:
+        # Pick breakpoints that create the most evenly sized phases
+        step = len(valid_bps) / (target_max - 1)
+        selected = []
+        for i in range(target_max - 1):
+            idx = int(i * step)
+            if idx < len(valid_bps):
+                selected.append(valid_bps[idx])
+        valid_bps = selected
+
+    phases: list[dict] = []
+    prev = 0
+    for bp in valid_bps:
+        if bp > prev:
+            phases.append(_make_phase(events[prev:bp]))
+        prev = bp
+    if prev < len(events):
+        phases.append(_make_phase(events[prev:]))
+
+    return phases
+
+
+def _split_equal_chunks(events: list[dict], chunk_size: int) -> list[dict]:
+    """Split events into roughly equal chunks."""
+    if chunk_size <= 0:
+        chunk_size = 1
+    phases: list[dict] = []
+    for i in range(0, len(events), chunk_size):
+        chunk = events[i : i + chunk_size]
+        if chunk:
+            phases.append(_make_phase(chunk))
+    return phases
+
+
+def _merge_to_target(phases: list[dict], target: int) -> list[dict]:
+    """Merge the smallest adjacent phases until we reach the target count."""
+    while len(phases) > target:
+        # Find the pair of adjacent phases with the smallest combined event count
+        min_combined = float("inf")
+        min_idx = 0
+        for i in range(len(phases) - 1):
+            combined = phases[i]["event_count"] + phases[i + 1]["event_count"]
+            if combined < min_combined:
+                min_combined = combined
+                min_idx = i
+
+        # Merge phases[min_idx] and phases[min_idx + 1]
+        merged_events = phases[min_idx]["events"] + phases[min_idx + 1]["events"]
+        merged = _make_phase(merged_events)
+        phases = phases[:min_idx] + [merged] + phases[min_idx + 2 :]
+
+    return phases
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Relationship History Merger
+# ---------------------------------------------------------------------------
+
+def merge_relationship_histories(relationships: list[dict]) -> dict[str, list[dict]]:
+    """Merge all relationship entries for the same target_id into unified timelines.
+
+    Handles:
+      - Case-insensitive target_id matching
+      - ID alias resolution
+      - Chronological sorting by turn number
+      - Deduplication of entries at the same turn
+
+    Args:
+        relationships: List of relationship dicts from an entity's catalog entry.
+            Each has ``target_id``, ``history`` (list of dicts with ``turn``, ``type``,
+            ``description``), and other relationship metadata.
+
+    Returns:
+        Mapping of ``canonical_target_id → merged_sorted_history``.
+    """
+    grouped: dict[str, list[dict]] = defaultdict(list)
+
+    for rel in relationships:
+        raw_target = rel.get("target_id", "")
+        canonical = resolve_entity_id(raw_target)
+        history = rel.get("history", [])
+        grouped[canonical].extend(history)
+
+    result: dict[str, list[dict]] = {}
+    for target_id, entries in grouped.items():
+        # Sort by turn number
+        entries.sort(key=lambda e: _parse_turn_number(e.get("turn", "")))
+        # Deduplicate: keep the entry with more detail at the same turn
+        deduped = _deduplicate_history(entries)
+        result[target_id] = deduped
+
+    return result
+
+
+def _deduplicate_history(entries: list[dict]) -> list[dict]:
+    """Remove duplicate entries at the same turn, keeping the one with more detail."""
+    seen: dict[str, dict] = {}  # turn → best entry
+    for entry in entries:
+        turn = entry.get("turn", "")
+        if turn not in seen:
+            seen[turn] = entry
+        else:
+            existing = seen[turn]
+            # Keep the entry with the longer description
+            existing_desc = existing.get("description", "")
+            new_desc = entry.get("description", "")
+            if len(new_desc) > len(existing_desc):
+                seen[turn] = entry
+    # Return in turn order
+    result = list(seen.values())
+    result.sort(key=lambda e: _parse_turn_number(e.get("turn", "")))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Step 5: Relationship Arc Summarizer
+# ---------------------------------------------------------------------------
+
+def chunk_relationship_arcs(history: list[dict]) -> list[dict]:
+    """Rule-based chunking: Phase A of the arc summarizer.
+
+    Groups history entries by:
+      1. Type field transitions (when ``type`` changes, start a new chunk)
+      2. Within same type, clustering entries within 20 turns of each other
+
+    Args:
+        history: Merged, sorted relationship history.
+
+    Returns:
+        List of chunk dicts, each with ``turn_range``, ``type``, ``entries``.
+        Returns empty list if history has ≤ 3 entries (too little data).
+    """
+    if len(history) <= 3:
+        return []
+
+    chunks: list[dict] = []
+    current_chunk_entries: list[dict] = []
+    current_type: str | None = None
+
+    for entry in history:
+        entry_type = entry.get("type", "other")
+        entry_turn = _parse_turn_number(entry.get("turn", ""))
+
+        if current_type is None:
+            # First entry
+            current_type = entry_type
+            current_chunk_entries = [entry]
+            continue
+
+        # Check for type transition
+        if entry_type != current_type:
+            # Save current chunk and start new one
+            chunks.append(_make_arc_chunk(current_chunk_entries, current_type))
+            current_type = entry_type
+            current_chunk_entries = [entry]
+            continue
+
+        # Same type: check temporal proximity (within 20 turns)
+        last_turn = _parse_turn_number(
+            current_chunk_entries[-1].get("turn", "")
+        )
+        if entry_turn - last_turn > 20:
+            # Gap too large, start new chunk even though type is same
+            chunks.append(_make_arc_chunk(current_chunk_entries, current_type))
+            current_chunk_entries = [entry]
+            continue
+
+        current_chunk_entries.append(entry)
+
+    # Don't forget the last chunk
+    if current_chunk_entries:
+        chunks.append(_make_arc_chunk(current_chunk_entries, current_type or "other"))
+
+    return chunks
+
+
+def _make_arc_chunk(entries: list[dict], rel_type: str) -> dict:
+    """Create an arc chunk dict from history entries."""
+    first_turn = entries[0].get("turn", "") if entries else ""
+    last_turn = entries[-1].get("turn", "") if entries else ""
+    return {
+        "turn_range": [first_turn, last_turn],
+        "type": rel_type,
+        "entries": entries,
+    }
+
+
+def _build_arc_prompt(source_name: str, target_name: str, chunks: list[dict]) -> str:
+    """Build the LLM prompt for arc naming and summarization."""
+    lines = [
+        f"Given these interaction phases for the relationship between "
+        f"{source_name} and {target_name},",
+        "name each phase and write a 1-2 sentence summary. "
+        "Merge or split phases if the narrative warrants it.",
+        "",
+    ]
+    for i, chunk in enumerate(chunks, 1):
+        start = chunk["turn_range"][0]
+        end = chunk["turn_range"][1]
+        rel_type = chunk["type"]
+        lines.append(f"Phase {i} (turns {start}-{end}, type: {rel_type}):")
+        for entry in chunk["entries"]:
+            turn = entry.get("turn", "?")
+            desc = entry.get("description", "")
+            lines.append(f"  - {turn}: {desc}")
+        lines.append("")
+
+    lines.append("Respond with JSON:")
+    lines.append('[')
+    lines.append(
+        '  {"phase": "Phase Name", "turn_range": ["turn-NNN", "turn-NNN"], '
+        '"type": "...", "summary": "...", "key_turns": ["turn-NNN"]}'
+    )
+    lines.append(']')
+
+    return "\n".join(lines)
+
+
+def _fallback_arc_summaries(chunks: list[dict]) -> list[dict]:
+    """Generate fallback arc summaries when LLM is unavailable or fails."""
+    summaries = []
+    for i, chunk in enumerate(chunks, 1):
+        summaries.append({
+            "phase": f"Phase {i}",
+            "turn_range": chunk["turn_range"],
+            "type": chunk["type"],
+            "summary": "",
+            "key_turns": [chunk["turn_range"][0]],
+        })
+    return summaries
+
+
+def summarize_relationship_arcs(
+    source_id: str,
+    source_name: str,
+    relationships: list[dict],
+    llm_client: object | None = None,
+) -> dict:
+    """Full arc summarization pipeline: merge → chunk → LLM → parse → store format.
+
+    Args:
+        source_id: The entity ID of the relationship source.
+        source_name: Display name of the source entity.
+        relationships: List of relationship dicts from the entity's catalog.
+        llm_client: An LLMClient instance (from tools/llm_client.py).
+            If None, only rule-based chunking is performed.
+
+    Returns:
+        Dict in the sidecar format::
+
+            {
+                "entity_id": "char-player",
+                "generated_at": "...",
+                "arcs": {
+                    "target-id": {
+                        "arc_summary": [...],
+                        "current_relationship": "...",
+                        "interaction_count": N
+                    }
+                }
+            }
+    """
+    merged = merge_relationship_histories(relationships)
+
+    # Build a lookup for current_relationship from the original relationship entries
+    current_rel_lookup: dict[str, str] = {}
+    for rel in relationships:
+        canonical = resolve_entity_id(rel.get("target_id", ""))
+        cur_rel = rel.get("current_relationship", "")
+        if cur_rel:
+            current_rel_lookup[canonical] = cur_rel
+
+    arcs: dict[str, dict] = {}
+
+    for target_id, history in merged.items():
+        chunks = chunk_relationship_arcs(history)
+
+        if not chunks:
+            # Too few interactions, skip
+            continue
+
+        target_name = _infer_name_from_id(target_id)
+
+        arc_summary: list[dict]
+        if llm_client is not None:
+            arc_summary = _llm_summarize_arcs(
+                llm_client, source_name, target_name, chunks
+            )
+        else:
+            arc_summary = _fallback_arc_summaries(chunks)
+
+        arcs[target_id] = {
+            "arc_summary": arc_summary,
+            "current_relationship": current_rel_lookup.get(target_id, ""),
+            "interaction_count": len(history),
+        }
+
+    return {
+        "entity_id": source_id,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "arcs": arcs,
+    }
+
+
+def _llm_summarize_arcs(
+    llm_client: object,
+    source_name: str,
+    target_name: str,
+    chunks: list[dict],
+) -> list[dict]:
+    """Call the LLM to name and summarize relationship arc chunks.
+
+    Falls back to rule-based naming on parse failure.
+    """
+    prompt = _build_arc_prompt(source_name, target_name, chunks)
+
+    system_prompt = (
+        "You are a narrative analyst for an RPG campaign wiki. "
+        "Given interaction phases between two characters, name each phase "
+        "and write a 1-2 sentence summary. Respond with a JSON array only."
+    )
+
+    try:
+        # llm_client.extract_json returns parsed JSON
+        result = llm_client.extract_json(  # type: ignore[union-attr]
+            system_prompt=system_prompt,
+            user_prompt=prompt,
+        )
+        # extract_json returns a dict (due to json_object mode), but we
+        # expect an array. It may be wrapped in a key.
+        if isinstance(result, dict):
+            # Try common wrapper keys
+            for key in ("phases", "arcs", "arc_summary", "result", "data"):
+                if key in result and isinstance(result[key], list):
+                    return result[key]
+            # If the dict contains a single list value, use it
+            for v in result.values():
+                if isinstance(v, list):
+                    return v
+            return _fallback_arc_summaries(chunks)
+        if isinstance(result, list):
+            return result
+        return _fallback_arc_summaries(chunks)
+    except Exception:
+        return _fallback_arc_summaries(chunks)
+
+
+# ---------------------------------------------------------------------------
+# Sidecar I/O
+# ---------------------------------------------------------------------------
+
+def write_arc_sidecar(arc_data: dict, output_dir: str) -> str:
+    """Write arc summaries to a ``{entity_id}.arcs.json`` sidecar file.
+
+    Args:
+        arc_data: The dict returned by ``summarize_relationship_arcs()``.
+        output_dir: Directory to write the file into (e.g. the entity's
+            catalog type directory).
+
+    Returns:
+        The path of the written file.
+    """
+    entity_id = arc_data.get("entity_id", "unknown")
+    filename = f"{entity_id}.arcs.json"
+    filepath = os.path.join(output_dir, filename)
+
+    os.makedirs(output_dir, exist_ok=True)
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(arc_data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+    return filepath
+
+
+def load_events(framework_dir: str) -> list[dict]:
+    """Load events.json from the framework catalogs directory.
+
+    Args:
+        framework_dir: Path to the framework directory (e.g., ``framework/``).
+
+    Returns:
+        List of event dicts. Empty list if file not found or invalid.
+    """
+    events_path = os.path.join(framework_dir, "catalogs", "events.json")
+    if not os.path.isfile(events_path):
+        return []
+    try:
+        with open(events_path, "r", encoding="utf-8-sig") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            return data
+        return []
+    except (json.JSONDecodeError, OSError):
+        return []

--- a/tools/synthesis.py
+++ b/tools/synthesis.py
@@ -76,9 +76,9 @@ def _sort_key_turn(turn_id: str) -> int:
 def resolve_entity_id(raw_id: str) -> str:
     """Resolve an entity ID through the alias table with case-insensitive matching.
 
-    If a ``normalize_entity_id`` function is available from catalog_merger,
-    that is preferred for full fuzzy matching. This function provides the
-    lightweight fallback described in design-synthesis-layer.md §4.2.
+    This is a lightweight fallback described in design-synthesis-layer.md §4.2.
+    For full fuzzy matching (Levenshtein, token overlap), use
+    ``catalog_merger.normalize_entity_id()`` directly.
     """
     if not raw_id:
         return raw_id
@@ -211,7 +211,7 @@ def build_event_derived_profile(entity_id: str, events: list[dict]) -> dict:
 # Step 3: Phase Segmentation
 # ---------------------------------------------------------------------------
 
-def segment_phases(events: list[dict], entity_type: str, entity_id: str) -> list[dict]:
+def segment_phases(events: list[dict], entity_id: str) -> list[dict]:
     """Divide an entity's event timeline into narrative phases.
 
     Rules (from design-synthesis-layer.md §3.3):
@@ -222,7 +222,6 @@ def segment_phases(events: list[dict], entity_type: str, entity_id: str) -> list
 
     Args:
         events: Sorted list of events for this entity.
-        entity_type: ``"character"``, ``"location"``, etc.
         entity_id: The entity's canonical ID (used to detect PC).
 
     Returns:
@@ -438,24 +437,47 @@ def merge_relationship_histories(relationships: list[dict]) -> dict[str, list[di
     Handles:
       - Case-insensitive target_id matching
       - ID alias resolution
+      - Enriching history entries with the parent relationship ``type``
+        (V2 schema history items are ``{turn, description}`` only)
+      - Synthesizing a "current" entry from ``current_relationship`` /
+        ``last_updated_turn`` so the timeline reflects the present state
       - Chronological sorting by turn number
       - Deduplication of entries at the same turn
 
     Args:
         relationships: List of relationship dicts from an entity's catalog entry.
-            Each has ``target_id``, ``history`` (list of dicts with ``turn``, ``type``,
+            Each has ``target_id``, ``history`` (list of dicts with ``turn``,
             ``description``), and other relationship metadata.
 
     Returns:
         Mapping of ``canonical_target_id → merged_sorted_history``.
+        Each history entry is enriched with a ``type`` field derived from
+        the parent relationship object.
     """
     grouped: dict[str, list[dict]] = defaultdict(list)
 
     for rel in relationships:
         raw_target = rel.get("target_id", "")
         canonical = resolve_entity_id(raw_target)
+        parent_type = rel.get("type", "other")
         history = rel.get("history", [])
-        grouped[canonical].extend(history)
+        # Enrich each history entry with the parent relationship type
+        # (V2 schema history items only have {turn, description})
+        for entry in history:
+            enriched = dict(entry)
+            if "type" not in enriched:
+                enriched["type"] = parent_type
+            grouped[canonical].append(enriched)
+        # Synthesize a "current" entry so the timeline includes the
+        # present state (current_relationship lives outside history)
+        cur_rel = rel.get("current_relationship", "")
+        last_turn = rel.get("last_updated_turn", "")
+        if cur_rel and last_turn:
+            grouped[canonical].append({
+                "turn": last_turn,
+                "type": parent_type,
+                "description": cur_rel,
+            })
 
     result: dict[str, list[dict]] = {}
     for target_id, entries in grouped.items():
@@ -499,8 +521,13 @@ def chunk_relationship_arcs(history: list[dict]) -> list[dict]:
       1. Type field transitions (when ``type`` changes, start a new chunk)
       2. Within same type, clustering entries within 20 turns of each other
 
+    The ``type`` field on each entry is expected to be set by
+    ``merge_relationship_histories()``, which enriches V2 schema history
+    items (originally ``{turn, description}`` only) with the parent
+    relationship's ``type``.
+
     Args:
-        history: Merged, sorted relationship history.
+        history: Merged, sorted, type-enriched relationship history.
 
     Returns:
         List of chunk dicts, each with ``turn_range``, ``type``, ``entries``.
@@ -581,13 +608,15 @@ def _build_arc_prompt(source_name: str, target_name: str, chunks: list[dict]) ->
             lines.append(f"  - {turn}: {desc}")
         lines.append("")
 
-    lines.append("Respond with JSON:")
-    lines.append('[')
+    lines.append('Respond with a JSON object containing a "phases" key:')
+    lines.append('{')
+    lines.append('  "phases": [')
     lines.append(
-        '  {"phase": "Phase Name", "turn_range": ["turn-NNN", "turn-NNN"], '
+        '    {"phase": "Phase Name", "turn_range": ["turn-NNN", "turn-NNN"], '
         '"type": "...", "summary": "...", "key_turns": ["turn-NNN"]}'
     )
-    lines.append(']')
+    lines.append('  ]')
+    lines.append('}')
 
     return "\n".join(lines)
 
@@ -638,13 +667,19 @@ def summarize_relationship_arcs(
     """
     merged = merge_relationship_histories(relationships)
 
-    # Build a lookup for current_relationship from the original relationship entries
+    # Build a lookup for current_relationship, preferring the entry with
+    # the latest last_updated_turn for each canonical target.
     current_rel_lookup: dict[str, str] = {}
+    _current_rel_turn: dict[str, int] = {}  # track latest turn per target
     for rel in relationships:
         canonical = resolve_entity_id(rel.get("target_id", ""))
         cur_rel = rel.get("current_relationship", "")
-        if cur_rel:
+        if not cur_rel:
+            continue
+        turn_num = _parse_turn_number(rel.get("last_updated_turn", ""))
+        if canonical not in _current_rel_turn or turn_num > _current_rel_turn[canonical]:
             current_rel_lookup[canonical] = cur_rel
+            _current_rel_turn[canonical] = turn_num
 
     arcs: dict[str, dict] = {}
 
@@ -693,7 +728,8 @@ def _llm_summarize_arcs(
     system_prompt = (
         "You are a narrative analyst for an RPG campaign wiki. "
         "Given interaction phases between two characters, name each phase "
-        "and write a 1-2 sentence summary. Respond with a JSON array only."
+        "and write a 1-2 sentence summary. Respond with a JSON object "
+        'containing a "phases" key whose value is the array of phases.'
     )
 
     try:


### PR DESCRIPTION
## Summary

Builds the data assembly layer for wiki narrative synthesis, completing #109 (relationship arc
summarization) and establishing the foundation for #110 (narrative wiki synthesis).

## Relationship Arc Summarization (#109)

- Relationship history merger: consolidates duplicate relationship entries per target
- Rule-based chunking: groups interactions by type transitions and temporal proximity
- LLM arc summarizer: names phases and generates narrative summaries
- Arc sidecar files: `.arcs.json` alongside entity JSONs

## Synthesis Data Foundation (partial #110)

- Event-entity grouping with case-insensitive matching and ID aliases
- Event-derived entity profiles for entities without catalog entries
- Phase segmentation algorithm for narrative generation
- All components unit-tested with fixture data

Closes #109
