### PR TITLE
feat: add LLM narrative wiki synthesis pipeline

### DIFF
--- a/tests/test_narrative_synthesis.py
+++ b/tests/test_narrative_synthesis.py
@@ -36,7 +36,7 @@ from narrative_synthesis import (
     _build_current_status,
 )
 
-from synthesis import ID_ALIASES, segment_phases
+from synthesis import ID_ALIASES
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/test_narrative_synthesis.py
+++ b/tests/test_narrative_synthesis.py
@@ -36,7 +36,7 @@ from narrative_synthesis import (
     _build_current_status,
 )
 
-from synthesis import ID_ALIASES
+from narrative_synthesis import _collect_critical_turns
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -179,7 +179,7 @@ class TestInputAssembly:
 
         result = assemble_synthesis_input(
             "char-player", phase, SAMPLE_CATALOG,
-            SAMPLE_ARC_SUMMARIES, ID_ALIASES)
+            SAMPLE_ARC_SUMMARIES)
 
         assert "system_prompt" in result
         assert "user_prompt" in result
@@ -208,7 +208,7 @@ class TestInputAssembly:
         }
 
         result = assemble_synthesis_input(
-            "char-kael", phase, None, None, ID_ALIASES)
+            "char-kael", phase, None, None)
 
         prompt = result["user_prompt"]
         assert "No catalog entry exists" in prompt
@@ -226,7 +226,7 @@ class TestInputAssembly:
         }
 
         result = assemble_synthesis_input(
-            "char-elder", phase, None, None, ID_ALIASES)
+            "char-elder", phase, None, None)
 
         assert len(result["events_used"]) == 5
 
@@ -240,7 +240,7 @@ class TestInputAssembly:
         }
 
         result = assemble_synthesis_input(
-            "char-player", phase, SAMPLE_CATALOG, None, ID_ALIASES)
+            "char-player", phase, SAMPLE_CATALOG, None)
 
         assert "turn-001" in result["available_turns"]
         assert "turn-005" in result["available_turns"]
@@ -293,13 +293,13 @@ class TestFormatHelpers:
         assert "No catalog entry exists" in text
 
     def test_format_arc_section_present(self):
-        text = _format_arc_section(SAMPLE_ARC_SUMMARIES, "char-player")
+        text = _format_arc_section(SAMPLE_ARC_SUMMARIES)
         assert "Kael" in text
         assert "Early Bond" in text
         assert "Partner" in text
 
     def test_format_arc_section_absent(self):
-        text = _format_arc_section(None, "char-player")
+        text = _format_arc_section(None)
         assert "No relationship arc summaries" in text
 
 
@@ -351,6 +351,27 @@ class TestProvenanceValidation:
         assert "⚠️" in result
         assert "char-test.synthesis.json" in result
         assert result.endswith("Content.")
+
+    def test_collect_critical_turns(self):
+        """Critical turns extracted from birth/decision/ritual events."""
+        events = [
+            _make_event("e1", ["turn-001"], ["char-player"], "encounter", "Walk"),
+            _make_event("e2", ["turn-015"], ["char-player"], "ritual", "Accepted"),
+            _make_event("e3", ["turn-050"], ["char-player"], "encounter", "Chat"),
+            _make_event("e4", ["turn-141"], ["char-player"], "birth", "Baby born"),
+        ]
+        turns = _collect_critical_turns(events)
+        assert "turn-015" in turns  # ritual is critical
+        assert "turn-141" in turns  # birth is critical
+        assert "turn-001" not in turns  # encounter is not critical
+        assert "turn-050" not in turns  # encounter is not critical
+
+    def test_collect_critical_turns_empty(self):
+        """No critical turns when all events are non-critical type."""
+        events = [
+            _make_event("e1", ["turn-001"], ["char-player"], "encounter", "Walk"),
+        ]
+        assert _collect_critical_turns(events) == []
 
 
 # ---------------------------------------------------------------------------
@@ -541,7 +562,7 @@ class TestBiographyGeneration:
             "event_count": 3,
         }
         synth_input = assemble_synthesis_input(
-            "char-player", phase, SAMPLE_CATALOG, None, ID_ALIASES)
+            "char-player", phase, SAMPLE_CATALOG, None)
 
         text, meta = generate_phase_biography(llm, synth_input)
 

--- a/tests/test_narrative_synthesis.py
+++ b/tests/test_narrative_synthesis.py
@@ -1,0 +1,863 @@
+"""Tests for the LLM narrative synthesis pipeline (tools/narrative_synthesis.py)."""
+
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from narrative_synthesis import (
+    assemble_synthesis_input,
+    assemble_lede_input,
+    assemble_location_input,
+    assemble_faction_input,
+    assemble_item_input,
+    assemble_character_page,
+    assemble_location_page,
+    assemble_faction_page,
+    assemble_item_page,
+    extract_cited_turns,
+    validate_provenance,
+    add_provenance_warning,
+    build_synthesis_sidecar,
+    write_synthesis_sidecar,
+    load_synthesis_sidecar,
+    should_synthesize,
+    generate_phase_biography,
+    generate_lede,
+    synthesize_entity,
+    needs_regeneration,
+    _format_events_for_prompt,
+    _format_catalog_section,
+    _format_arc_section,
+    _build_infobox,
+    _build_event_timeline,
+    _build_current_status,
+)
+
+from synthesis import ID_ALIASES, segment_phases
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_event(event_id, turns, related, etype="decision", desc="Test event"):
+    return {
+        "id": event_id,
+        "source_turns": turns,
+        "type": etype,
+        "description": desc,
+        "related_entities": related,
+    }
+
+
+SAMPLE_EVENTS = [
+    _make_event("evt-001", ["turn-001"], ["char-player"], "encounter", "Awakens in snow"),
+    _make_event("evt-002", ["turn-005"], ["char-player", "char-kael"], "encounter", "Triggers snare"),
+    _make_event("evt-003", ["turn-015"], ["char-player", "char-elder"], "ritual", "Acceptance ritual"),
+    _make_event("evt-004", ["turn-050"], ["char-player", "char-kael"], "encounter", "Sits near fire"),
+    _make_event("evt-005", ["turn-079"], ["char-player", "char-kael"], "encounter", "Good-luck kiss"),
+    _make_event("evt-006", ["turn-108"], ["char-player", "char-kael", "char-elder"], "decision", "Council"),
+    _make_event("evt-007", ["turn-121"], ["char-player"], "discovery", "Pregnancy discovered"),
+    _make_event("evt-008", ["turn-141"], ["char-player", "char-kael"], "birth", "Lyrawyn born"),
+]
+
+SAMPLE_CATALOG = {
+    "id": "char-player",
+    "name": "Fenouille Moonwind",
+    "type": "character",
+    "identity": "Elven warlock who awakened in the snow",
+    "first_seen_turn": "turn-001",
+    "last_updated_turn": "turn-141",
+    "current_status": "Leading the tribe",
+    "status_updated_turn": "turn-141",
+    "stable_attributes": {
+        "race": {"value": "Elf", "source_turn": "turn-001", "confidence": 1.0},
+        "class": {"value": "Warlock", "source_turn": "turn-001", "confidence": 0.9},
+    },
+    "volatile_state": {
+        "condition": "healthy",
+        "location": "the encampment",
+    },
+    "relationships": [
+        {
+            "target_id": "char-kael",
+            "type": "romantic",
+            "current_relationship": "Partner",
+            "status": "active",
+            "last_updated_turn": "turn-141",
+            "history": [
+                {"turn": "turn-050", "description": "Shared fire"},
+                {"turn": "turn-079", "description": "Good-luck kiss"},
+                {"turn": "turn-141", "description": "Birth of child"},
+            ],
+        }
+    ],
+}
+
+SAMPLE_ARC_SUMMARIES = {
+    "entity_id": "char-player",
+    "generated_at": "2026-04-15T00:00:00Z",
+    "arcs": {
+        "char-kael": {
+            "arc_summary": [
+                {
+                    "phase": "Early Bond",
+                    "turn_range": ["turn-050", "turn-079"],
+                    "type": "romantic",
+                    "summary": "Bond deepened from shared fire to affection.",
+                    "key_turns": ["turn-050"],
+                },
+                {
+                    "phase": "Family",
+                    "turn_range": ["turn-108", "turn-141"],
+                    "type": "romantic",
+                    "summary": "Partnership solidified through council and birth.",
+                    "key_turns": ["turn-141"],
+                },
+            ],
+            "current_relationship": "Partner",
+            "interaction_count": 5,
+        }
+    },
+}
+
+
+class MockLLMClient:
+    """Mock LLM client that returns predictable text with turn citations."""
+
+    def __init__(self, response_text=None):
+        self.response_text = response_text or (
+            "The character awakened in the snow [turn-001] and triggered a "
+            "snare [turn-005]. Through acceptance rituals [turn-015], they "
+            "joined the tribe."
+        )
+        self.model = "mock-model"
+        self.calls = []
+
+    def generate_text(self, system_prompt, user_prompt, timeout=None):
+        self.calls.append({
+            "system_prompt": system_prompt,
+            "user_prompt": user_prompt,
+        })
+        return self.response_text
+
+    def delay(self):
+        pass
+
+
+class FailingLLMClient:
+    """Mock LLM client that always raises an exception."""
+
+    model = "failing-model"
+
+    def generate_text(self, system_prompt, user_prompt, timeout=None):
+        raise RuntimeError("LLM unavailable")
+
+    def delay(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Test input assembly
+# ---------------------------------------------------------------------------
+
+
+class TestInputAssembly:
+    """Tests for assemble_synthesis_input and related formatting."""
+
+    def test_full_data_entity(self):
+        """Entity with catalog + events + arcs produces complete prompt."""
+        phase = {
+            "name": "The Awakening",
+            "turn_range": ["turn-001", "turn-015"],
+            "events": SAMPLE_EVENTS[:3],
+            "event_count": 3,
+        }
+
+        result = assemble_synthesis_input(
+            "char-player", phase, SAMPLE_CATALOG,
+            SAMPLE_ARC_SUMMARIES, ID_ALIASES)
+
+        assert "system_prompt" in result
+        assert "user_prompt" in result
+        assert "events_used" in result
+        assert result["events_used"] == ["evt-001", "evt-002", "evt-003"]
+        assert result["phase_name"] == "The Awakening"
+        assert result["turn_range"] == ["turn-001", "turn-015"]
+
+        prompt = result["user_prompt"]
+        assert "Fenouille Moonwind" in prompt
+        assert "char-player" in prompt
+        assert "Elven warlock" in prompt
+        assert "Awakens in snow" in prompt
+        assert "Triggers snare" in prompt
+        assert "Acceptance ritual" in prompt
+        assert "Kael" in prompt  # from arc summaries
+        assert "The Awakening" in prompt
+
+    def test_events_only_entity(self):
+        """Entity with events only (no catalog) notes absence."""
+        phase = {
+            "name": None,
+            "turn_range": ["turn-050", "turn-108"],
+            "events": SAMPLE_EVENTS[3:6],
+            "event_count": 3,
+        }
+
+        result = assemble_synthesis_input(
+            "char-kael", phase, None, None, ID_ALIASES)
+
+        prompt = result["user_prompt"]
+        assert "No catalog entry exists" in prompt
+        assert "Kael" in prompt
+        assert "No relationship arc summaries" in prompt
+
+    def test_single_call_small_entity(self):
+        """Entity with < 40 events gets all events in one call."""
+        events = SAMPLE_EVENTS[:5]
+        phase = {
+            "name": "Full Timeline",
+            "turn_range": ["turn-001", "turn-079"],
+            "events": events,
+            "event_count": 5,
+        }
+
+        result = assemble_synthesis_input(
+            "char-elder", phase, None, None, ID_ALIASES)
+
+        assert len(result["events_used"]) == 5
+
+    def test_available_turns_collected(self):
+        """Available turns are collected from all events."""
+        phase = {
+            "name": "Test",
+            "turn_range": ["turn-001", "turn-015"],
+            "events": SAMPLE_EVENTS[:3],
+            "event_count": 3,
+        }
+
+        result = assemble_synthesis_input(
+            "char-player", phase, SAMPLE_CATALOG, None, ID_ALIASES)
+
+        assert "turn-001" in result["available_turns"]
+        assert "turn-005" in result["available_turns"]
+        assert "turn-015" in result["available_turns"]
+
+    def test_lede_input_assembly(self):
+        """Lede input combines biography sections."""
+        sections = ["Phase 1 text [turn-001].", "Phase 2 text [turn-050]."]
+        result = assemble_lede_input("char-player", sections, SAMPLE_CATALOG)
+
+        assert "Fenouille Moonwind" in result["user_prompt"]
+        assert "Phase 1 text" in result["user_prompt"]
+        assert "Phase 2 text" in result["user_prompt"]
+        assert "2–3 sentence summary" in result["user_prompt"]
+
+    def test_location_input_assembly(self):
+        events = SAMPLE_EVENTS[:2]
+        result = assemble_location_input("loc-camp", events, None)
+        assert "loc-camp" in result["user_prompt"]
+        assert "Awakens in snow" in result["user_prompt"]
+
+    def test_faction_input_assembly(self):
+        events = SAMPLE_EVENTS[:2]
+        result = assemble_faction_input("faction-tribe", events, None)
+        assert "faction-tribe" in result["user_prompt"]
+
+    def test_item_input_assembly(self):
+        events = SAMPLE_EVENTS[:2]
+        result = assemble_item_input("item-fragment", events, None)
+        assert "item-fragment" in result["user_prompt"]
+
+
+class TestFormatHelpers:
+    """Tests for prompt formatting helper functions."""
+
+    def test_format_events_for_prompt(self):
+        text = _format_events_for_prompt(SAMPLE_EVENTS[:2])
+        assert "[turn-001]" in text
+        assert "(encounter)" in text
+        assert "Awakens in snow" in text
+
+    def test_format_catalog_section_present(self):
+        text = _format_catalog_section(SAMPLE_CATALOG)
+        assert "Elven warlock" in text
+        assert "race" in text
+        assert "Leading the tribe" in text
+
+    def test_format_catalog_section_absent(self):
+        text = _format_catalog_section(None)
+        assert "No catalog entry exists" in text
+
+    def test_format_arc_section_present(self):
+        text = _format_arc_section(SAMPLE_ARC_SUMMARIES, "char-player")
+        assert "Kael" in text
+        assert "Early Bond" in text
+        assert "Partner" in text
+
+    def test_format_arc_section_absent(self):
+        text = _format_arc_section(None, "char-player")
+        assert "No relationship arc summaries" in text
+
+
+# ---------------------------------------------------------------------------
+# Test provenance validation
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceValidation:
+
+    def test_detect_hallucinated_turns(self):
+        """Turns cited but not in input are flagged as hallucinations."""
+        markdown = "Something happened [turn-001] and then [turn-999]."
+        result = validate_provenance(markdown, ["turn-001", "turn-005"])
+
+        assert "turn-999" in result["hallucination_flags"]
+        assert "turn-001" not in result["hallucination_flags"]
+
+    def test_detect_omitted_critical_events(self):
+        """Critical events not cited are flagged."""
+        markdown = "Something happened [turn-001]."
+        result = validate_provenance(
+            markdown, ["turn-001", "turn-005"],
+            critical_event_turns=["turn-001", "turn-005"])
+
+        assert "turn-005" in result["uncited_critical_events"]
+        assert "turn-001" not in result["uncited_critical_events"]
+
+    def test_correct_provenance(self):
+        """No flags when all citations match available turns."""
+        markdown = "Event A [turn-001] and event B [turn-005]."
+        result = validate_provenance(markdown, ["turn-001", "turn-005"])
+
+        assert result["hallucination_flags"] == []
+        assert result["uncited_critical_events"] == []
+
+    def test_extract_cited_turns(self):
+        """Extracts turn references from markdown."""
+        md = "Text [turn-001] more [turn-050] end [turn-001]."
+        turns = extract_cited_turns(md)
+        assert "[turn-001]" in turns
+        assert "[turn-050]" in turns
+        assert len(turns) == 2  # deduplicated
+
+    def test_provenance_warning_added(self):
+        """Warning banner is prepended when hallucinations exist."""
+        md = "# Test Page\n\nContent."
+        result = add_provenance_warning(md, "char-test")
+        assert "⚠️" in result
+        assert "char-test.synthesis.json" in result
+        assert result.endswith("Content.")
+
+
+# ---------------------------------------------------------------------------
+# Test page assembly
+# ---------------------------------------------------------------------------
+
+
+class TestPageAssembly:
+
+    def test_character_page_structure(self):
+        """Character page has all required sections."""
+        phase_texts = [
+            ("The Awakening", "Fenouille awoke in the snow [turn-001]."),
+            ("Finding the Tribe", "She was accepted into the tribe [turn-015]."),
+        ]
+        page = assemble_character_page(
+            "char-player", "Fenouille Moonwind",
+            "Elven warlock who built a civilization.",
+            phase_texts, SAMPLE_CATALOG, None,
+            SAMPLE_ARC_SUMMARIES, SAMPLE_EVENTS)
+
+        assert "# Fenouille Moonwind" in page
+        assert "> Elven warlock who built a civilization." in page
+        assert "## Overview" in page
+        assert "## Biography" in page
+        assert "### The Awakening" in page
+        assert "### Finding the Tribe" in page
+        assert "## Relationships" in page
+        assert "## Current Status" in page
+        assert "## Event Timeline" in page
+        assert "turn-001" in page
+
+    def test_character_page_event_derived(self):
+        """Character page works with event-derived profile (no catalog)."""
+        derived = {
+            "id": "char-kael",
+            "name": "Kael",
+            "type": "character",
+            "source": "events_only",
+            "first_event_turn": "turn-050",
+            "last_event_turn": "turn-141",
+            "event_count": 5,
+        }
+        page = assemble_character_page(
+            "char-kael", "Kael", "A mysterious warrior.",
+            [("Full Timeline", "Kael appeared [turn-050].")],
+            None, derived, None, SAMPLE_EVENTS[3:])
+
+        assert "# Kael" in page
+        assert "Events only" in page
+        assert "## Biography" in page
+
+    def test_location_page_structure(self):
+        """Location page uses event table instead of biography."""
+        page = assemble_location_page(
+            "loc-camp", "The Encampment",
+            "Central tribal settlement.",
+            None, None, SAMPLE_EVENTS[:3])
+
+        assert "# The Encampment" in page
+        assert "## Significance" in page
+        assert "Central tribal settlement." in page
+        assert "## Key Events" in page
+        assert "| Turn | Type | Description |" in page
+        assert "Biography" not in page
+
+    def test_faction_page_structure(self):
+        """Faction page has history and members sections."""
+        events = [
+            _make_event("evt-f1", ["turn-100"], ["faction-tribe", "char-player"],
+                        "encounter", "Meeting"),
+        ]
+        page = assemble_faction_page(
+            "faction-tribe", "The Tribe",
+            "The tribe grew from nomads to settlers.",
+            None, None, events)
+
+        assert "# The Tribe" in page
+        assert "## History" in page
+        assert "## Known Members" in page
+        assert "Player" in page  # From char-player co-occurrence
+
+    def test_item_page_structure(self):
+        """Item page has significance and key events."""
+        page = assemble_item_page(
+            "item-fragment", "The Fragment",
+            "A mysterious arcane object.",
+            None, None, SAMPLE_EVENTS[:2])
+
+        assert "# The Fragment" in page
+        assert "## Significance" in page
+        assert "## Key Events" in page
+
+    def test_hallucination_warning_in_page(self):
+        """Page gets warning banner when hallucinations detected."""
+        md = "# Test\n\nContent [turn-999]."
+        result = add_provenance_warning(md, "char-test")
+        assert "⚠️ **Provenance warning**" in result
+
+    def test_infobox_from_catalog(self):
+        """Infobox built from catalog data."""
+        text = _build_infobox("char-player", SAMPLE_CATALOG, None)
+        assert "Character" in text
+        assert "turn-001" in text
+        assert "Elf" in text
+
+    def test_infobox_from_derived_profile(self):
+        """Infobox built from event-derived profile."""
+        derived = {
+            "type": "character",
+            "source": "events_only",
+            "first_event_turn": "turn-050",
+            "last_event_turn": "turn-141",
+            "event_count": 5,
+        }
+        text = _build_infobox("char-kael", None, derived)
+        assert "Events only" in text
+        assert "turn-050" in text
+
+    def test_event_timeline(self):
+        """Event timeline table is generated."""
+        text = _build_event_timeline(SAMPLE_EVENTS[:2])
+        assert "| Turn | Type | Description |" in text
+        assert "turn-001" in text
+        assert "Awakens in snow" in text
+
+    def test_current_status_from_catalog(self):
+        """Current status from catalog data."""
+        text = _build_current_status(SAMPLE_CATALOG, SAMPLE_EVENTS)
+        assert "Leading the tribe" in text
+        assert "turn-141" in text
+
+    def test_current_status_from_events(self):
+        """Current status derived from latest event."""
+        text = _build_current_status(None, SAMPLE_EVENTS)
+        assert "Lyrawyn born" in text
+
+
+# ---------------------------------------------------------------------------
+# Test should_synthesize
+# ---------------------------------------------------------------------------
+
+
+class TestShouldSynthesize:
+
+    def test_character_3_events(self):
+        assert should_synthesize("char-test", 3, "character") is True
+
+    def test_character_1_event(self):
+        assert should_synthesize("char-test", 1, "character") is False
+
+    def test_character_0_events(self):
+        assert should_synthesize("char-test", 0, "character") is False
+
+    def test_location_3_events(self):
+        assert should_synthesize("loc-test", 3, "location") is True
+
+    def test_location_2_events(self):
+        assert should_synthesize("loc-test", 2, "location") is False
+
+    def test_faction_5_events(self):
+        assert should_synthesize("faction-test", 5, "faction") is True
+
+    def test_item_2_events(self):
+        assert should_synthesize("item-test", 2, "item") is False
+
+    def test_item_5_events(self):
+        assert should_synthesize("item-test", 5, "item") is True
+
+    def test_unknown_type(self):
+        assert should_synthesize("x-test", 10, "unknown") is False
+
+
+# ---------------------------------------------------------------------------
+# Test LLM generation with mock
+# ---------------------------------------------------------------------------
+
+
+class TestBiographyGeneration:
+
+    def test_generate_phase_biography_success(self):
+        """Phase biography returns LLM text and metadata."""
+        llm = MockLLMClient()
+        phase = {
+            "name": "Test Phase",
+            "turn_range": ["turn-001", "turn-015"],
+            "events": SAMPLE_EVENTS[:3],
+            "event_count": 3,
+        }
+        synth_input = assemble_synthesis_input(
+            "char-player", phase, SAMPLE_CATALOG, None, ID_ALIASES)
+
+        text, meta = generate_phase_biography(llm, synth_input)
+
+        assert "[turn-001]" in text
+        assert meta["name"] == "Test Phase"
+        assert meta["llm_model"] == "mock-model"
+        assert meta["tokens_used"] > 0
+        assert len(llm.calls) == 1
+
+    def test_generate_phase_biography_failure(self):
+        """Phase biography returns fallback on LLM failure."""
+        llm = FailingLLMClient()
+        synth_input = {
+            "system_prompt": "test",
+            "user_prompt": "test",
+            "events_used": [],
+            "turn_range": ["turn-001", "turn-015"],
+            "phase_name": "Test",
+            "available_turns": [],
+        }
+
+        text, meta = generate_phase_biography(llm, synth_input)
+
+        assert "Generation failed" in text
+        assert "error" in meta
+
+    def test_generate_lede(self):
+        """Lede generation returns text."""
+        llm = MockLLMClient("A concise summary of the story arc.")
+        lede_input = assemble_lede_input(
+            "char-player", ["Phase 1 text.", "Phase 2 text."], SAMPLE_CATALOG)
+
+        text = generate_lede(llm, lede_input)
+        assert text == "A concise summary of the story arc."
+
+    def test_generate_lede_failure(self):
+        """Lede returns empty string on failure."""
+        llm = FailingLLMClient()
+        lede_input = {"system_prompt": "test", "user_prompt": "test"}
+        text = generate_lede(llm, lede_input)
+        assert text == ""
+
+
+# ---------------------------------------------------------------------------
+# Test sidecar generation
+# ---------------------------------------------------------------------------
+
+
+class TestSidecarGeneration:
+
+    def test_build_synthesis_sidecar(self):
+        """Sidecar has all required fields."""
+        provenance = {
+            "turns_cited": ["turn-001", "turn-005"],
+            "turns_available": ["turn-001", "turn-005", "turn-015"],
+            "hallucination_flags": [],
+            "uncited_critical_events": [],
+        }
+        phase_meta = [{
+            "name": "Test Phase",
+            "turn_range": ["turn-001", "turn-015"],
+            "events_used": ["evt-001", "evt-002"],
+            "llm_model": "mock",
+            "tokens_used": 500,
+        }]
+        sidecar = build_synthesis_sidecar(
+            "char-player", SAMPLE_EVENTS[:3],
+            True, "turn-141", 1, phase_meta, provenance)
+
+        assert sidecar["entity_id"] == "char-player"
+        assert "generated_at" in sidecar
+        assert sidecar["source_data"]["events_count"] == 3
+        assert sidecar["source_data"]["catalog_available"] is True
+        assert sidecar["source_data"]["catalog_last_updated"] == "turn-141"
+        assert sidecar["source_data"]["relationship_arcs_count"] == 1
+        assert len(sidecar["phases"]) == 1
+        assert sidecar["provenance_check"]["hallucination_flags"] == []
+
+    def test_write_and_load_sidecar(self):
+        """Sidecar round-trips through write and load."""
+        sidecar = {
+            "entity_id": "char-test",
+            "generated_at": "2026-04-15T00:00:00Z",
+            "source_data": {"events_count": 5},
+            "phases": [],
+            "provenance_check": {},
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "char-test.synthesis.json")
+            write_synthesis_sidecar(sidecar, path)
+
+            loaded = load_synthesis_sidecar(path)
+            assert loaded is not None
+            assert loaded["entity_id"] == "char-test"
+            assert loaded["source_data"]["events_count"] == 5
+
+    def test_load_missing_sidecar(self):
+        """Loading non-existent sidecar returns None."""
+        result = load_synthesis_sidecar("/nonexistent/path.json")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Test incremental awareness
+# ---------------------------------------------------------------------------
+
+
+class TestIncrementalAwareness:
+
+    def test_needs_regeneration_no_sidecar(self):
+        """Regeneration needed when no sidecar exists."""
+        assert needs_regeneration("char-test", 10, "/nonexistent.json") is True
+
+    def test_needs_regeneration_force(self):
+        """Force always triggers regeneration."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "test.synthesis.json")
+            sidecar = {"source_data": {"events_count": 10}}
+            with open(path, "w") as f:
+                json.dump(sidecar, f)
+
+            assert needs_regeneration("char-test", 10, path, force=True) is True
+
+    def test_no_regeneration_same_count(self):
+        """No regeneration when event count unchanged."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "test.synthesis.json")
+            sidecar = {"source_data": {"events_count": 10}}
+            with open(path, "w") as f:
+                json.dump(sidecar, f)
+
+            assert needs_regeneration("char-test", 10, path) is False
+
+    def test_regeneration_new_events(self):
+        """Regeneration needed when event count changed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "test.synthesis.json")
+            sidecar = {"source_data": {"events_count": 10}}
+            with open(path, "w") as f:
+                json.dump(sidecar, f)
+
+            assert needs_regeneration("char-test", 15, path) is True
+
+
+# ---------------------------------------------------------------------------
+# Integration test: full pipeline with mock LLM
+# ---------------------------------------------------------------------------
+
+
+class TestFullPipelineIntegration:
+
+    def test_character_synthesis_full_data(self):
+        """Full character pipeline with catalog + events + arcs."""
+        llm = MockLLMClient(
+            "The character awakened in the snow [turn-001] and triggered "
+            "a snare [turn-005]. They were accepted into the tribe [turn-015]."
+        )
+
+        page, sidecar = synthesize_entity(
+            "char-player", SAMPLE_EVENTS, SAMPLE_CATALOG,
+            SAMPLE_ARC_SUMMARIES, llm, entity_type="character")
+
+        # Page structure
+        assert "# Fenouille Moonwind" in page
+        assert "## Biography" in page
+        assert "## Event Timeline" in page
+        assert "[turn-001]" in page
+
+        # Sidecar
+        assert sidecar["entity_id"] == "char-player"
+        assert sidecar["source_data"]["catalog_available"] is True
+        assert len(sidecar["phases"]) >= 1
+        assert "provenance_check" in sidecar
+
+    def test_character_synthesis_events_only(self):
+        """Character pipeline with events only (no catalog)."""
+        llm = MockLLMClient(
+            "Kael appeared near the fire [turn-050] and attended "
+            "the council [turn-108]."
+        )
+        kael_events = [e for e in SAMPLE_EVENTS
+                       if "char-kael" in e.get("related_entities", [])]
+
+        page, sidecar = synthesize_entity(
+            "char-kael", kael_events, None, None,
+            llm, entity_type="character")
+
+        assert "# Kael" in page
+        assert "Events only" in page
+        assert sidecar["source_data"]["catalog_available"] is False
+
+    def test_location_synthesis(self):
+        """Location synthesis produces event table."""
+        llm = MockLLMClient(
+            "The encampment served as the tribal center [turn-001].")
+
+        page, sidecar = synthesize_entity(
+            "loc-camp", SAMPLE_EVENTS[:3], None, None,
+            llm, entity_type="location")
+
+        assert "# Camp" in page
+        assert "## Significance" in page
+        assert "## Key Events" in page
+        assert "Biography" not in page
+
+    def test_faction_synthesis(self):
+        """Faction synthesis produces history and members."""
+        events = [
+            _make_event("evt-f1", ["turn-100"], ["faction-tribe", "char-player"],
+                        "encounter", "Tribe meeting"),
+            _make_event("evt-f2", ["turn-110"], ["faction-tribe", "char-elder"],
+                        "decision", "Tribal decision"),
+            _make_event("evt-f3", ["turn-120"], ["faction-tribe", "char-kael"],
+                        "decision", "Alliance formed"),
+        ]
+        llm = MockLLMClient(
+            "The tribe evolved through meetings [turn-100] "
+            "and alliances [turn-120].")
+
+        page, sidecar = synthesize_entity(
+            "faction-tribe", events, None, None,
+            llm, entity_type="faction")
+
+        assert "# Tribe" in page
+        assert "## History" in page
+        assert "## Known Members" in page
+
+    def test_item_synthesis(self):
+        """Item synthesis produces significance summary."""
+        events = [
+            _make_event("evt-i1", ["turn-108"], ["item-fragment"],
+                        "discovery", "Fragment studied"),
+            _make_event("evt-i2", ["turn-306"], ["item-fragment"],
+                        "discovery", "Fragment flares"),
+            _make_event("evt-i3", ["turn-340"], ["item-fragment"],
+                        "discovery", "Deepened thrum"),
+        ]
+        llm = MockLLMClient(
+            "The fragment is a mysterious artifact [turn-108] "
+            "that flares with power [turn-306].")
+
+        page, sidecar = synthesize_entity(
+            "item-fragment", events, None, None,
+            llm, entity_type="item")
+
+        assert "# Fragment" in page
+        assert "## Significance" in page
+
+    def test_provenance_pass(self):
+        """Provenance validation passes when citations match."""
+        llm = MockLLMClient(
+            "Something happened [turn-001] and [turn-005].")
+
+        page, sidecar = synthesize_entity(
+            "char-player", SAMPLE_EVENTS[:3], SAMPLE_CATALOG,
+            None, llm, entity_type="character")
+
+        assert sidecar["provenance_check"]["hallucination_flags"] == []
+        assert "⚠️" not in page
+
+    def test_provenance_hallucination_flagged(self):
+        """Hallucinated turns trigger warning banner."""
+        llm = MockLLMClient(
+            "Something happened [turn-001] and also [turn-999].")
+
+        page, sidecar = synthesize_entity(
+            "char-player", SAMPLE_EVENTS[:3], SAMPLE_CATALOG,
+            None, llm, entity_type="character")
+
+        assert "turn-999" in sidecar["provenance_check"]["hallucination_flags"]
+        assert "⚠️" in page
+
+    def test_incremental_skip_on_second_run(self):
+        """Entity is skipped on second run when no new events."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sidecar_path = os.path.join(tmpdir, "char-test.synthesis.json")
+
+            # First run: needs regeneration
+            assert needs_regeneration("char-test", 5, sidecar_path) is True
+
+            # Write sidecar
+            sidecar = {"source_data": {"events_count": 5}}
+            with open(sidecar_path, "w") as f:
+                json.dump(sidecar, f)
+
+            # Second run: skip
+            assert needs_regeneration("char-test", 5, sidecar_path) is False
+
+            # New events: regenerate
+            assert needs_regeneration("char-test", 7, sidecar_path) is True
+
+    def test_output_files_written(self):
+        """Full pipeline writes .md and .synthesis.json files."""
+        from narrative_synthesis import write_synthesis_sidecar
+
+        llm = MockLLMClient(
+            "The character awakened [turn-001].")
+
+        page, sidecar = synthesize_entity(
+            "char-player", SAMPLE_EVENTS[:3], SAMPLE_CATALOG,
+            None, llm, entity_type="character")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            md_path = os.path.join(tmpdir, "char-player.md")
+            sidecar_path = os.path.join(tmpdir, "char-player.synthesis.json")
+
+            with open(md_path, "w", encoding="utf-8") as f:
+                f.write(page)
+            write_synthesis_sidecar(sidecar, sidecar_path)
+
+            assert os.path.isfile(md_path)
+            assert os.path.isfile(sidecar_path)
+
+            with open(md_path, "r", encoding="utf-8") as f:
+                content = f.read()
+            assert "# Fenouille Moonwind" in content
+
+            loaded = load_synthesis_sidecar(sidecar_path)
+            assert loaded["entity_id"] == "char-player"

--- a/tools/generate_wiki_pages.py
+++ b/tools/generate_wiki_pages.py
@@ -623,11 +623,15 @@ def generate_wiki_pages(catalog_dir: str, entity_types: list[str] | None = None,
                     page_count += 1
 
             # Prune stale .md files whose entity JSON no longer exists
+            # Preserve event-only synthesized pages (have .synthesis.json sidecar)
             for fname in os.listdir(type_dir):
                 if fname == "README.md" or not fname.endswith(".md"):
                     continue
                 stem = fname[:-3]  # strip .md
                 if stem not in live_ids:
+                    sidecar = os.path.join(type_dir, f"{stem}.synthesis.json")
+                    if os.path.isfile(sidecar):
+                        continue  # Event-only synthesized page; keep it
                     stale_path = os.path.join(type_dir, fname)
                     os.remove(stale_path)
                     print(f"  Pruned stale wiki page: {fname}", file=sys.stderr)
@@ -676,6 +680,11 @@ def main():
     )
     args = parser.parse_args()
 
+    if args.force and not args.synthesize:
+        parser.error("--force requires --synthesize")
+    if args.index_only and args.synthesize:
+        parser.error("--index-only cannot be used with --synthesize")
+
     catalog_dir = os.path.join(args.framework, "catalogs")
     if not os.path.isdir(catalog_dir):
         print(f"ERROR: Catalog directory not found: {catalog_dir}", file=sys.stderr)
@@ -720,7 +729,6 @@ def run_synthesis_pipeline(framework_dir: str, catalog_dir: str,
         summarize_relationship_arcs,
         write_arc_sidecar,
         _infer_type_from_id,
-        _infer_name_from_id,
     )
     from llm_client import LLMClient
 
@@ -734,15 +742,6 @@ def run_synthesis_pipeline(framework_dir: str, catalog_dir: str,
     grouped = group_events_by_entity(events)
     all_entities = _load_all_entities(catalog_dir)
     name_index = _build_name_index(all_entities)
-
-    # Build catalog lookup: entity_id → catalog dict
-    catalog_lookup: dict[str, dict] = {}
-    entity_type_lookup: dict[str, str] = {}
-    for etype, elist in all_entities.items():
-        for entity in elist:
-            eid = entity.get("id", "")
-            catalog_lookup[eid] = entity
-            entity_type_lookup[eid] = etype
 
     # Initialise LLM client
     config_path = os.path.join(framework_dir, "..", "config", "llm.json")
@@ -782,7 +781,6 @@ def run_synthesis_pipeline(framework_dir: str, catalog_dir: str,
                 if not needs_regeneration(eid, len(entity_events),
                                           sidecar_path, force=force):
                     print(f"  Skipping {eid} (no new events)", file=sys.stderr)
-                    page_count += 1
                     continue
 
                 # Load arc summaries if available
@@ -841,7 +839,6 @@ def run_synthesis_pipeline(framework_dir: str, catalog_dir: str,
                                               sidecar_path, force=force):
                         print(f"  Skipping {eid} (no new events)",
                               file=sys.stderr)
-                        page_count += 1
                         continue
 
                     print(f"  Synthesizing {eid} "
@@ -858,8 +855,26 @@ def run_synthesis_pipeline(framework_dir: str, catalog_dir: str,
                     page_count += 1
                     processed_ids.add(eid)
 
-        # Generate index page
-        index_content = generate_index_page(entity_type, entities)
+        # Generate index page — include event-only entities alongside catalog ones
+        index_entities = list(entities)
+        if entity_type == "characters":
+            from synthesis import build_event_derived_profile as _build_profile
+            for eid in sorted(processed_ids):
+                if any(e.get("id") == eid for e in entities):
+                    continue  # Already in catalog entities
+                entity_events = grouped.get(eid, [])
+                if not entity_events:
+                    continue
+                profile = _build_profile(eid, entity_events)
+                index_entities.append({
+                    "id": eid,
+                    "name": profile.get("name", eid),
+                    "current_status": f"Events-only ({profile.get('event_count', 0)} events)",
+                    "first_seen_turn": profile.get("first_event_turn", ""),
+                    "last_updated_turn": profile.get("last_event_turn", ""),
+                    "relationships": [],
+                })
+        index_content = generate_index_page(entity_type, index_entities)
         readme_path = os.path.join(type_dir, "README.md")
         with open(readme_path, "w", encoding="utf-8") as f:
             f.write(index_content)

--- a/tools/generate_wiki_pages.py
+++ b/tools/generate_wiki_pages.py
@@ -793,7 +793,7 @@ def run_synthesis_pipeline(framework_dir: str, catalog_dir: str,
                         with open(arc_path, "r", encoding="utf-8-sig") as f:
                             arc_summaries = json.load(f)
                     except (json.JSONDecodeError, OSError):
-                        pass
+                        pass  # Corrupt or unreadable arcs sidecar; regenerate below
 
                 # Generate arcs if not available and entity has relationships
                 if arc_summaries is None and entity.get("relationships"):

--- a/tools/generate_wiki_pages.py
+++ b/tools/generate_wiki_pages.py
@@ -666,6 +666,14 @@ def main():
         "--index-only", action="store_true",
         help="Only regenerate index pages, not individual entity pages"
     )
+    parser.add_argument(
+        "--synthesize", action="store_true",
+        help="Run LLM-powered narrative synthesis pipeline"
+    )
+    parser.add_argument(
+        "--force", action="store_true",
+        help="Force regeneration even if sidecar shows no new events (requires --synthesize)"
+    )
     args = parser.parse_args()
 
     catalog_dir = os.path.join(args.framework, "catalogs")
@@ -674,10 +682,204 @@ def main():
         sys.exit(1)
 
     types = [args.entity_type] if args.entity_type else None
-    stats = generate_wiki_pages(catalog_dir, entity_types=types, index_only=args.index_only)
+
+    if args.synthesize:
+        stats = run_synthesis_pipeline(
+            args.framework, catalog_dir,
+            entity_types=types, force=args.force)
+    else:
+        stats = generate_wiki_pages(
+            catalog_dir, entity_types=types, index_only=args.index_only)
 
     total = sum(stats.values())
     print(f"\nTotal: {total} wiki pages generated.")
+
+
+# ---------------------------------------------------------------------------
+# Synthesis pipeline integration
+# ---------------------------------------------------------------------------
+
+def run_synthesis_pipeline(framework_dir: str, catalog_dir: str,
+                           entity_types: list[str] | None = None,
+                           force: bool = False) -> dict[str, int]:
+    """Run the full LLM synthesis pipeline.
+
+    Generates narrative wiki pages using the LLM for entities that meet
+    the synthesis threshold.  Falls back to template rendering for
+    entities below the threshold.
+    """
+    from narrative_synthesis import (
+        should_synthesize,
+        synthesize_entity,
+        needs_regeneration,
+        write_synthesis_sidecar,
+    )
+    from synthesis import (
+        group_events_by_entity,
+        load_events,
+        summarize_relationship_arcs,
+        write_arc_sidecar,
+        _infer_type_from_id,
+        _infer_name_from_id,
+    )
+    from llm_client import LLMClient
+
+    # Load events
+    events = load_events(framework_dir)
+    if not events:
+        print("WARNING: No events found. Falling back to template rendering.",
+              file=sys.stderr)
+        return generate_wiki_pages(catalog_dir, entity_types=entity_types)
+
+    grouped = group_events_by_entity(events)
+    all_entities = _load_all_entities(catalog_dir)
+    name_index = _build_name_index(all_entities)
+
+    # Build catalog lookup: entity_id → catalog dict
+    catalog_lookup: dict[str, dict] = {}
+    entity_type_lookup: dict[str, str] = {}
+    for etype, elist in all_entities.items():
+        for entity in elist:
+            eid = entity.get("id", "")
+            catalog_lookup[eid] = entity
+            entity_type_lookup[eid] = etype
+
+    # Initialise LLM client
+    config_path = os.path.join(framework_dir, "..", "config", "llm.json")
+    if not os.path.isfile(config_path):
+        config_path = "config/llm.json"
+    try:
+        llm_client = LLMClient(config_path=config_path)
+    except Exception as e:
+        print(f"ERROR: Cannot initialise LLM client: {e}", file=sys.stderr)
+        print("Falling back to template rendering.", file=sys.stderr)
+        return generate_wiki_pages(catalog_dir, entity_types=entity_types)
+
+    types_to_process = entity_types or ENTITY_TYPES
+    stats: dict[str, int] = {}
+
+    for entity_type in types_to_process:
+        if entity_type not in ENTITY_TYPES:
+            continue
+        type_dir = os.path.join(catalog_dir, entity_type)
+        os.makedirs(type_dir, exist_ok=True)
+        entities = all_entities.get(entity_type, [])
+        page_count = 0
+
+        # Process catalog entities
+        processed_ids: set[str] = set()
+        for entity in entities:
+            eid = entity.get("id", "")
+            if not eid:
+                continue
+            processed_ids.add(eid)
+
+            entity_events = grouped.get(eid, [])
+            etype_str = _type_label_for_synth(entity_type)
+
+            if should_synthesize(eid, len(entity_events), etype_str):
+                sidecar_path = os.path.join(type_dir, f"{eid}.synthesis.json")
+                if not needs_regeneration(eid, len(entity_events),
+                                          sidecar_path, force=force):
+                    print(f"  Skipping {eid} (no new events)", file=sys.stderr)
+                    page_count += 1
+                    continue
+
+                # Load arc summaries if available
+                arc_path = os.path.join(type_dir, f"{eid}.arcs.json")
+                arc_summaries = None
+                if os.path.isfile(arc_path):
+                    try:
+                        with open(arc_path, "r", encoding="utf-8-sig") as f:
+                            arc_summaries = json.load(f)
+                    except (json.JSONDecodeError, OSError):
+                        pass
+
+                # Generate arcs if not available and entity has relationships
+                if arc_summaries is None and entity.get("relationships"):
+                    arc_data = summarize_relationship_arcs(
+                        eid, entity.get("name", eid),
+                        entity.get("relationships", []),
+                        llm_client=llm_client)
+                    write_arc_sidecar(arc_data, type_dir)
+                    arc_summaries = arc_data
+
+                print(f"  Synthesizing {eid} ({len(entity_events)} events)...",
+                      file=sys.stderr)
+                page, sidecar = synthesize_entity(
+                    eid, entity_events, entity, arc_summaries,
+                    llm_client, entity_type=etype_str)
+
+                md_path = os.path.join(type_dir, f"{eid}.md")
+                with open(md_path, "w", encoding="utf-8") as f:
+                    f.write(page)
+                write_synthesis_sidecar(sidecar, sidecar_path)
+                page_count += 1
+            else:
+                # Below threshold: use template rendering
+                generator = PAGE_GENERATORS.get(entity_type)
+                if generator:
+                    md_content = generator(entity, name_index)
+                    md_path = os.path.join(type_dir, f"{eid}.md")
+                    with open(md_path, "w", encoding="utf-8") as f:
+                        f.write(md_content)
+                    page_count += 1
+
+        # Process event-only entities (no catalog entry) for this type
+        if entity_type == "characters":
+            for eid, entity_events in grouped.items():
+                if eid in processed_ids:
+                    continue
+                etype_str = _infer_type_from_id(eid)
+                if etype_str != "character":
+                    continue
+
+                if should_synthesize(eid, len(entity_events), etype_str):
+                    sidecar_path = os.path.join(type_dir,
+                                                f"{eid}.synthesis.json")
+                    if not needs_regeneration(eid, len(entity_events),
+                                              sidecar_path, force=force):
+                        print(f"  Skipping {eid} (no new events)",
+                              file=sys.stderr)
+                        page_count += 1
+                        continue
+
+                    print(f"  Synthesizing {eid} "
+                          f"({len(entity_events)} events, events-only)...",
+                          file=sys.stderr)
+                    page, sidecar = synthesize_entity(
+                        eid, entity_events, None, None,
+                        llm_client, entity_type=etype_str)
+
+                    md_path = os.path.join(type_dir, f"{eid}.md")
+                    with open(md_path, "w", encoding="utf-8") as f:
+                        f.write(page)
+                    write_synthesis_sidecar(sidecar, sidecar_path)
+                    page_count += 1
+                    processed_ids.add(eid)
+
+        # Generate index page
+        index_content = generate_index_page(entity_type, entities)
+        readme_path = os.path.join(type_dir, "README.md")
+        with open(readme_path, "w", encoding="utf-8") as f:
+            f.write(index_content)
+        page_count += 1
+
+        stats[entity_type] = page_count
+        print(f"  {entity_type}: {page_count} pages generated")
+
+    return stats
+
+
+def _type_label_for_synth(entity_type_dir: str) -> str:
+    """Convert directory type name to synthesis type label."""
+    _map = {
+        "characters": "character",
+        "locations": "location",
+        "factions": "faction",
+        "items": "item",
+    }
+    return _map.get(entity_type_dir, entity_type_dir)
 
 
 if __name__ == "__main__":

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -145,6 +145,65 @@ class LLMClient:
                 f"Raw response (first 500 chars): {raw_text[:500]}"
             )
 
+    def generate_text(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        timeout: int | None = None,
+    ) -> str:
+        """Send a chat completion request and return the raw text response.
+
+        Unlike ``extract_json``, this does not enforce JSON formatting or
+        parsing. Use this for free-form text generation (e.g., narrative
+        biography synthesis).
+
+        Args:
+            system_prompt: Role instructions for the model.
+            user_prompt: The user message / task description.
+            timeout: Optional per-call timeout in seconds.
+
+        Returns:
+            The raw text content from the LLM response.
+
+        Raises:
+            LLMExtractionError: If the LLM returns an empty response or
+                all retry attempts fail.
+        """
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+
+        last_error = None
+        for attempt in range(self.retry_attempts):
+            try:
+                kwargs = {
+                    "model": self.model,
+                    "messages": messages,
+                    "temperature": self.temperature,
+                    "max_tokens": self.max_tokens,
+                }
+                if timeout is not None:
+                    kwargs["timeout"] = timeout
+
+                response = self.client.chat.completions.create(**kwargs)
+                raw_text = response.choices[0].message.content
+
+                if not raw_text:
+                    raise LLMExtractionError("Empty response from LLM.")
+
+                return raw_text.strip()
+
+            except Exception as e:
+                last_error = e
+                if attempt < self.retry_attempts - 1:
+                    backoff = (2 ** attempt) * 1.0
+                    time.sleep(backoff)
+
+        raise LLMExtractionError(
+            f"Failed after {self.retry_attempts} attempts. Last error: {last_error}"
+        )
+
     def delay(self) -> None:
         """Apply the configured batch delay between API calls."""
         if self.batch_delay_ms > 0:

--- a/tools/narrative_synthesis.py
+++ b/tools/narrative_synthesis.py
@@ -1,0 +1,1044 @@
+#!/usr/bin/env python3
+"""
+narrative_synthesis.py — LLM-powered narrative wiki page generation.
+
+Transforms structured event data into readable wiki pages with full
+provenance tracking.  Builds on the synthesis data foundation in
+``synthesis.py`` (event grouping, phase segmentation, arc summaries).
+
+Components:
+  1. Input assembly — structured LLM prompt input per entity/phase
+  2. Narrative biography generator — per-phase LLM calls
+  3. Entity type adaptations — characters, locations, factions, items
+  4. Page assembly — combine LLM output + data into final markdown
+  5. Provenance validation — flag hallucinated / omitted turn citations
+  6. Sidecar generation — .synthesis.json metadata
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from datetime import datetime, timezone
+
+from synthesis import (
+    ID_ALIASES,
+    build_event_derived_profile,
+    group_events_by_entity,
+    load_events,
+    merge_relationship_histories,
+    resolve_entity_id,
+    segment_phases,
+    summarize_relationship_arcs,
+    write_arc_sidecar,
+    _infer_name_from_id,
+    _infer_type_from_id,
+    _parse_turn_number,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# System prompt for narrative biography generation
+# ---------------------------------------------------------------------------
+
+BIOGRAPHY_SYSTEM_PROMPT = """\
+You are a narrative biographer for an RPG campaign wiki. Your task is to
+transform structured event data into readable prose.
+
+Rules:
+1. Use ONLY facts present in the provided data. Do not invent events,
+   dialogue, motivations, or backstory not supported by the input.
+2. Cite source turns inline using [turn-NNN] notation after each factual
+   claim.
+3. Write in third person past tense for biography sections.
+4. Write in third person present tense for "Current Status" sections.
+5. Organize biography by narrative phases, not by individual turns.
+6. For relationships, describe the arc trajectory, not individual
+   micro-interactions.
+7. If uncertain about a connection (e.g., whether two entity IDs refer
+   to the same person), note the uncertainty explicitly.
+8. Keep each biography phase to 3–6 sentences.\
+"""
+
+LEDE_SYSTEM_PROMPT = """\
+You are a narrative biographer for an RPG campaign wiki. Given biography
+sections for a character, write a concise 2–3 sentence summary of this
+entity's overall story arc. Write in third person present tense for the
+summary. Do not add information not present in the biography sections.\
+"""
+
+LOCATION_SYSTEM_PROMPT = """\
+You are a narrative encyclopedist for an RPG campaign wiki. Given events
+that occurred at or involve a location, write a 2–4 sentence summary of
+this location's significance in the campaign. Use only facts present in
+the provided data. Cite source turns inline using [turn-NNN] notation.\
+"""
+
+FACTION_SYSTEM_PROMPT = """\
+You are a narrative historian for an RPG campaign wiki. Given events
+involving a faction, write a concise history section describing the
+faction's stance, trajectory, and key moments. Use only facts present in
+the provided data. Cite source turns inline using [turn-NNN] notation.
+Keep to 3–6 sentences.\
+"""
+
+ITEM_SYSTEM_PROMPT = """\
+You are a narrative encyclopedist for an RPG campaign wiki. Given events
+involving a notable item, write a 2–4 sentence summary of this item's
+significance in the campaign. Use only facts present in the provided
+data. Cite source turns inline using [turn-NNN] notation.\
+"""
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Input Assembly
+# ---------------------------------------------------------------------------
+
+def _build_id_alias_section(entity_id: str) -> str:
+    """Build the ID variant mapping section for an entity."""
+    aliases = [raw for raw, canon in ID_ALIASES.items()
+               if canon == entity_id or raw.lower() == entity_id]
+    if not aliases:
+        return f"Canonical ID: {entity_id} (no known variants)"
+    return f"Canonical ID: {entity_id}\nKnown variants: {', '.join(aliases)}"
+
+
+def _format_events_for_prompt(events: list[dict]) -> str:
+    """Format a list of events as LLM-readable text lines."""
+    lines = []
+    for evt in events:
+        turns = evt.get("source_turns", [])
+        turn_str = ", ".join(turns) if turns else "unknown"
+        etype = evt.get("type", "other")
+        desc = evt.get("description", "")
+        lines.append(f"[{turn_str}] ({etype}): {desc}")
+    return "\n".join(lines)
+
+
+def _format_catalog_section(catalog_data: dict | None) -> str:
+    """Format catalog data or absence note."""
+    if catalog_data is None:
+        return ("No catalog entry exists for this entity. "
+                "Generate the biography from events only.")
+
+    parts = []
+    identity = catalog_data.get("identity", "")
+    if identity:
+        parts.append(f"Identity: {identity}")
+
+    stable = catalog_data.get("stable_attributes", {})
+    if stable:
+        attr_lines = []
+        for key, attr in stable.items():
+            if isinstance(attr, dict):
+                val = attr.get("value", "")
+            else:
+                val = attr
+            attr_lines.append(f"  {key}: {val}")
+        parts.append("Stable attributes:\n" + "\n".join(attr_lines))
+
+    current = catalog_data.get("current_status", "")
+    if current:
+        status_turn = catalog_data.get("status_updated_turn",
+                                       catalog_data.get("last_updated_turn", ""))
+        parts.append(f"Current status (as of {status_turn}): {current}")
+
+    volatile = catalog_data.get("volatile_state", {})
+    if volatile:
+        vol_lines = []
+        for k, v in volatile.items():
+            if isinstance(v, list):
+                v = ", ".join(str(x) for x in v)
+            vol_lines.append(f"  {k}: {v}")
+        parts.append("Volatile state:\n" + "\n".join(vol_lines))
+
+    return "\n\n".join(parts) if parts else "Catalog entry exists but contains no data."
+
+
+def _format_arc_section(arc_summaries: dict | None, entity_id: str,
+                        max_arcs: int = 5) -> str:
+    """Format relationship arc summaries for the LLM prompt."""
+    if not arc_summaries:
+        return "No relationship arc summaries available."
+
+    arcs = arc_summaries.get("arcs", {})
+    if not arcs:
+        return "No relationship arc summaries available."
+
+    # Sort by interaction count, take top N
+    sorted_targets = sorted(arcs.keys(),
+                            key=lambda t: arcs[t].get("interaction_count", 0),
+                            reverse=True)[:max_arcs]
+
+    sections = []
+    for target_id in sorted_targets:
+        arc = arcs[target_id]
+        target_name = _infer_name_from_id(target_id)
+        current = arc.get("current_relationship", "")
+        phases = arc.get("arc_summary", [])
+
+        lines = [f"### {target_name} ({target_id})"]
+        if current:
+            lines.append(f"Current: {current}")
+        for phase in phases:
+            pname = phase.get("phase", "")
+            tr = phase.get("turn_range", ["?", "?"])
+            summary = phase.get("summary", "")
+            lines.append(f"- {pname} (turns {tr[0]}–{tr[1]}): {summary}")
+        sections.append("\n".join(lines))
+
+    return "\n\n".join(sections)
+
+
+def assemble_synthesis_input(entity_id: str, phase: dict,
+                             catalog_data: dict | None,
+                             arc_summaries: dict | None,
+                             id_aliases: dict) -> dict:
+    """Assemble structured input for the narrative LLM.
+
+    Args:
+        entity_id: Canonical entity ID.
+        phase: Phase dict with ``name``, ``turn_range``, ``events``.
+        catalog_data: Entity catalog JSON or None.
+        arc_summaries: Arc sidecar data or None.
+        id_aliases: ID alias mapping dict.
+
+    Returns:
+        Dict with ``system_prompt``, ``user_prompt``, ``events_used``,
+        ``turn_range``.
+    """
+    entity_name = (catalog_data or {}).get("name") or _infer_name_from_id(entity_id)
+    entity_type = (catalog_data or {}).get("type") or _infer_type_from_id(entity_id)
+
+    events = phase.get("events", [])
+    turn_range = phase.get("turn_range", ["?", "?"])
+    phase_name = phase.get("name") or f"Phase (turns {turn_range[0]}–{turn_range[1]})"
+
+    user_prompt_parts = [
+        "## Entity",
+        f"Name: {entity_name}",
+        f"ID: {entity_id}",
+        f"Type: {entity_type}",
+    ]
+    identity = (catalog_data or {}).get("identity", "")
+    if identity:
+        user_prompt_parts.append(f"Identity: {identity}")
+
+    user_prompt_parts += [
+        "",
+        "## Known ID Variants",
+        _build_id_alias_section(entity_id),
+        "",
+        "## Catalog Data",
+        _format_catalog_section(catalog_data),
+        "",
+        f"## Events (turns {turn_range[0]}–{turn_range[1]})",
+        _format_events_for_prompt(events),
+        "",
+        "## Relationship Arcs",
+        _format_arc_section(arc_summaries, entity_id),
+        "",
+        "## Task",
+        (f"Write the \"{phase_name}\" section of this entity's biography, "
+         f"covering turns {turn_range[0]} through {turn_range[1]}. "
+         "Cite turns inline."),
+    ]
+
+    # Collect event IDs used
+    events_used = [e.get("id", "") for e in events if e.get("id")]
+
+    # Collect available turns from input events
+    available_turns: set[str] = set()
+    for evt in events:
+        for t in evt.get("source_turns", []):
+            available_turns.add(t)
+
+    return {
+        "system_prompt": BIOGRAPHY_SYSTEM_PROMPT,
+        "user_prompt": "\n".join(user_prompt_parts),
+        "events_used": events_used,
+        "turn_range": turn_range,
+        "phase_name": phase_name,
+        "available_turns": sorted(available_turns,
+                                  key=lambda t: _parse_turn_number(t)),
+    }
+
+
+def assemble_lede_input(entity_id: str, biography_sections: list[str],
+                        catalog_data: dict | None) -> dict:
+    """Assemble input for the final lede/summary LLM call."""
+    entity_name = (catalog_data or {}).get("name") or _infer_name_from_id(entity_id)
+    combined = "\n\n".join(biography_sections)
+    user_prompt = (
+        f"Entity: {entity_name} ({entity_id})\n\n"
+        f"Biography sections:\n\n{combined}\n\n"
+        "Given these biography sections, write a 2–3 sentence summary of "
+        "this entity's overall story arc."
+    )
+    return {
+        "system_prompt": LEDE_SYSTEM_PROMPT,
+        "user_prompt": user_prompt,
+    }
+
+
+def assemble_location_input(entity_id: str, events: list[dict],
+                            catalog_data: dict | None) -> dict:
+    """Assemble input for a location significance summary."""
+    entity_name = (catalog_data or {}).get("name") or _infer_name_from_id(entity_id)
+    user_prompt = (
+        f"Location: {entity_name} ({entity_id})\n\n"
+        f"## Catalog Data\n{_format_catalog_section(catalog_data)}\n\n"
+        f"## Events at this location\n{_format_events_for_prompt(events)}\n\n"
+        "Write a 2–4 sentence summary of this location's significance."
+    )
+    return {
+        "system_prompt": LOCATION_SYSTEM_PROMPT,
+        "user_prompt": user_prompt,
+    }
+
+
+def assemble_faction_input(entity_id: str, events: list[dict],
+                           catalog_data: dict | None) -> dict:
+    """Assemble input for a faction history section."""
+    entity_name = (catalog_data or {}).get("name") or _infer_name_from_id(entity_id)
+    user_prompt = (
+        f"Faction: {entity_name} ({entity_id})\n\n"
+        f"## Catalog Data\n{_format_catalog_section(catalog_data)}\n\n"
+        f"## Events involving this faction\n{_format_events_for_prompt(events)}\n\n"
+        "Write a concise history of this faction's role and trajectory."
+    )
+    return {
+        "system_prompt": FACTION_SYSTEM_PROMPT,
+        "user_prompt": user_prompt,
+    }
+
+
+def assemble_item_input(entity_id: str, events: list[dict],
+                        catalog_data: dict | None) -> dict:
+    """Assemble input for a notable item significance summary."""
+    entity_name = (catalog_data or {}).get("name") or _infer_name_from_id(entity_id)
+    user_prompt = (
+        f"Item: {entity_name} ({entity_id})\n\n"
+        f"## Catalog Data\n{_format_catalog_section(catalog_data)}\n\n"
+        f"## Events involving this item\n{_format_events_for_prompt(events)}\n\n"
+        "Write a 2–4 sentence summary of this item's significance."
+    )
+    return {
+        "system_prompt": ITEM_SYSTEM_PROMPT,
+        "user_prompt": user_prompt,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Narrative Biography Generator (LLM)
+# ---------------------------------------------------------------------------
+
+def generate_phase_biography(llm_client, synthesis_input: dict) -> tuple[str, dict]:
+    """Generate biography prose for a single phase via LLM.
+
+    Args:
+        llm_client: An LLMClient instance with a ``generate_text`` method.
+        synthesis_input: Dict from ``assemble_synthesis_input()``.
+
+    Returns:
+        Tuple of (markdown_text, phase_metadata).
+        On failure, returns a fallback message and metadata with error info.
+    """
+    try:
+        text = llm_client.generate_text(
+            system_prompt=synthesis_input["system_prompt"],
+            user_prompt=synthesis_input["user_prompt"],
+        )
+        llm_client.delay()
+
+        metadata = {
+            "name": synthesis_input.get("phase_name", ""),
+            "turn_range": synthesis_input.get("turn_range", []),
+            "events_used": synthesis_input.get("events_used", []),
+            "llm_model": getattr(llm_client, "model", "unknown"),
+            "tokens_used": _estimate_tokens(synthesis_input["user_prompt"], text),
+        }
+        return text, metadata
+
+    except Exception as e:
+        logger.error("Phase biography generation failed: %s", e)
+        fallback = ("[Generation failed — source events available in "
+                    "timeline below]")
+        metadata = {
+            "name": synthesis_input.get("phase_name", ""),
+            "turn_range": synthesis_input.get("turn_range", []),
+            "events_used": synthesis_input.get("events_used", []),
+            "llm_model": getattr(llm_client, "model", "unknown"),
+            "tokens_used": 0,
+            "error": str(e),
+        }
+        return fallback, metadata
+
+
+def generate_lede(llm_client, lede_input: dict) -> str:
+    """Generate the summary/lede paragraph from combined biography sections."""
+    try:
+        text = llm_client.generate_text(
+            system_prompt=lede_input["system_prompt"],
+            user_prompt=lede_input["user_prompt"],
+        )
+        llm_client.delay()
+        return text
+    except Exception as e:
+        logger.error("Lede generation failed: %s", e)
+        return ""
+
+
+def generate_location_summary(llm_client, loc_input: dict) -> str:
+    """Generate significance summary for a location."""
+    try:
+        text = llm_client.generate_text(
+            system_prompt=loc_input["system_prompt"],
+            user_prompt=loc_input["user_prompt"],
+        )
+        llm_client.delay()
+        return text
+    except Exception as e:
+        logger.error("Location summary generation failed: %s", e)
+        return ""
+
+
+def generate_faction_history(llm_client, faction_input: dict) -> str:
+    """Generate history section for a faction."""
+    try:
+        text = llm_client.generate_text(
+            system_prompt=faction_input["system_prompt"],
+            user_prompt=faction_input["user_prompt"],
+        )
+        llm_client.delay()
+        return text
+    except Exception as e:
+        logger.error("Faction history generation failed: %s", e)
+        return ""
+
+
+def generate_item_summary(llm_client, item_input: dict) -> str:
+    """Generate significance summary for a notable item."""
+    try:
+        text = llm_client.generate_text(
+            system_prompt=item_input["system_prompt"],
+            user_prompt=item_input["user_prompt"],
+        )
+        llm_client.delay()
+        return text
+    except Exception as e:
+        logger.error("Item summary generation failed: %s", e)
+        return ""
+
+
+def _estimate_tokens(prompt: str, response: str) -> int:
+    """Rough token estimate (~4 chars per token)."""
+    return (len(prompt) + len(response)) // 4
+
+
+# ---------------------------------------------------------------------------
+# Step 3: should_synthesize — entity type threshold
+# ---------------------------------------------------------------------------
+
+def should_synthesize(entity_id: str, event_count: int, entity_type: str) -> bool:
+    """Determine whether an entity warrants narrative synthesis."""
+    if entity_type == "character":
+        return event_count >= 3
+    if entity_type in ("location", "faction"):
+        return event_count >= 3
+    if entity_type == "item":
+        return event_count >= 3
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Page Assembly
+# ---------------------------------------------------------------------------
+
+def _escape_table_cell(text: str) -> str:
+    """Escape text for safe inclusion in a markdown table cell."""
+    text = str(text)
+    text = text.replace("|", "\\|")
+    text = text.replace("\n", " ")
+    text = text.replace("\r", "")
+    return text
+
+
+def _build_infobox(entity_id: str, catalog_data: dict | None,
+                   derived_profile: dict | None) -> str:
+    """Build an infobox table from catalog or event-derived profile."""
+    lines = ["| | |", "|---|---|"]
+
+    if catalog_data:
+        entity_type = catalog_data.get("type", "character").replace("_", " ").title()
+        lines.append(f"| **Type** | {entity_type} |")
+        first_seen = catalog_data.get("first_seen_turn", "")
+        last_updated = catalog_data.get("last_updated_turn", "")
+        if first_seen:
+            lines.append(f"| **First Seen** | {first_seen} |")
+        if last_updated:
+            lines.append(f"| **Last Updated** | {last_updated} |")
+        stable = catalog_data.get("stable_attributes", {})
+        for key, attr in stable.items():
+            if key == "aliases":
+                continue
+            if isinstance(attr, dict):
+                val = attr.get("value", "")
+            else:
+                val = attr
+            display_val = _escape_table_cell(str(val) if not isinstance(val, list)
+                                             else ", ".join(str(v) for v in val))
+            if len(display_val) <= 80:
+                lines.append(f"| **{key.replace('_', ' ').title()}** | {display_val} |")
+    elif derived_profile:
+        entity_type = derived_profile.get("type", "unknown").replace("_", " ").title()
+        lines.append(f"| **Type** | {entity_type} |")
+        lines.append(f"| **Source** | Events only (no catalog entry) |")
+        first = derived_profile.get("first_event_turn", "")
+        last = derived_profile.get("last_event_turn", "")
+        if first:
+            lines.append(f"| **First Event** | {first} |")
+        if last:
+            lines.append(f"| **Last Event** | {last} |")
+        lines.append(f"| **Event Count** | {derived_profile.get('event_count', 0)} |")
+
+    return "\n".join(lines)
+
+
+def _build_event_timeline(events: list[dict]) -> str:
+    """Build a chronological event timeline table."""
+    lines = ["| Turn | Type | Description |", "|---|---|---|"]
+    for evt in events:
+        turns = evt.get("source_turns", [])
+        turn_str = ", ".join(turns) if turns else "—"
+        etype = _escape_table_cell(evt.get("type", "other"))
+        desc = _escape_table_cell(evt.get("description", ""))
+        lines.append(f"| {turn_str} | {etype} | {desc} |")
+    return "\n".join(lines)
+
+
+def _build_relationship_table(arc_summaries: dict | None) -> str:
+    """Build a relationship arcs table from sidecar data."""
+    if not arc_summaries:
+        return ""
+
+    arcs = arc_summaries.get("arcs", {})
+    if not arcs:
+        return ""
+
+    lines = ["| Entity | Current Relationship | Interactions |",
+             "|---|---|---|"]
+    for target_id in sorted(arcs.keys()):
+        arc = arcs[target_id]
+        name = _infer_name_from_id(target_id)
+        current = _escape_table_cell(arc.get("current_relationship", ""))
+        count = arc.get("interaction_count", 0)
+        lines.append(f"| {name} ({target_id}) | {current} | {count} |")
+
+    return "\n".join(lines)
+
+
+def _build_current_status(catalog_data: dict | None, events: list[dict]) -> str:
+    """Build current status section from catalog or latest event."""
+    if catalog_data:
+        status = catalog_data.get("current_status", "")
+        turn = catalog_data.get("status_updated_turn",
+                                catalog_data.get("last_updated_turn", ""))
+        if status:
+            return f"*As of {turn}:*\n\n{status}"
+
+    # Derive from latest event
+    if events:
+        last = events[-1]
+        turns = last.get("source_turns", [])
+        turn = turns[0] if turns else "unknown"
+        desc = last.get("description", "")
+        return f"*Derived from latest event ({turn}):*\n\n{desc}"
+
+    return ""
+
+
+def assemble_character_page(entity_id: str, entity_name: str,
+                            lede: str, phase_texts: list[tuple[str, str]],
+                            catalog_data: dict | None,
+                            derived_profile: dict | None,
+                            arc_summaries: dict | None,
+                            all_events: list[dict]) -> str:
+    """Assemble a full character wiki page.
+
+    Args:
+        entity_id: Canonical entity ID.
+        entity_name: Display name.
+        lede: Summary paragraph from LLM.
+        phase_texts: List of (phase_name, markdown_text) tuples.
+        catalog_data: Catalog JSON or None.
+        derived_profile: Event-derived profile or None.
+        arc_summaries: Arc sidecar data or None.
+        all_events: All events for this entity (for timeline).
+
+    Returns:
+        Complete markdown page string.
+    """
+    lines = [f"# {entity_name}", ""]
+
+    if lede:
+        lines += [f"> {lede}", ""]
+
+    # Overview / infobox
+    lines += ["## Overview", "",
+              _build_infobox(entity_id, catalog_data, derived_profile), ""]
+
+    # Biography
+    lines += ["## Biography", ""]
+    for phase_name, text in phase_texts:
+        if phase_name:
+            lines += [f"### {phase_name}", ""]
+        lines += [text, ""]
+
+    # Relationships
+    rel_table = _build_relationship_table(arc_summaries)
+    if rel_table:
+        lines += ["## Relationships", "", rel_table, ""]
+
+    # Current Status
+    status = _build_current_status(catalog_data, all_events)
+    if status:
+        lines += ["## Current Status", "", status, ""]
+
+    # Event Timeline
+    lines += ["## Event Timeline", "",
+              _build_event_timeline(all_events), ""]
+
+    # Footer
+    lines += ["---",
+              f"*Generated from events data — do not edit manually.*"]
+
+    return "\n".join(lines) + "\n"
+
+
+def assemble_location_page(entity_id: str, entity_name: str,
+                           significance: str,
+                           catalog_data: dict | None,
+                           derived_profile: dict | None,
+                           all_events: list[dict]) -> str:
+    """Assemble a location wiki page."""
+    lines = [f"# {entity_name}", ""]
+
+    identity = (catalog_data or {}).get("identity", "")
+    if identity:
+        lines += [f"> {identity}", ""]
+
+    # Overview / infobox
+    lines += ["## Overview", "",
+              _build_infobox(entity_id, catalog_data, derived_profile), ""]
+
+    # Significance
+    if significance:
+        lines += ["## Significance", "", significance, ""]
+
+    # Key Events
+    lines += ["## Key Events", "",
+              _build_event_timeline(all_events), ""]
+
+    # Connected entities (from catalog relationships)
+    if catalog_data and catalog_data.get("relationships"):
+        lines += ["## Connected Entities", "",
+                  "| Entity | Connection |", "|---|---|"]
+        for rel in catalog_data["relationships"]:
+            target = rel.get("target_id", "")
+            name = _infer_name_from_id(target)
+            cur = _escape_table_cell(rel.get("current_relationship", ""))
+            lines.append(f"| {name} ({target}) | {cur} |")
+        lines.append("")
+
+    lines += ["---",
+              f"*Generated from events data — do not edit manually.*"]
+    return "\n".join(lines) + "\n"
+
+
+def assemble_faction_page(entity_id: str, entity_name: str,
+                          history: str,
+                          catalog_data: dict | None,
+                          derived_profile: dict | None,
+                          all_events: list[dict]) -> str:
+    """Assemble a faction wiki page."""
+    lines = [f"# {entity_name}", ""]
+
+    identity = (catalog_data or {}).get("identity", "")
+    if identity:
+        lines += [f"> {identity}", ""]
+
+    # Overview / infobox
+    lines += ["## Overview", "",
+              _build_infobox(entity_id, catalog_data, derived_profile), ""]
+
+    # History
+    if history:
+        lines += ["## History", "", history, ""]
+
+    # Members (from event co-occurrences)
+    member_ids: set[str] = set()
+    for evt in all_events:
+        for raw_id in evt.get("related_entities", []):
+            canon = resolve_entity_id(raw_id)
+            if canon != entity_id and _infer_type_from_id(canon) == "character":
+                member_ids.add(canon)
+
+    if member_ids:
+        lines += ["## Known Members", "",
+                  "| Member | First Seen |", "|---|---|"]
+        for mid in sorted(member_ids):
+            name = _infer_name_from_id(mid)
+            # Find first event with this member
+            first_turn = ""
+            for evt in all_events:
+                resolved = [resolve_entity_id(r) for r in evt.get("related_entities", [])]
+                if mid in resolved:
+                    turns = evt.get("source_turns", [])
+                    first_turn = turns[0] if turns else ""
+                    break
+            lines.append(f"| {name} ({mid}) | {first_turn} |")
+        lines.append("")
+
+    # Key Events
+    lines += ["## Key Events", "",
+              _build_event_timeline(all_events), ""]
+
+    lines += ["---",
+              f"*Generated from events data — do not edit manually.*"]
+    return "\n".join(lines) + "\n"
+
+
+def assemble_item_page(entity_id: str, entity_name: str,
+                       significance: str,
+                       catalog_data: dict | None,
+                       derived_profile: dict | None,
+                       all_events: list[dict]) -> str:
+    """Assemble an item wiki page."""
+    lines = [f"# {entity_name}", ""]
+
+    identity = (catalog_data or {}).get("identity", "")
+    if identity:
+        lines += [f"> {identity}", ""]
+
+    # Overview / infobox
+    lines += ["## Overview", "",
+              _build_infobox(entity_id, catalog_data, derived_profile), ""]
+
+    # Significance
+    if significance:
+        lines += ["## Significance", "", significance, ""]
+
+    # Key Events
+    lines += ["## Key Events", "",
+              _build_event_timeline(all_events), ""]
+
+    lines += ["---",
+              f"*Generated from events data — do not edit manually.*"]
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Step 5: Provenance Validation
+# ---------------------------------------------------------------------------
+
+def extract_cited_turns(markdown: str) -> list[str]:
+    """Extract all [turn-NNN] references from generated markdown."""
+    return sorted(set(re.findall(r"\[turn-\d+\]", markdown)),
+                  key=lambda t: _parse_turn_number(t.strip("[]")))
+
+
+def validate_provenance(markdown: str, available_turns: list[str],
+                        critical_event_turns: list[str] | None = None
+                        ) -> dict:
+    """Run post-generation provenance validation.
+
+    Args:
+        markdown: Generated markdown text.
+        available_turns: Turns that were provided as input to the LLM.
+        critical_event_turns: Turns of critical events that should be cited.
+
+    Returns:
+        Provenance check dict with hallucination_flags and
+        uncited_critical_events.
+    """
+    cited = extract_cited_turns(markdown)
+    cited_bare = [t.strip("[]") for t in cited]
+
+    available_set = set(available_turns)
+    hallucination_flags = [t for t in cited_bare if t not in available_set]
+    uncited = []
+    if critical_event_turns:
+        cited_set = set(cited_bare)
+        uncited = [t for t in critical_event_turns if t not in cited_set]
+
+    return {
+        "turns_cited": cited_bare,
+        "turns_available": sorted(available_turns,
+                                  key=lambda t: _parse_turn_number(t)),
+        "hallucination_flags": hallucination_flags,
+        "uncited_critical_events": uncited,
+    }
+
+
+def add_provenance_warning(markdown: str, entity_id: str) -> str:
+    """Prepend a provenance warning banner to the page."""
+    warning = (
+        f"> \u26a0\ufe0f **Provenance warning**: This page cites turns not "
+        f"present in source data.\n"
+        f"> Review flagged citations in {entity_id}.synthesis.json.\n\n"
+    )
+    return warning + markdown
+
+
+# ---------------------------------------------------------------------------
+# Step 6: Sidecar Generation
+# ---------------------------------------------------------------------------
+
+def build_synthesis_sidecar(entity_id: str, events: list[dict],
+                            catalog_available: bool,
+                            catalog_last_updated: str,
+                            arc_count: int,
+                            phase_metadata: list[dict],
+                            provenance: dict) -> dict:
+    """Build the .synthesis.json sidecar data."""
+    turn_range = ["", ""]
+    if events:
+        first_turns = events[0].get("source_turns", [])
+        last_turns = events[-1].get("source_turns", [])
+        if first_turns:
+            turn_range[0] = first_turns[0]
+        if last_turns:
+            turn_range[1] = last_turns[0]
+
+    return {
+        "entity_id": entity_id,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source_data": {
+            "events_count": len(events),
+            "events_turn_range": turn_range,
+            "catalog_available": catalog_available,
+            "catalog_last_updated": catalog_last_updated,
+            "relationship_arcs_count": arc_count,
+        },
+        "phases": phase_metadata,
+        "provenance_check": provenance,
+    }
+
+
+def write_synthesis_sidecar(sidecar: dict, output_path: str) -> str:
+    """Write the .synthesis.json sidecar file."""
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(sidecar, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    return output_path
+
+
+def load_synthesis_sidecar(path: str) -> dict | None:
+    """Load an existing synthesis sidecar. Returns None if not found."""
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8-sig") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Step 7: Full synthesis pipeline for a single entity
+# ---------------------------------------------------------------------------
+
+def synthesize_entity(entity_id: str, entity_events: list[dict],
+                      catalog_data: dict | None,
+                      arc_summaries: dict | None,
+                      llm_client,
+                      entity_type: str | None = None) -> tuple[str, dict]:
+    """Run the full synthesis pipeline for a single entity.
+
+    Args:
+        entity_id: Canonical entity ID.
+        entity_events: Sorted events for this entity.
+        catalog_data: Catalog entry dict or None.
+        arc_summaries: Arc sidecar data or None.
+        llm_client: LLMClient instance.
+        entity_type: Override entity type (otherwise inferred).
+
+    Returns:
+        Tuple of (markdown_page, sidecar_dict).
+    """
+    etype = entity_type or (catalog_data or {}).get("type") or _infer_type_from_id(entity_id)
+    entity_name = (catalog_data or {}).get("name") or _infer_name_from_id(entity_id)
+    derived_profile = None if catalog_data else build_event_derived_profile(entity_id, entity_events)
+
+    if etype == "location":
+        return _synthesize_location(entity_id, entity_name, entity_events,
+                                    catalog_data, derived_profile, llm_client)
+    elif etype == "faction":
+        return _synthesize_faction(entity_id, entity_name, entity_events,
+                                   catalog_data, derived_profile, llm_client)
+    elif etype == "item":
+        return _synthesize_item(entity_id, entity_name, entity_events,
+                                catalog_data, derived_profile, llm_client)
+    else:
+        return _synthesize_character(entity_id, entity_name, entity_events,
+                                     catalog_data, derived_profile,
+                                     arc_summaries, llm_client)
+
+
+def _synthesize_character(entity_id, entity_name, events, catalog_data,
+                          derived_profile, arc_summaries, llm_client):
+    """Synthesize a character page with per-phase biography."""
+    phases = segment_phases(events, entity_id)
+
+    all_available_turns: set[str] = set()
+    phase_texts = []
+    phase_metadata = []
+
+    for phase in phases:
+        synth_input = assemble_synthesis_input(
+            entity_id, phase, catalog_data, arc_summaries, ID_ALIASES)
+        for t in synth_input["available_turns"]:
+            all_available_turns.add(t)
+
+        text, meta = generate_phase_biography(llm_client, synth_input)
+        phase_name = synth_input["phase_name"]
+        phase_texts.append((phase_name, text))
+        phase_metadata.append(meta)
+
+    # Generate lede
+    bio_sections = [text for _, text in phase_texts]
+    lede_input = assemble_lede_input(entity_id, bio_sections, catalog_data)
+    lede = generate_lede(llm_client, lede_input)
+
+    # Assemble page
+    page = assemble_character_page(
+        entity_id, entity_name, lede, phase_texts,
+        catalog_data, derived_profile, arc_summaries, events)
+
+    # Provenance validation across all phases
+    available = sorted(all_available_turns,
+                       key=lambda t: _parse_turn_number(t))
+    provenance = validate_provenance(page, available)
+
+    if provenance["hallucination_flags"]:
+        page = add_provenance_warning(page, entity_id)
+
+    # Sidecar
+    catalog_last_updated = (catalog_data or {}).get("last_updated_turn", "")
+    arc_count = len((arc_summaries or {}).get("arcs", {}))
+    sidecar = build_synthesis_sidecar(
+        entity_id, events, catalog_data is not None,
+        catalog_last_updated, arc_count, phase_metadata, provenance)
+
+    return page, sidecar
+
+
+def _synthesize_location(entity_id, entity_name, events, catalog_data,
+                         derived_profile, llm_client):
+    """Synthesize a location page."""
+    loc_input = assemble_location_input(entity_id, events, catalog_data)
+    significance = generate_location_summary(llm_client, loc_input)
+
+    page = assemble_location_page(entity_id, entity_name, significance,
+                                  catalog_data, derived_profile, events)
+
+    available_turns = set()
+    for evt in events:
+        for t in evt.get("source_turns", []):
+            available_turns.add(t)
+    available = sorted(available_turns, key=lambda t: _parse_turn_number(t))
+    provenance = validate_provenance(page, available)
+    if provenance["hallucination_flags"]:
+        page = add_provenance_warning(page, entity_id)
+
+    sidecar = build_synthesis_sidecar(
+        entity_id, events, catalog_data is not None,
+        (catalog_data or {}).get("last_updated_turn", ""),
+        0, [], provenance)
+
+    return page, sidecar
+
+
+def _synthesize_faction(entity_id, entity_name, events, catalog_data,
+                        derived_profile, llm_client):
+    """Synthesize a faction page."""
+    fac_input = assemble_faction_input(entity_id, events, catalog_data)
+    history = generate_faction_history(llm_client, fac_input)
+
+    page = assemble_faction_page(entity_id, entity_name, history,
+                                 catalog_data, derived_profile, events)
+
+    available_turns = set()
+    for evt in events:
+        for t in evt.get("source_turns", []):
+            available_turns.add(t)
+    available = sorted(available_turns, key=lambda t: _parse_turn_number(t))
+    provenance = validate_provenance(page, available)
+    if provenance["hallucination_flags"]:
+        page = add_provenance_warning(page, entity_id)
+
+    sidecar = build_synthesis_sidecar(
+        entity_id, events, catalog_data is not None,
+        (catalog_data or {}).get("last_updated_turn", ""),
+        0, [], provenance)
+
+    return page, sidecar
+
+
+def _synthesize_item(entity_id, entity_name, events, catalog_data,
+                     derived_profile, llm_client):
+    """Synthesize an item page."""
+    item_input = assemble_item_input(entity_id, events, catalog_data)
+    significance = generate_item_summary(llm_client, item_input)
+
+    page = assemble_item_page(entity_id, entity_name, significance,
+                              catalog_data, derived_profile, events)
+
+    available_turns = set()
+    for evt in events:
+        for t in evt.get("source_turns", []):
+            available_turns.add(t)
+    available = sorted(available_turns, key=lambda t: _parse_turn_number(t))
+    provenance = validate_provenance(page, available)
+    if provenance["hallucination_flags"]:
+        page = add_provenance_warning(page, entity_id)
+
+    sidecar = build_synthesis_sidecar(
+        entity_id, events, catalog_data is not None,
+        (catalog_data or {}).get("last_updated_turn", ""),
+        0, [], provenance)
+
+    return page, sidecar
+
+
+# ---------------------------------------------------------------------------
+# Incremental awareness
+# ---------------------------------------------------------------------------
+
+def needs_regeneration(entity_id: str, event_count: int,
+                       sidecar_path: str, force: bool = False) -> bool:
+    """Check if an entity needs synthesis regeneration.
+
+    Args:
+        entity_id: The entity ID.
+        event_count: Current number of events for this entity.
+        sidecar_path: Path to existing .synthesis.json.
+        force: If True, always regenerate.
+
+    Returns:
+        True if regeneration is needed.
+    """
+    if force:
+        return True
+
+    existing = load_synthesis_sidecar(sidecar_path)
+    if existing is None:
+        return True
+
+    prev_count = existing.get("source_data", {}).get("events_count", 0)
+    return event_count != prev_count

--- a/tools/narrative_synthesis.py
+++ b/tools/narrative_synthesis.py
@@ -153,7 +153,7 @@ def _format_catalog_section(catalog_data: dict | None) -> str:
     return "\n\n".join(parts) if parts else "Catalog entry exists but contains no data."
 
 
-def _format_arc_section(arc_summaries: dict | None, entity_id: str,
+def _format_arc_section(arc_summaries: dict | None,
                         max_arcs: int = 5) -> str:
     """Format relationship arc summaries for the LLM prompt."""
     if not arc_summaries:
@@ -190,8 +190,7 @@ def _format_arc_section(arc_summaries: dict | None, entity_id: str,
 
 def assemble_synthesis_input(entity_id: str, phase: dict,
                              catalog_data: dict | None,
-                             arc_summaries: dict | None,
-                             id_aliases: dict) -> dict:
+                             arc_summaries: dict | None) -> dict:
     """Assemble structured input for the narrative LLM.
 
     Args:
@@ -199,7 +198,6 @@ def assemble_synthesis_input(entity_id: str, phase: dict,
         phase: Phase dict with ``name``, ``turn_range``, ``events``.
         catalog_data: Entity catalog JSON or None.
         arc_summaries: Arc sidecar data or None.
-        id_aliases: ID alias mapping dict.
 
     Returns:
         Dict with ``system_prompt``, ``user_prompt``, ``events_used``,
@@ -234,7 +232,7 @@ def assemble_synthesis_input(entity_id: str, phase: dict,
         _format_events_for_prompt(events),
         "",
         "## Relationship Arcs",
-        _format_arc_section(arc_summaries, entity_id),
+        _format_arc_section(arc_summaries),
         "",
         "## Task",
         (f"Write the \"{phase_name}\" section of this entity's biography, "
@@ -432,6 +430,23 @@ def generate_item_summary(llm_client, item_input: dict) -> str:
 def _estimate_tokens(prompt: str, response: str) -> int:
     """Rough token estimate (~4 chars per token)."""
     return (len(prompt) + len(response)) // 4
+
+
+# Critical event types that should be cited in the biography
+_CRITICAL_EVENT_TYPES = frozenset({
+    "birth", "death", "arrival", "departure", "decision", "ritual",
+    "discovery", "recruitment", "combat",
+})
+
+
+def _collect_critical_turns(events: list[dict]) -> list[str]:
+    """Collect source turns from critical events for omission checking."""
+    turns: list[str] = []
+    for evt in events:
+        if evt.get("type", "") in _CRITICAL_EVENT_TYPES:
+            for t in evt.get("source_turns", []):
+                turns.append(t)
+    return sorted(set(turns), key=_parse_turn_number)
 
 
 # ---------------------------------------------------------------------------
@@ -896,7 +911,7 @@ def _synthesize_character(entity_id, entity_name, events, catalog_data,
 
     for phase in phases:
         synth_input = assemble_synthesis_input(
-            entity_id, phase, catalog_data, arc_summaries, ID_ALIASES)
+            entity_id, phase, catalog_data, arc_summaries)
         for t in synth_input["available_turns"]:
             all_available_turns.add(t)
 
@@ -917,7 +932,9 @@ def _synthesize_character(entity_id, entity_name, events, catalog_data,
 
     # Provenance validation across all phases
     available = sorted(all_available_turns, key=_parse_turn_number)
-    provenance = validate_provenance(page, available)
+    # Identify critical events (births, deaths, arrivals) for omission checking
+    critical_turns = _collect_critical_turns(events)
+    provenance = validate_provenance(page, available, critical_turns)
 
     if provenance["hallucination_flags"]:
         page = add_provenance_warning(page, entity_id)

--- a/tools/narrative_synthesis.py
+++ b/tools/narrative_synthesis.py
@@ -26,13 +26,8 @@ from datetime import datetime, timezone
 from synthesis import (
     ID_ALIASES,
     build_event_derived_profile,
-    group_events_by_entity,
-    load_events,
-    merge_relationship_histories,
     resolve_entity_id,
     segment_phases,
-    summarize_relationship_arcs,
-    write_arc_sidecar,
     _infer_name_from_id,
     _infer_type_from_id,
     _parse_turn_number,
@@ -263,7 +258,7 @@ def assemble_synthesis_input(entity_id: str, phase: dict,
         "turn_range": turn_range,
         "phase_name": phase_name,
         "available_turns": sorted(available_turns,
-                                  key=lambda t: _parse_turn_number(t)),
+                                  key=_parse_turn_number),
     }
 
 
@@ -778,7 +773,7 @@ def validate_provenance(markdown: str, available_turns: list[str],
     return {
         "turns_cited": cited_bare,
         "turns_available": sorted(available_turns,
-                                  key=lambda t: _parse_turn_number(t)),
+                                  key=_parse_turn_number),
         "hallucination_flags": hallucination_flags,
         "uncited_critical_events": uncited,
     }
@@ -921,8 +916,7 @@ def _synthesize_character(entity_id, entity_name, events, catalog_data,
         catalog_data, derived_profile, arc_summaries, events)
 
     # Provenance validation across all phases
-    available = sorted(all_available_turns,
-                       key=lambda t: _parse_turn_number(t))
+    available = sorted(all_available_turns, key=_parse_turn_number)
     provenance = validate_provenance(page, available)
 
     if provenance["hallucination_flags"]:
@@ -951,7 +945,7 @@ def _synthesize_location(entity_id, entity_name, events, catalog_data,
     for evt in events:
         for t in evt.get("source_turns", []):
             available_turns.add(t)
-    available = sorted(available_turns, key=lambda t: _parse_turn_number(t))
+    available = sorted(available_turns, key=_parse_turn_number)
     provenance = validate_provenance(page, available)
     if provenance["hallucination_flags"]:
         page = add_provenance_warning(page, entity_id)
@@ -977,7 +971,7 @@ def _synthesize_faction(entity_id, entity_name, events, catalog_data,
     for evt in events:
         for t in evt.get("source_turns", []):
             available_turns.add(t)
-    available = sorted(available_turns, key=lambda t: _parse_turn_number(t))
+    available = sorted(available_turns, key=_parse_turn_number)
     provenance = validate_provenance(page, available)
     if provenance["hallucination_flags"]:
         page = add_provenance_warning(page, entity_id)
@@ -1003,7 +997,7 @@ def _synthesize_item(entity_id, entity_name, events, catalog_data,
     for evt in events:
         for t in evt.get("source_turns", []):
             available_turns.add(t)
-    available = sorted(available_turns, key=lambda t: _parse_turn_number(t))
+    available = sorted(available_turns, key=_parse_turn_number)
     provenance = validate_provenance(page, available)
     if provenance["hallucination_flags"]:
         page = add_provenance_warning(page, entity_id)


### PR DESCRIPTION
## Summary

LLM-powered narrative wiki generation that transforms structured event data into readable
campaign wiki pages with full provenance tracking.

## Narrative Biography Generation

- Per-phase LLM biography generation with inline turn citations
- Entity type adaptations: characters (full biography), locations (event table),
  factions (history arc), items (significance for notable items)
- Input assembly supporting full catalog data, events-only, and mixed scenarios
- System prompts enforcing encyclopedic tone, factual grounding, and citation requirements

## Page Assembly and Provenance

- Markdown page assembly with infobox, biography, relationships, timeline appendix
- Post-generation provenance validation flagging hallucinated and omitted turns
- Warning banners prepended to pages with citation issues
- Synthesis sidecar metadata files (`.synthesis.json`) for incremental regeneration and cost tracking

## CLI Integration

- `--synthesize` flag for `generate_wiki_pages.py`
- `--force` for full regeneration
- Incremental awareness: skips entities with no new events since last generation
- Backward compatible: without `--synthesize`, existing template rendering unchanged
- Works with `--type` filter (e.g., `--type characters --synthesize`)

## LLM Client Extension

- Added `generate_text()` method to `LLMClient` for free-form text responses (narrative prose)
- Existing `extract_json()` unchanged; `generate_text()` omits JSON response format constraint

## Testing

- 58 unit and integration tests in `tests/test_narrative_synthesis.py`
- Input assembly tests for full-data, events-only, and small entities
- Provenance validation: hallucination detection, omission detection, clean pass
- Page assembly: character, location, faction, item structures verified
- `should_synthesize()` threshold tests for all entity types
- Full pipeline integration tests with mock LLM client
- Incremental skip verification on second run
- All 365 existing tests continue to pass

Closes #110
