### PR TITLE
feat: context compacting for PC extraction (#118, #120, #121)

### DIFF
--- a/config/llm.json
+++ b/config/llm.json
@@ -7,5 +7,6 @@
   "max_tokens": 4096,
   "timeout_seconds": 120,
   "retry_attempts": 3,
-  "batch_delay_ms": 200
+  "batch_delay_ms": 200,
+  "context_length": 32768
 }

--- a/tests/test_pipeline_v3.py
+++ b/tests/test_pipeline_v3.py
@@ -11,6 +11,10 @@ from semantic_extraction import (
     _format_prior_entity_context,
     _post_batch_orphan_sweep,
     format_detail_prompt,
+    _compact_relationships_with_arcs,
+    _build_volatile_digest,
+    _extract_turn_number,
+    _extract_themes,
 )
 
 
@@ -479,3 +483,429 @@ class TestPCDetailPromptContext:
         npc_prompt = format_detail_prompt(turn, npc_ref, npc_entry)
 
         assert len(pc_prompt) < len(npc_prompt)
+
+
+# ---------------------------------------------------------------------------
+# num_ctx / context_length support tests (#118)
+# ---------------------------------------------------------------------------
+
+class TestContextLengthPassthrough:
+    """LLMClient passes extra_body with num_ctx when context_length is set."""
+
+    def test_extract_json_includes_num_ctx(self, tmp_path):
+        config = {
+            "provider": "openai",
+            "base_url": "http://localhost:11434/v1",
+            "model": "test-model",
+            "api_key_env": "",
+            "temperature": 0.0,
+            "max_tokens": 100,
+            "timeout_seconds": 10,
+            "retry_attempts": 1,
+            "batch_delay_ms": 0,
+            "context_length": 32768,
+        }
+        config_path = tmp_path / "llm.json"
+        config_path.write_text(json.dumps(config))
+
+        from unittest.mock import MagicMock, patch
+        from llm_client import LLMClient
+
+        with patch("openai.OpenAI") as mock_openai_cls:
+            mock_client = MagicMock()
+            mock_openai_cls.return_value = mock_client
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = '{"result": "ok"}'
+            mock_client.chat.completions.create.return_value = mock_response
+
+            client = LLMClient(str(config_path))
+            client.extract_json("system", "user")
+
+            call_kwargs = mock_client.chat.completions.create.call_args[1]
+            assert "extra_body" in call_kwargs
+            assert call_kwargs["extra_body"] == {"num_ctx": 32768}
+
+    def test_extract_json_no_extra_body_when_unset(self, tmp_path):
+        config = {
+            "provider": "openai",
+            "base_url": "http://localhost:11434/v1",
+            "model": "test-model",
+            "api_key_env": "",
+            "temperature": 0.0,
+            "max_tokens": 100,
+            "timeout_seconds": 10,
+            "retry_attempts": 1,
+            "batch_delay_ms": 0,
+        }
+        config_path = tmp_path / "llm.json"
+        config_path.write_text(json.dumps(config))
+
+        from unittest.mock import MagicMock, patch
+        from llm_client import LLMClient
+
+        with patch("openai.OpenAI") as mock_openai_cls:
+            mock_client = MagicMock()
+            mock_openai_cls.return_value = mock_client
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = '{"result": "ok"}'
+            mock_client.chat.completions.create.return_value = mock_response
+
+            client = LLMClient(str(config_path))
+            client.extract_json("system", "user")
+
+            call_kwargs = mock_client.chat.completions.create.call_args[1]
+            assert "extra_body" not in call_kwargs
+
+    def test_generate_text_includes_num_ctx(self, tmp_path):
+        config = {
+            "provider": "openai",
+            "base_url": "http://localhost:11434/v1",
+            "model": "test-model",
+            "api_key_env": "",
+            "temperature": 0.0,
+            "max_tokens": 100,
+            "timeout_seconds": 10,
+            "retry_attempts": 1,
+            "batch_delay_ms": 0,
+            "context_length": 16384,
+        }
+        config_path = tmp_path / "llm.json"
+        config_path.write_text(json.dumps(config))
+
+        from unittest.mock import MagicMock, patch
+        from llm_client import LLMClient
+
+        with patch("openai.OpenAI") as mock_openai_cls:
+            mock_client = MagicMock()
+            mock_openai_cls.return_value = mock_client
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = "Hello world"
+            mock_client.chat.completions.create.return_value = mock_response
+
+            client = LLMClient(str(config_path))
+            client.generate_text("system", "user")
+
+            call_kwargs = mock_client.chat.completions.create.call_args[1]
+            assert "extra_body" in call_kwargs
+            assert call_kwargs["extra_body"] == {"num_ctx": 16384}
+
+
+# ---------------------------------------------------------------------------
+# Relationship arc compaction tests (#120)
+# ---------------------------------------------------------------------------
+
+class TestRelationshipArcCompaction:
+    """_compact_relationships_with_arcs replaces history with arc summaries."""
+
+    def test_compacts_with_arc_data(self):
+        from semantic_extraction import _compact_relationships_with_arcs
+
+        relationships = [
+            {
+                "target_id": "char-kael",
+                "type": "ally",
+                "status": "active",
+                "history": [
+                    {"turn": "turn-010", "detail": "Met in forest"},
+                    {"turn": "turn-050", "detail": "Fought together"},
+                    {"turn": "turn-100", "detail": "Disagreement"},
+                    {"turn": "turn-150", "detail": "Reconciled"},
+                ],
+            },
+            {
+                "target_id": "char-lyra",
+                "type": "friend",
+                "status": "active",
+                "history": [
+                    {"turn": "turn-020", "detail": "Traded goods"},
+                ],
+            },
+        ]
+        arcs_data = {
+            "arcs": {
+                "char-kael": {
+                    "arc_summary": [
+                        {"phase": "alliance"},
+                        {"phase": "conflict"},
+                        {"phase": "reconciliation"},
+                    ],
+                    "current_relationship": "trusted ally",
+                },
+            },
+        }
+        result = _compact_relationships_with_arcs(relationships, arcs_data)
+        assert len(result) == 2
+        # char-kael should be compacted
+        kael = result[0]
+        assert kael["target_id"] == "char-kael"
+        assert "history" not in kael
+        assert kael["arc_phases"] == 3
+        assert kael["current"] == "trusted ally"
+        assert "alliance" in kael["summary"]
+        # char-lyra has no arc data — history trimmed to last 3
+        lyra = result[1]
+        assert lyra["target_id"] == "char-lyra"
+        assert len(lyra["history"]) == 1  # only 1 entry, all kept
+
+    def test_trims_history_without_arcs(self):
+        from semantic_extraction import _compact_relationships_with_arcs
+
+        relationships = [
+            {
+                "target_id": "char-unknown",
+                "type": "rival",
+                "status": "active",
+                "history": [{"turn": f"turn-{i:03d}", "detail": f"event {i}"} for i in range(10)],
+            },
+        ]
+        arcs_data = {"arcs": {}}
+        result = _compact_relationships_with_arcs(relationships, arcs_data)
+        assert len(result[0]["history"]) == 3
+
+    def test_fallback_when_no_arcs_data(self):
+        """_format_prior_entity_context falls back when arcs_data is None."""
+        entry = {
+            "id": "char-player",
+            "name": "Player Character",
+            "type": "character",
+            "identity": "The PC.",
+            "relationships": [
+                {"target_id": "char-kael", "type": "ally", "history": [{"turn": "turn-001"}]},
+            ],
+            "first_seen_turn": "turn-001",
+            "last_updated_turn": "turn-100",
+        }
+        result = json.loads(_format_prior_entity_context(entry, arcs_data=None))
+        # Should still have relationships (trimmed, not compacted)
+        rels = result.get("relationships", [])
+        assert len(rels) == 1
+        assert rels[0]["target_id"] == "char-kael"
+
+    def test_token_savings_with_arcs(self):
+        """Arc compaction should produce a shorter context than raw history."""
+        relationships = [
+            {
+                "target_id": f"char-npc-{i}",
+                "type": "ally",
+                "status": "active",
+                "history": [{"turn": f"turn-{j:03d}", "detail": f"interaction {j}"}
+                            for j in range(10)],
+            }
+            for i in range(20)
+        ]
+        arcs_data = {
+            "arcs": {
+                f"char-npc-{i}": {
+                    "arc_summary": [{"phase": "meeting"}, {"phase": "bonding"}],
+                    "current_relationship": "friend",
+                }
+                for i in range(20)
+            }
+        }
+        entry_with_arcs = {
+            "id": "char-player", "name": "PC", "type": "character",
+            "identity": "The PC.", "relationships": relationships,
+            "first_seen_turn": "turn-001", "last_updated_turn": "turn-200",
+        }
+        with_arcs = _format_prior_entity_context(entry_with_arcs, arcs_data=arcs_data)
+        without_arcs = _format_prior_entity_context(entry_with_arcs, arcs_data=None)
+        assert len(with_arcs) < len(without_arcs)
+
+
+# ---------------------------------------------------------------------------
+# Volatile state digest tests (#121)
+# ---------------------------------------------------------------------------
+
+class TestVolatileStateDigest:
+    """_build_volatile_digest compresses old entries."""
+
+    def test_digests_old_entries(self):
+        from semantic_extraction import _build_volatile_digest
+
+        volatile = {
+            "observations": [
+                {"turn": "turn-010", "detail": "pregnancy signs noticed"},
+                {"turn": "turn-020", "detail": "harvest preparations"},
+                {"turn": "turn-030", "detail": "ritual performed"},
+                {"turn": "turn-180", "detail": "council meeting held"},
+                {"turn": "turn-190", "detail": "defense planned"},
+            ],
+        }
+        result = _build_volatile_digest(volatile, current_turn_num=200)
+        obs = result["observations"]
+        # Old entries (turn-010..030) digested, recent (180, 190) kept
+        assert isinstance(obs[0], str)
+        assert "3 earlier entries" in obs[0]
+        assert len(obs) == 3  # 1 summary + 2 recent
+
+    def test_empty_volatile_state(self):
+        from semantic_extraction import _build_volatile_digest
+
+        assert _build_volatile_digest({}, 200) == {}
+
+    def test_non_list_values_pass_through(self):
+        from semantic_extraction import _build_volatile_digest
+
+        volatile = {"condition": "healthy", "location": "forest"}
+        result = _build_volatile_digest(volatile, 200)
+        assert result["condition"] == "healthy"
+        assert result["location"] == "forest"
+
+    def test_all_recent_entries_no_digest(self):
+        from semantic_extraction import _build_volatile_digest
+
+        volatile = {
+            "notes": [
+                {"turn": "turn-180", "detail": "something"},
+                {"turn": "turn-190", "detail": "something else"},
+            ],
+        }
+        result = _build_volatile_digest(volatile, current_turn_num=200)
+        assert len(result["notes"]) == 2
+        assert isinstance(result["notes"][0], dict)
+
+    def test_digest_includes_themes(self):
+        from semantic_extraction import _build_volatile_digest
+
+        volatile = {
+            "events": [
+                {"turn": "turn-010", "detail": "pregnancy confirmed"},
+                {"turn": "turn-020", "detail": "construction of walls began"},
+                {"turn": "turn-030", "detail": "healing ritual success"},
+            ],
+        }
+        result = _build_volatile_digest(volatile, current_turn_num=200)
+        summary = result["events"][0]
+        assert "pregnancy" in summary or "construction" in summary or "healing" in summary
+
+    def test_none_volatile_returns_none(self):
+        from semantic_extraction import _build_volatile_digest
+
+        assert _build_volatile_digest(None, 200) is None
+
+
+class TestExtractTurnNumber:
+    """_extract_turn_number handles various formats."""
+
+    def test_dict_with_turn_key(self):
+        from semantic_extraction import _extract_turn_number
+
+        assert _extract_turn_number({"turn": "turn-042"}) == 42
+
+    def test_dict_with_source_turn(self):
+        from semantic_extraction import _extract_turn_number
+
+        assert _extract_turn_number({"source_turn": "turn-100"}) == 100
+
+    def test_string_with_turn_pattern(self):
+        from semantic_extraction import _extract_turn_number
+
+        assert _extract_turn_number("something at turn-055 happened") == 55
+
+    def test_no_turn_info(self):
+        from semantic_extraction import _extract_turn_number
+
+        assert _extract_turn_number({"detail": "no turn"}) is None
+
+    def test_integer_value(self):
+        from semantic_extraction import _extract_turn_number
+
+        assert _extract_turn_number(42) is None
+
+
+class TestExtractThemes:
+    """_extract_themes identifies keyword themes from entries."""
+
+    def test_finds_keywords(self):
+        from semantic_extraction import _extract_themes
+
+        items = [
+            {"detail": "pregnancy confirmed"},
+            {"detail": "harvest completed"},
+        ]
+        themes = _extract_themes(items)
+        assert "pregnancy" in themes
+        assert "harvest" in themes
+
+    def test_caps_at_five(self):
+        from semantic_extraction import _extract_themes
+
+        items = [
+            "pregnancy text", "birth text", "construction text",
+            "harvest text", "defense text", "ritual text",
+        ]
+        themes = _extract_themes(items)
+        assert len(themes) <= 5
+
+    def test_fallback_count(self):
+        from semantic_extraction import _extract_themes
+
+        items = [{"detail": "unrecognized content"}]
+        themes = _extract_themes(items)
+        assert any("1 observations" in t for t in themes)
+
+
+# ---------------------------------------------------------------------------
+# Integration: PC prompt with all compacting features active (#118, #120, #121)
+# ---------------------------------------------------------------------------
+
+class TestPCCompactingIntegration:
+    """format_detail_prompt for char-player is shorter with all compacting."""
+
+    def test_compact_prompt_shorter(self):
+        turn = {"turn_id": "turn-300", "speaker": "DM", "text": "The storm rages on."}
+        pc_ref = {"name": "Player Character", "type": "character",
+                  "existing_id": "char-player", "is_new": False}
+
+        # Large PC entry with relationships and volatile state
+        relationships = [
+            {
+                "target_id": f"char-npc-{i}",
+                "type": "ally",
+                "status": "active",
+                "history": [{"turn": f"turn-{j:03d}", "detail": f"met {j}"}
+                            for j in range(1, 11)],
+            }
+            for i in range(15)
+        ]
+        volatile = {
+            "observations": [
+                {"turn": f"turn-{t:03d}", "detail": f"harvest event at turn {t}"}
+                for t in range(10, 300, 5)
+            ],
+            "condition": "healthy",
+        }
+        pc_entry = {
+            "id": "char-player",
+            "name": "Player Character",
+            "type": "character",
+            "identity": "A brave adventurer in the northern wastes.",
+            "current_status": "Weathering the storm.",
+            "stable_attributes": {
+                "race": {"value": "Human"},
+                "class": {"value": "Ranger"},
+                "aliases": {"value": ["PC"]},
+                "backstory": {"value": "Long backstory " * 20},
+            },
+            "volatile_state": volatile,
+            "relationships": relationships,
+            "first_seen_turn": "turn-001",
+            "last_updated_turn": "turn-299",
+        }
+        arcs_data = {
+            "arcs": {
+                f"char-npc-{i}": {
+                    "arc_summary": [{"phase": "meeting"}, {"phase": "trust"}],
+                    "current_relationship": "ally",
+                }
+                for i in range(15)
+            }
+        }
+
+        prompt_compact = format_detail_prompt(turn, pc_ref, pc_entry, arcs_data=arcs_data)
+        prompt_raw = format_detail_prompt(turn, pc_ref, pc_entry, arcs_data=None)
+
+        assert len(prompt_compact) < len(prompt_raw)

--- a/tests/test_pipeline_v3.py
+++ b/tests/test_pipeline_v3.py
@@ -492,6 +492,47 @@ class TestPCDetailPromptContext:
 class TestContextLengthPassthrough:
     """LLMClient passes extra_body with num_ctx when context_length is set."""
 
+    def _make_client(self, tmp_path, config):
+        """Create an LLMClient with a mocked openai module."""
+        import sys
+        from unittest.mock import MagicMock
+        from types import ModuleType
+
+        config_path = tmp_path / "llm.json"
+        config_path.write_text(json.dumps(config))
+
+        # Inject a fake 'openai' module if the real one isn't installed
+        mock_openai = ModuleType("openai")
+        mock_openai_cls = MagicMock()
+        mock_openai.OpenAI = mock_openai_cls
+        orig = sys.modules.get("openai")
+        sys.modules["openai"] = mock_openai
+
+        # Force llm_client to re-import with the fake module
+        if "llm_client" in sys.modules:
+            del sys.modules["llm_client"]
+
+        try:
+            from llm_client import LLMClient
+
+            mock_client_instance = MagicMock()
+            mock_openai_cls.return_value = mock_client_instance
+
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = '{"result": "ok"}'
+            mock_client_instance.chat.completions.create.return_value = mock_response
+
+            client = LLMClient(str(config_path))
+            return client, mock_client_instance
+        finally:
+            # Restore original module state
+            if orig is not None:
+                sys.modules["openai"] = orig
+            else:
+                sys.modules.pop("openai", None)
+            sys.modules.pop("llm_client", None)
+
     def test_extract_json_includes_num_ctx(self, tmp_path):
         config = {
             "provider": "openai",
@@ -505,26 +546,11 @@ class TestContextLengthPassthrough:
             "batch_delay_ms": 0,
             "context_length": 32768,
         }
-        config_path = tmp_path / "llm.json"
-        config_path.write_text(json.dumps(config))
-
-        from unittest.mock import MagicMock, patch
-        from llm_client import LLMClient
-
-        with patch("openai.OpenAI") as mock_openai_cls:
-            mock_client = MagicMock()
-            mock_openai_cls.return_value = mock_client
-            mock_response = MagicMock()
-            mock_response.choices = [MagicMock()]
-            mock_response.choices[0].message.content = '{"result": "ok"}'
-            mock_client.chat.completions.create.return_value = mock_response
-
-            client = LLMClient(str(config_path))
-            client.extract_json("system", "user")
-
-            call_kwargs = mock_client.chat.completions.create.call_args[1]
-            assert "extra_body" in call_kwargs
-            assert call_kwargs["extra_body"] == {"num_ctx": 32768}
+        client, mock_inner = self._make_client(tmp_path, config)
+        client.extract_json("system", "user")
+        call_kwargs = mock_inner.chat.completions.create.call_args[1]
+        assert "extra_body" in call_kwargs
+        assert call_kwargs["extra_body"] == {"num_ctx": 32768}
 
     def test_extract_json_no_extra_body_when_unset(self, tmp_path):
         config = {
@@ -538,25 +564,10 @@ class TestContextLengthPassthrough:
             "retry_attempts": 1,
             "batch_delay_ms": 0,
         }
-        config_path = tmp_path / "llm.json"
-        config_path.write_text(json.dumps(config))
-
-        from unittest.mock import MagicMock, patch
-        from llm_client import LLMClient
-
-        with patch("openai.OpenAI") as mock_openai_cls:
-            mock_client = MagicMock()
-            mock_openai_cls.return_value = mock_client
-            mock_response = MagicMock()
-            mock_response.choices = [MagicMock()]
-            mock_response.choices[0].message.content = '{"result": "ok"}'
-            mock_client.chat.completions.create.return_value = mock_response
-
-            client = LLMClient(str(config_path))
-            client.extract_json("system", "user")
-
-            call_kwargs = mock_client.chat.completions.create.call_args[1]
-            assert "extra_body" not in call_kwargs
+        client, mock_inner = self._make_client(tmp_path, config)
+        client.extract_json("system", "user")
+        call_kwargs = mock_inner.chat.completions.create.call_args[1]
+        assert "extra_body" not in call_kwargs
 
     def test_generate_text_includes_num_ctx(self, tmp_path):
         config = {
@@ -571,26 +582,12 @@ class TestContextLengthPassthrough:
             "batch_delay_ms": 0,
             "context_length": 16384,
         }
-        config_path = tmp_path / "llm.json"
-        config_path.write_text(json.dumps(config))
-
-        from unittest.mock import MagicMock, patch
-        from llm_client import LLMClient
-
-        with patch("openai.OpenAI") as mock_openai_cls:
-            mock_client = MagicMock()
-            mock_openai_cls.return_value = mock_client
-            mock_response = MagicMock()
-            mock_response.choices = [MagicMock()]
-            mock_response.choices[0].message.content = "Hello world"
-            mock_client.chat.completions.create.return_value = mock_response
-
-            client = LLMClient(str(config_path))
-            client.generate_text("system", "user")
-
-            call_kwargs = mock_client.chat.completions.create.call_args[1]
-            assert "extra_body" in call_kwargs
-            assert call_kwargs["extra_body"] == {"num_ctx": 16384}
+        client, mock_inner = self._make_client(tmp_path, config)
+        mock_inner.chat.completions.create.return_value.choices[0].message.content = "Hello world"
+        client.generate_text("system", "user")
+        call_kwargs = mock_inner.chat.completions.create.call_args[1]
+        assert "extra_body" in call_kwargs
+        assert call_kwargs["extra_body"] == {"num_ctx": 16384}
 
 
 # ---------------------------------------------------------------------------

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -55,6 +55,7 @@ class LLMClient:
         self.retry_attempts = self.config.get("retry_attempts", 3)
         self.batch_delay_ms = self.config.get("batch_delay_ms", 200)
         self.default_timeout = self.config.get("timeout_seconds", 60)
+        self.context_length = self.config.get("context_length", None)
 
     def extract_json(
         self,
@@ -96,6 +97,8 @@ class LLMClient:
                 }
                 if timeout is not None:
                     kwargs["timeout"] = timeout
+                if self.context_length:
+                    kwargs["extra_body"] = {"num_ctx": self.context_length}
 
                 response = self.client.chat.completions.create(**kwargs)
                 raw_text = response.choices[0].message.content
@@ -185,6 +188,8 @@ class LLMClient:
                 }
                 if timeout is not None:
                     kwargs["timeout"] = timeout
+                if self.context_length:
+                    kwargs["extra_body"] = {"num_ctx": self.context_length}
 
                 response = self.client.chat.completions.create(**kwargs)
                 raw_text = response.choices[0].message.content

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -367,8 +367,132 @@ _PC_KEY_STABLE_ATTRS = {"species", "race", "class", "aliases"}
 # Maximum number of volatile_state snapshots to include for PC
 _PC_MAX_VOLATILE_SNAPSHOTS = 3
 
+# Number of turns beyond which volatile state entries are digested (#121)
+_DIGEST_WINDOW = 50
 
-def _format_prior_entity_context(current_entry: dict | None) -> str:
+
+def _parse_turn_number(turn_id: str | None) -> int | None:
+    """Parse turn number from a turn ID string like 'turn-042'."""
+    if not turn_id or not isinstance(turn_id, str):
+        return None
+    m = re.search(r'turn-(\d+)', turn_id)
+    if m:
+        return int(m.group(1))
+    return None
+
+
+def _extract_turn_number(item) -> int | None:
+    """Try to extract a turn number from a volatile state entry."""
+    if isinstance(item, dict):
+        turn = item.get("turn") or item.get("source_turn") or item.get("turn_id")
+        if turn:
+            return _parse_turn_number(str(turn)) if not isinstance(turn, int) else turn
+    elif isinstance(item, str):
+        m = re.search(r'turn-(\d+)', item)
+        if m:
+            return int(m.group(1))
+    return None
+
+
+def _extract_themes(items: list) -> list[str]:
+    """Extract key themes from a list of volatile state entries for digest."""
+    _THEME_KEYWORDS = [
+        "pregnancy", "birth", "construction", "harvest",
+        "defense", "ritual", "expedition", "council",
+        "illness", "healing", "teaching", "craft",
+    ]
+    themes = set()
+    for item in items:
+        text = str(item) if not isinstance(item, str) else item
+        text_lower = text[:200].lower()
+        for keyword in _THEME_KEYWORDS:
+            if keyword in text_lower:
+                themes.add(keyword)
+            if len(themes) >= 5:
+                break
+        if len(themes) >= 5:
+            break
+    if not themes:
+        themes.add(f"{len(items)} observations")
+    return sorted(themes)
+
+
+def _build_volatile_digest(volatile_state: dict, current_turn_num: int) -> dict:
+    """Compress old volatile state entries into a rolling summary (#121).
+
+    Entries older than ``_DIGEST_WINDOW`` turns are replaced with a count +
+    theme summary.  Recent entries are kept verbatim.
+    """
+    if not volatile_state:
+        return volatile_state
+
+    result = {}
+    for key, value in volatile_state.items():
+        if not isinstance(value, list):
+            result[key] = value
+            continue
+
+        recent_items = []
+        old_items = []
+        for item in value:
+            turn_num = _extract_turn_number(item)
+            if turn_num is not None and current_turn_num - turn_num > _DIGEST_WINDOW:
+                old_items.append(item)
+            else:
+                recent_items.append(item)
+
+        if old_items:
+            cutoff = current_turn_num - _DIGEST_WINDOW
+            themes = _extract_themes(old_items)
+            summary = (
+                f"[{len(old_items)} earlier entries through ~turn-{cutoff}"
+                f", including: {', '.join(themes[:5])}]"
+            )
+            result[key] = [summary] + recent_items
+        else:
+            result[key] = recent_items
+
+    return result
+
+
+def _compact_relationships_with_arcs(
+    relationships: list, arcs_data: dict
+) -> list:
+    """Replace raw relationship histories with arc summaries (#120).
+
+    When ``arcs_data`` contains arc summaries for a relationship target,
+    the raw history is replaced with a compact representation.  Otherwise
+    the history is trimmed to the last 3 entries.
+    """
+    compact_rels = []
+    arcs_map = arcs_data.get("arcs", {})
+    for rel in relationships:
+        target_id = rel.get("target_id", "")
+        arc_info = arcs_map.get(target_id)
+        if arc_info and arc_info.get("arc_summary"):
+            compact_rel = {
+                "target_id": target_id,
+                "type": rel.get("type", ""),
+                "status": rel.get("status", "active"),
+                "arc_phases": len(arc_info["arc_summary"]),
+                "current": arc_info.get("current_relationship", ""),
+                "summary": " → ".join(
+                    p.get("phase", "") for p in arc_info["arc_summary"]
+                ),
+            }
+            compact_rels.append(compact_rel)
+        else:
+            trimmed = dict(rel)
+            if "history" in trimmed and isinstance(trimmed["history"], list):
+                trimmed["history"] = trimmed["history"][-3:]
+            compact_rels.append(trimmed)
+    return compact_rels
+
+
+def _format_prior_entity_context(
+    current_entry: dict | None,
+    arcs_data: dict | None = None,
+) -> str:
     """Format the prior entity state for injection into the detail prompt.
 
     Extracts identity, current_status, stable_attributes, and volatile_state
@@ -379,6 +503,8 @@ def _format_prior_entity_context(current_entry: dict | None) -> str:
     - Always includes identity and current_status
     - Only key stable_attributes (species, class, aliases)
     - Last 3 volatile_state snapshots only
+    - Relationship histories replaced with arc summaries when available (#120)
+    - Old volatile state entries digested into count + themes (#121)
     """
     if not current_entry:
         return "{}"
@@ -404,7 +530,7 @@ def _format_prior_entity_context(current_entry: dict | None) -> str:
         else:
             prior["stable_attributes"] = sa
 
-    # volatile_state — trimmed for PC (last N snapshots)
+    # volatile_state — trimmed for PC (last N snapshots), then digested (#121)
     vs = current_entry.get("volatile_state")
     if vs:
         if is_pc and isinstance(vs, dict):
@@ -416,9 +542,29 @@ def _format_prior_entity_context(current_entry: dict | None) -> str:
                     trimmed_vs[k] = v[-_PC_MAX_VOLATILE_SNAPSHOTS:]
                 else:
                     trimmed_vs[k] = v
+            # Apply rolling digest to compress old entries (#121)
+            current_turn_num = _parse_turn_number(
+                current_entry.get("last_updated_turn", "")
+            )
+            if current_turn_num:
+                trimmed_vs = _build_volatile_digest(trimmed_vs, current_turn_num)
             prior["volatile_state"] = trimmed_vs
         else:
             prior["volatile_state"] = vs
+
+    # Relationships — compact with arc summaries for PC (#120)
+    rels = current_entry.get("relationships")
+    if rels and is_pc and arcs_data:
+        prior["relationships"] = _compact_relationships_with_arcs(rels, arcs_data)
+    elif rels and is_pc:
+        # No arc data — trim history to last 3 entries
+        compact_rels = []
+        for rel in rels:
+            trimmed = dict(rel)
+            if "history" in trimmed and isinstance(trimmed["history"], list):
+                trimmed["history"] = trimmed["history"][-3:]
+            compact_rels.append(trimmed)
+        prior["relationships"] = compact_rels
 
     # V1 fallback: keep description/attributes if no V2 counterparts
     if "identity" not in prior and "description" in current_entry:
@@ -432,9 +578,14 @@ def _format_prior_entity_context(current_entry: dict | None) -> str:
     return json.dumps(prior, indent=2)
 
 
-def format_detail_prompt(turn: dict, entity_ref: dict, current_entry: dict | None) -> str:
+def format_detail_prompt(
+    turn: dict,
+    entity_ref: dict,
+    current_entry: dict | None,
+    arcs_data: dict | None = None,
+) -> str:
     """Format the user prompt for entity detail extraction."""
-    prior_json = _format_prior_entity_context(current_entry)
+    prior_json = _format_prior_entity_context(current_entry, arcs_data=arcs_data)
     entity_id = entity_ref.get('existing_id') or entity_ref.get('proposed_id')
     is_pc = (entity_id == "char-player")
     prompt = (
@@ -652,6 +803,7 @@ def extract_and_merge(
     events_list: list,
     llm: LLMClient,
     min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+    catalog_dir: str | None = None,
 ) -> tuple[dict, list]:
     """Process one turn through all extraction agents.
 
@@ -661,11 +813,24 @@ def extract_and_merge(
         events_list: Current list of events.
         llm: LLM client instance.
         min_confidence: Minimum confidence to catalog an entity.
+        catalog_dir: Optional path to the catalog directory, used to load
+            arc sidecar files for relationship compaction (#120).
 
     Returns:
         Updated (catalogs, events_list) tuple.
     """
     turn_id = turn["turn_id"]
+
+    # Load arc sidecar for PC relationship compaction (#120)
+    pc_arcs_data = None
+    if catalog_dir:
+        arcs_path = os.path.join(catalog_dir, "char-player.arcs.json")
+        if os.path.isfile(arcs_path):
+            try:
+                with open(arcs_path, "r", encoding="utf-8") as f:
+                    pc_arcs_data = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                pass  # Ignore corrupt/unreadable arcs file
 
     # --- 1. Entity Discovery ---
     known = format_known_entities(catalogs)
@@ -719,9 +884,11 @@ def extract_and_merge(
                 _, current_entry = result
 
         try:
+            entity_arcs = pc_arcs_data if entity_id == "char-player" else None
             detail_result = llm.extract_json(
                 system_prompt=load_template("entity-detail"),
-                user_prompt=format_detail_prompt(turn, entity_ref, current_entry),
+                user_prompt=format_detail_prompt(turn, entity_ref, current_entry,
+                                                 arcs_data=entity_arcs),
             )
         except LLMExtractionError as e:
             print(f"  WARNING: Detail extraction failed for {entity_id} at {turn_id}: {e}", file=sys.stderr)
@@ -760,7 +927,8 @@ def extract_and_merge(
         try:
             detail_result = llm.extract_json(
                 system_prompt=load_template("entity-detail"),
-                user_prompt=format_detail_prompt(turn, pc_ref, pc_entry),
+                user_prompt=format_detail_prompt(turn, pc_ref, pc_entry,
+                                                 arcs_data=pc_arcs_data),
                 timeout=pc_timeout,
             )
             entity_data = detail_result.get("entity")
@@ -1152,7 +1320,8 @@ def extract_semantic_batch(
 
         try:
             catalogs, events_list = extract_and_merge(
-                turn, catalogs, events_list, llm, min_confidence
+                turn, catalogs, events_list, llm, min_confidence,
+                catalog_dir=catalog_dir,
             )
         except Exception as e:
             print(f"  ERROR at {turn_id}: {e}", file=sys.stderr)
@@ -1239,7 +1408,8 @@ def extract_semantic_single(
 
     print(f"  Running semantic extraction for {turn_id}...")
     catalogs, events_list = extract_and_merge(
-        turn, catalogs, events_list, llm, min_confidence
+        turn, catalogs, events_list, llm, min_confidence,
+        catalog_dir=catalog_dir,
     )
 
     entities_total = sum(len(v) for v in catalogs.values())

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -530,24 +530,31 @@ def _format_prior_entity_context(
         else:
             prior["stable_attributes"] = sa
 
-    # volatile_state — trimmed for PC (last N snapshots), then digested (#121)
+    # volatile_state — digest first, then cap recent entries for PC (#121)
     vs = current_entry.get("volatile_state")
     if vs:
         if is_pc and isinstance(vs, dict):
-            # Keep only the most recent entries if the volatile state is large
-            # For dict-based volatile_state, keep all keys but trim list values
-            trimmed_vs = {}
-            for k, v in vs.items():
-                if isinstance(v, list) and len(v) > _PC_MAX_VOLATILE_SNAPSHOTS:
-                    trimmed_vs[k] = v[-_PC_MAX_VOLATILE_SNAPSHOTS:]
-                else:
-                    trimmed_vs[k] = v
-            # Apply rolling digest to compress old entries (#121)
             current_turn_num = _parse_turn_number(
                 current_entry.get("last_updated_turn", "")
             )
+            # Digest old entries BEFORE trimming so history is compressed
+            # rather than silently dropped.
             if current_turn_num:
-                trimmed_vs = _build_volatile_digest(trimmed_vs, current_turn_num)
+                digested_vs = _build_volatile_digest(vs, current_turn_num)
+            else:
+                digested_vs = dict(vs)
+            # Cap recent list-valued entries to keep prompt size bounded
+            trimmed_vs = {}
+            for k, v in digested_vs.items():
+                if isinstance(v, list) and len(v) > _PC_MAX_VOLATILE_SNAPSHOTS:
+                    # If the digest produced a summary at index 0 (a string),
+                    # preserve it and cap the rest to last N entries.
+                    if v and isinstance(v[0], str) and v[0].startswith("["):
+                        trimmed_vs[k] = v[:1] + v[-(  _PC_MAX_VOLATILE_SNAPSHOTS):]
+                    else:
+                        trimmed_vs[k] = v[-_PC_MAX_VOLATILE_SNAPSHOTS:]
+                else:
+                    trimmed_vs[k] = v
             prior["volatile_state"] = trimmed_vs
         else:
             prior["volatile_state"] = vs
@@ -822,15 +829,22 @@ def extract_and_merge(
     turn_id = turn["turn_id"]
 
     # Load arc sidecar for PC relationship compaction (#120)
+    # V2 layout stores per-entity files under <catalog_dir>/characters/;
+    # fall back to catalog root for legacy/V1 layouts.
     pc_arcs_data = None
     if catalog_dir:
-        arcs_path = os.path.join(catalog_dir, "char-player.arcs.json")
-        if os.path.isfile(arcs_path):
-            try:
-                with open(arcs_path, "r", encoding="utf-8") as f:
-                    pc_arcs_data = json.load(f)
-            except (json.JSONDecodeError, OSError):
-                pass  # Ignore corrupt/unreadable arcs file
+        arcs_candidates = [
+            os.path.join(catalog_dir, "characters", "char-player.arcs.json"),
+            os.path.join(catalog_dir, "char-player.arcs.json"),
+        ]
+        for arcs_path in arcs_candidates:
+            if os.path.isfile(arcs_path):
+                try:
+                    with open(arcs_path, "r", encoding="utf-8-sig") as f:
+                        pc_arcs_data = json.load(f)
+                except (json.JSONDecodeError, OSError):
+                    pass  # Ignore corrupt/unreadable arcs file
+                break
 
     # --- 1. Entity Discovery ---
     known = format_known_entities(catalogs)


### PR DESCRIPTION
## Summary

Context compacting for PC extraction to extend coverage past turn-266. Three complementary
improvements that reduce prompt token count while preserving narrative context.

## Issue #118 � num_ctx support

Added context_length config field to llm.json and extra_body.num_ctx passthrough
in LLM client. Prevents silent prompt truncation with local models (Ollama/vLLM).

## Issue #120 � Relationship arc compaction

PC extraction context now uses arc summaries from .arcs.json sidecar files instead of raw
per-turn relationship history. Falls back to history trimming (last 3 entries) when arcs are
unavailable. Saves ~3,000�5,000 tokens per extraction call for mature campaigns.

## Issue #121 � Rolling volatile state digest

Old volatile state entries (beyond 50 turns) are compressed into a count + theme summary.
Recent entries kept verbatim. Preserves historical context in ~200 tokens instead of
dropping it entirely.

### Testing

- 401 tests pass (34 new covering all three features + integration)
- Schema validation passes
- All existing tests unaffected

Closes #118
Closes #120
Closes #121
