### PR TITLE
fix: pronoun filter, concept-prefix stub guard, PC context dedup

### DIFF
--- a/tests/test_pipeline_v3.py
+++ b/tests/test_pipeline_v3.py
@@ -10,6 +10,7 @@ from semantic_extraction import (
     _pc_partial_merge,
     _format_prior_entity_context,
     _post_batch_orphan_sweep,
+    format_detail_prompt,
 )
 
 
@@ -337,3 +338,144 @@ class TestPostBatchOrphanSweep:
         ]
         count = _post_batch_orphan_sweep(catalogs, events)
         assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Pronoun entity filter tests (#116)
+# ---------------------------------------------------------------------------
+
+class TestPronounFilter:
+    """Pronouns in _GENERIC_STEMS are rejected by stub creation."""
+
+    def _empty_catalogs(self):
+        return {
+            "characters.json": [],
+            "locations.json": [],
+            "factions.json": [],
+            "items.json": [],
+        }
+
+    def test_skips_pronoun_char_she(self):
+        catalogs = self._empty_catalogs()
+        events = [{"id": "evt-1", "related_entities": ["char-she"], "turn_id": "turn-100"}]
+        _create_orphan_stubs(catalogs, events, "turn-100")
+        assert len(catalogs["characters.json"]) == 0
+
+    def test_skips_pronoun_char_he(self):
+        catalogs = self._empty_catalogs()
+        events = [{"id": "evt-1", "related_entities": ["char-he"], "turn_id": "turn-100"}]
+        _create_orphan_stubs(catalogs, events, "turn-100")
+        assert len(catalogs["characters.json"]) == 0
+
+    def test_skips_pronoun_char_they(self):
+        catalogs = self._empty_catalogs()
+        events = [{"id": "evt-1", "related_entities": ["char-they"], "turn_id": "turn-100"}]
+        _create_orphan_stubs(catalogs, events, "turn-100")
+        assert len(catalogs["characters.json"]) == 0
+
+    def test_skips_pronoun_char_it(self):
+        catalogs = self._empty_catalogs()
+        events = [{"id": "evt-1", "related_entities": ["char-it"], "turn_id": "turn-100"}]
+        _create_orphan_stubs(catalogs, events, "turn-100")
+        assert len(catalogs["characters.json"]) == 0
+
+    def test_existing_generic_stems_still_work(self):
+        catalogs = self._empty_catalogs()
+        events = [{"id": "evt-1", "related_entities": ["char-stranger"], "turn_id": "turn-100"}]
+        _create_orphan_stubs(catalogs, events, "turn-100")
+        assert len(catalogs["characters.json"]) == 0
+
+    def test_real_entity_still_created(self):
+        catalogs = self._empty_catalogs()
+        events = [{"id": "evt-1", "related_entities": ["char-kael"], "turn_id": "turn-100"}]
+        _create_orphan_stubs(catalogs, events, "turn-100")
+        assert len(catalogs["characters.json"]) == 1
+        assert catalogs["characters.json"][0]["id"] == "char-kael"
+
+
+# ---------------------------------------------------------------------------
+# Concept-prefix in stub creation tests (#117)
+# ---------------------------------------------------------------------------
+
+class TestConceptPrefixStubFilter:
+    """Concept-prefix entities are rejected by stub creation."""
+
+    def _empty_catalogs(self):
+        return {
+            "characters.json": [],
+            "locations.json": [],
+            "factions.json": [],
+            "items.json": [],
+        }
+
+    def test_skips_concept_midwinter_celebration(self):
+        catalogs = self._empty_catalogs()
+        events = [{"id": "evt-1", "related_entities": ["concept-midwinter-celebration"], "turn_id": "turn-200"}]
+        _create_orphan_stubs(catalogs, events, "turn-200")
+        all_ids = {e["id"] for cat in catalogs.values() for e in cat}
+        assert "concept-midwinter-celebration" not in all_ids
+
+    def test_skips_concept_anything(self):
+        catalogs = self._empty_catalogs()
+        events = [{"id": "evt-1", "related_entities": ["concept-honor"], "turn_id": "turn-200"}]
+        _create_orphan_stubs(catalogs, events, "turn-200")
+        all_ids = {e["id"] for cat in catalogs.values() for e in cat}
+        assert "concept-honor" not in all_ids
+
+    def test_non_concept_still_creates_stub(self):
+        catalogs = self._empty_catalogs()
+        events = [{"id": "evt-1", "related_entities": ["item-magic-sword"], "turn_id": "turn-200"}]
+        _create_orphan_stubs(catalogs, events, "turn-200")
+        all_ids = {e["id"] for cat in catalogs.values() for e in cat}
+        assert "item-magic-sword" in all_ids
+
+
+# ---------------------------------------------------------------------------
+# PC detail prompt double-context tests (#119)
+# ---------------------------------------------------------------------------
+
+class TestPCDetailPromptContext:
+    """format_detail_prompt omits full entry_json for char-player."""
+
+    def _make_turn(self):
+        return {"turn_id": "turn-100", "speaker": "DM", "text": "The forest grows dark."}
+
+    def _make_entry(self, entity_id="char-player"):
+        return {
+            "id": entity_id,
+            "name": "Player Character" if entity_id == "char-player" else "Kael",
+            "type": "character",
+            "identity": "A brave adventurer.",
+            "current_status": "Exploring the forest.",
+            "stable_attributes": {"race": {"value": "Human"}},
+            "volatile_state": {"condition": "healthy"},
+            "first_seen_turn": "turn-001",
+            "last_updated_turn": "turn-099",
+        }
+
+    def test_pc_prompt_omits_current_catalog_entry(self):
+        turn = self._make_turn()
+        ref = {"name": "Player Character", "type": "character", "existing_id": "char-player"}
+        entry = self._make_entry("char-player")
+        prompt = format_detail_prompt(turn, ref, entry)
+        assert "## Current Catalog Entry" not in prompt
+
+    def test_non_pc_prompt_includes_current_catalog_entry(self):
+        turn = self._make_turn()
+        ref = {"name": "Kael", "type": "character", "existing_id": "char-kael"}
+        entry = self._make_entry("char-kael")
+        prompt = format_detail_prompt(turn, ref, entry)
+        assert "## Current Catalog Entry" in prompt
+
+    def test_pc_prompt_shorter_than_non_pc(self):
+        turn = self._make_turn()
+        pc_ref = {"name": "Player Character", "type": "character", "existing_id": "char-player"}
+        pc_entry = self._make_entry("char-player")
+        pc_prompt = format_detail_prompt(turn, pc_ref, pc_entry)
+
+        npc_ref = {"name": "Player Character", "type": "character", "existing_id": "char-npc"}
+        npc_entry = self._make_entry("char-player")
+        npc_entry["id"] = "char-npc"
+        npc_prompt = format_detail_prompt(turn, npc_ref, npc_entry)
+
+        assert len(pc_prompt) < len(npc_prompt)

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -434,7 +434,6 @@ def _format_prior_entity_context(current_entry: dict | None) -> str:
 
 def format_detail_prompt(turn: dict, entity_ref: dict, current_entry: dict | None) -> str:
     """Format the user prompt for entity detail extraction."""
-    entry_json = json.dumps(current_entry, indent=2) if current_entry else "{}"
     prior_json = _format_prior_entity_context(current_entry)
     entity_id = entity_ref.get('existing_id') or entity_ref.get('proposed_id')
     is_pc = (entity_id == "char-player")
@@ -453,6 +452,7 @@ def format_detail_prompt(turn: dict, entity_ref: dict, current_entry: dict | Non
     # For PC, skip the full catalog entry to avoid context bloat (#119).
     # The trimmed prior_json already contains all essential entity context.
     if not is_pc:
+        entry_json = json.dumps(current_entry, indent=2) if current_entry else "{}"
         prompt += f"\n\n## Current Catalog Entry\n```json\n{entry_json}\n```"
     return prompt
 

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -436,19 +436,25 @@ def format_detail_prompt(turn: dict, entity_ref: dict, current_entry: dict | Non
     """Format the user prompt for entity detail extraction."""
     entry_json = json.dumps(current_entry, indent=2) if current_entry else "{}"
     prior_json = _format_prior_entity_context(current_entry)
-    return (
+    entity_id = entity_ref.get('existing_id') or entity_ref.get('proposed_id')
+    is_pc = (entity_id == "char-player")
+    prompt = (
         f"## Current Turn\n"
         f"Turn ID: {turn['turn_id']}\n"
         f"Speaker: {turn['speaker']}\n"
         f"Text:\n{turn['text']}\n\n"
         f"## Entity to Extract/Update\n"
-        f"Entity ID: {entity_ref.get('existing_id') or entity_ref.get('proposed_id')}\n"
+        f"Entity ID: {entity_id}\n"
         f"Entity Name: {entity_ref['name']}\n"
         f"Entity Type: {entity_ref['type']}\n\n"
         f"## Prior entity state (for reference, update as needed):\n"
-        f"```json\n{prior_json}\n```\n\n"
-        f"## Current Catalog Entry\n```json\n{entry_json}\n```"
+        f"```json\n{prior_json}\n```"
     )
+    # For PC, skip the full catalog entry to avoid context bloat (#119).
+    # The trimmed prior_json already contains all essential entity context.
+    if not is_pc:
+        prompt += f"\n\n## Current Catalog Entry\n```json\n{entry_json}\n```"
+    return prompt
 
 
 def _collect_existing_relationships(catalogs: dict, entity_ids: list[str]) -> str:
@@ -589,6 +595,9 @@ _GENERIC_STEMS = {
     "stranger", "figure", "someone", "person", "creature", "thing",
     "guard", "villager", "traveler", "merchant", "soldier", "voice",
     "shadow", "spirit", "beast", "animal",
+    # Pronouns — should never become entity IDs
+    "she", "he", "they", "it", "her", "him", "them",
+    "his", "hers", "its", "their", "theirs",
 }
 
 
@@ -607,6 +616,9 @@ def _create_orphan_stubs(catalogs: dict, events: list, turn_id: str) -> None:
                 orphan_ids.add(eid)
 
     for eid in sorted(orphan_ids):
+        # Skip concept-prefix entities — abstract concepts, not catalogue entities
+        if eid.startswith("concept-"):
+            continue
         # Skip generic/unnamed entity references
         stem = _strip_any_prefix(eid)
         if stem in _GENERIC_STEMS:
@@ -692,6 +704,11 @@ def extract_and_merge(
     for entity_ref in qualified:
         entity_id = get_entity_id(entity_ref)
         if not entity_id:
+            continue
+
+        # Skip pronoun / generic-stem IDs that slipped through discovery
+        stem = _strip_any_prefix(entity_id)
+        if stem.lower() in _GENERIC_STEMS:
             continue
 
         # Look up current entry for existing entities
@@ -1025,6 +1042,9 @@ def _post_batch_orphan_sweep(catalogs: dict, events_list: list) -> int:
         if len(turn_ids) < _POST_BATCH_ORPHAN_MIN_REFS:
             continue
 
+        # Skip concept-prefix entities
+        if eid.startswith("concept-"):
+            continue
         stem = _strip_any_prefix(eid)
         if stem in _GENERIC_STEMS:
             continue


### PR DESCRIPTION
## Summary

Three quick fixes addressing extraction data quality and PC context size.

## Issue #116 � Pronoun entity filter

Added pronouns (she, he, they, it, her, him, them, etc.) to _GENERIC_STEMS blocklist.
Pronoun IDs are now rejected in both stub creation and entity discovery paths.

## Issue #117 � Concept-prefix in stub creation

Added concept- prefix check to _create_orphan_stubs() and _post_batch_orphan_sweep(),
matching the existing filter in the normal extraction path.

## Issue #119 � Remove double context in PC extraction

Removed the redundant full entry_json section from PC extraction prompts.
The trimmed prior_json already contains all essential entity context.
Non-PC entities retain both sections (context is small enough).

Closes #116
Closes #117
Closes #119
