### PR TITLE
fix: Run 7 quality fixes (#124-#129)

### DIFF
--- a/tests/test_run7_quality.py
+++ b/tests/test_run7_quality.py
@@ -1,5 +1,4 @@
 """Tests for Run 7 quality fixes (#124-#129)."""
-import io
 import os
 import sys
 
@@ -16,7 +15,6 @@ from semantic_extraction import (
 )
 from catalog_merger import (
     _coerce_relationship_type,
-    _RELATIONSHIP_TYPE_MAP,
     _consolidate_relationship,
 )
 
@@ -149,8 +147,11 @@ class TestRelationshipTypeCoercion:
     def test_guild_maps_to_factional(self):
         assert _coerce_relationship_type("guild") == "factional"
 
-    def test_unmapped_passes_through(self):
-        assert _coerce_relationship_type("blood_oath") == "blood_oath"
+    def test_unmapped_defaults_to_other(self):
+        assert _coerce_relationship_type("blood_oath") == "other"
+
+    def test_empty_defaults_to_other(self):
+        assert _coerce_relationship_type("") == "other"
 
     def test_case_insensitive(self):
         assert _coerce_relationship_type("ALLY") == "social"
@@ -159,6 +160,10 @@ class TestRelationshipTypeCoercion:
     def test_strips_whitespace(self):
         assert _coerce_relationship_type("  ally  ") == "social"
 
+    def test_collaborating_maps_to_partnership(self):
+        assert _coerce_relationship_type("collaborating") == "partnership"
+        assert _coerce_relationship_type("collaborator") == "partnership"
+
     def test_schema_enum_values_pass_through(self):
         schema_enums = [
             "kinship", "partnership", "mentorship", "political",
@@ -166,7 +171,7 @@ class TestRelationshipTypeCoercion:
         ]
         for val in schema_enums:
             result = _coerce_relationship_type(val)
-            assert result == val or result in schema_enums
+            assert result == val
 
     def test_coercion_applied_in_consolidate(self):
         existing = {
@@ -270,9 +275,20 @@ class TestEventSourceTurnsValidation:
 # ---------------------------------------------------------------------------
 
 class TestStubIdentification:
-    def test_stub_with_stub_in_notes(self):
-        entity = {"id": "char-lyra", "name": "Lyra", "notes": "Auto-created by event-stub."}
+    def test_stub_with_event_stub_notes(self):
+        entity = {"id": "char-lyra", "name": "Lyra", "identity": "Known",
+                  "notes": "Auto-created by event-stub."}
         assert _is_stub_entity(entity) is True
+
+    def test_stub_with_orphan_sweep_notes(self):
+        entity = {"id": "char-lyra", "name": "Lyra", "identity": "Known",
+                  "notes": "Auto-created by post-batch orphan sweep."}
+        assert _is_stub_entity(entity) is True
+
+    def test_non_stub_notes_not_flagged(self):
+        entity = {"id": "char-test", "name": "Test", "identity": "A person.",
+                  "notes": "Has a stubborn personality."}
+        assert _is_stub_entity(entity) is False
 
     def test_stub_with_empty_identity(self):
         entity = {"id": "char-test", "name": "Test", "identity": "", "notes": "something"}
@@ -281,6 +297,11 @@ class TestStubIdentification:
     def test_stub_with_missing_identity(self):
         entity = {"id": "char-test", "name": "Test", "notes": "normal"}
         assert _is_stub_entity(entity) is True
+
+    def test_backfilled_entity_not_reflagged(self):
+        entity = {"id": "char-lyra", "name": "Lyra", "identity": "An elf.",
+                  "notes": "Backfilled from stub."}
+        assert _is_stub_entity(entity) is False
 
     def test_full_entity_not_stub(self):
         entity = {
@@ -301,12 +322,14 @@ class TestStubIdentification:
             {
                 "id": "evt-002",
                 "related_entities": ["char-other"],
-                "source_turns": ["turn-020"],
+                "source_turns": ["turn-050"],
             },
         ]
         turns = [
+            {"turn_id": "turn-009", "speaker": "DM", "text": "Previous context."},
             {"turn_id": "turn-010", "speaker": "DM", "text": "Lyra appeared at the gate."},
-            {"turn_id": "turn-020", "speaker": "DM", "text": "Other speaks."},
+            {"turn_id": "turn-011", "speaker": "DM", "text": "Next context."},
+            {"turn_id": "turn-050", "speaker": "DM", "text": "Other speaks."},
         ]
         context = _collect_stub_context("char-lyra", events, turns, "turn-010")
         assert "Lyra appeared" in context
@@ -315,10 +338,15 @@ class TestStubIdentification:
     def test_collect_context_includes_first_seen(self):
         events = []  # no events reference this entity
         turns = [
+            {"turn_id": "turn-004", "speaker": "DM", "text": "Previous turn."},
             {"turn_id": "turn-005", "speaker": "DM", "text": "First appearance."},
+            {"turn_id": "turn-006", "speaker": "DM", "text": "Next turn."},
         ]
         context = _collect_stub_context("char-unknown", events, turns, "turn-005")
         assert "First appearance" in context
+        # Neighbors should also be included
+        assert "Previous turn" in context
+        assert "Next turn" in context
 
     def test_backfill_preserves_first_seen_turn(self):
         """Stub detection finds entities correctly before backfill."""

--- a/tests/test_run7_quality.py
+++ b/tests/test_run7_quality.py
@@ -1,0 +1,412 @@
+"""Tests for Run 7 quality fixes (#124-#129)."""
+import io
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from semantic_extraction import (
+    _pc_partial_merge,
+    _fix_event_source_turns,
+    _dedup_catalogs,
+    _is_stub_entity,
+    _collect_stub_context,
+    get_entity_id,
+    filter_by_confidence,
+)
+from catalog_merger import (
+    _coerce_relationship_type,
+    _RELATIONSHIP_TYPE_MAP,
+    _consolidate_relationship,
+)
+
+
+# ---------------------------------------------------------------------------
+# #124 — Concept-prefix filter at discovery time
+# ---------------------------------------------------------------------------
+
+class TestConceptPrefixDiscoveryFilter:
+    """Test that concept-prefix entities are rejected at discovery time."""
+
+    def test_concept_prefix_filtered_from_qualified(self):
+        """Entities with concept- prefix IDs should be filtered before detail extraction."""
+        discovered = [
+            {"proposed_id": "concept-spirit-world", "name": "Spirit World",
+             "type": "concept", "confidence": 0.9},
+            {"proposed_id": "char-grim", "name": "Grim",
+             "type": "character", "confidence": 0.9},
+            {"proposed_id": "concept-honor", "name": "Honor",
+             "type": "concept", "confidence": 0.8},
+        ]
+        qualified = filter_by_confidence(discovered, 0.6)
+        # Simulate the discovery filter from extract_and_merge
+        filtered = []
+        for entity_ref in qualified:
+            eid = get_entity_id(entity_ref)
+            if eid and eid.lower().startswith("concept-"):
+                continue
+            filtered.append(entity_ref)
+
+        assert len(filtered) == 1
+        assert get_entity_id(filtered[0]) == "char-grim"
+
+    def test_non_concept_prefix_passes(self):
+        discovered = [
+            {"proposed_id": "char-test", "name": "Test", "type": "character", "confidence": 0.9},
+        ]
+        qualified = filter_by_confidence(discovered, 0.6)
+        filtered = [e for e in qualified if not get_entity_id(e).lower().startswith("concept-")]
+        assert len(filtered) == 1
+
+    def test_concept_prefix_case_insensitive(self):
+        discovered = [
+            {"proposed_id": "Concept-Magic", "name": "Magic", "type": "concept", "confidence": 0.9},
+        ]
+        qualified = filter_by_confidence(discovered, 0.6)
+        filtered = [e for e in qualified if not get_entity_id(e).lower().startswith("concept-")]
+        assert len(filtered) == 0
+
+
+# ---------------------------------------------------------------------------
+# #125 — PC partial merge diagnostic logging
+# ---------------------------------------------------------------------------
+
+class TestPCPartialMergeLogging:
+    def _make_pc_catalogs(self):
+        return {
+            "characters.json": [
+                {
+                    "id": "char-player",
+                    "name": "Player Character",
+                    "type": "character",
+                    "identity": "The player character.",
+                    "first_seen_turn": "turn-001",
+                    "last_updated_turn": "turn-050",
+                }
+            ]
+        }
+
+    def test_logs_merged_fields(self, capsys):
+        catalogs = self._make_pc_catalogs()
+        entity_data = {
+            "id": "char-player",
+            "current_status": "Fighting.",
+        }
+        _pc_partial_merge(catalogs, entity_data, "turn-100")
+        captured = capsys.readouterr()
+        assert "current_status" in captured.err
+        assert "merged" in captured.err.lower()
+        assert "turn-100" in captured.err
+
+    def test_logs_empty_merge_warning(self, capsys):
+        catalogs = self._make_pc_catalogs()
+        entity_data = {"id": "char-player"}
+        _pc_partial_merge(catalogs, entity_data, "turn-060")
+        captured = capsys.readouterr()
+        assert "empty" in captured.err.lower()
+        assert "turn-060" in captured.err
+
+    def test_logs_attempted_fields(self, capsys):
+        catalogs = self._make_pc_catalogs()
+        entity_data = {
+            "id": "char-player",
+            "current_status": "In camp.",
+            "volatile_state": {"condition": "resting"},
+        }
+        _pc_partial_merge(catalogs, entity_data, "turn-075")
+        captured = capsys.readouterr()
+        assert "attempted" in captured.err.lower()
+        assert "current_status" in captured.err
+        assert "volatile_state" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# #126 — Relationship type coercion
+# ---------------------------------------------------------------------------
+
+class TestRelationshipTypeCoercion:
+    def test_ally_maps_to_social(self):
+        assert _coerce_relationship_type("ally") == "social"
+
+    def test_captive_maps_to_adversarial(self):
+        assert _coerce_relationship_type("captive") == "adversarial"
+
+    def test_mentor_maps_to_mentorship(self):
+        assert _coerce_relationship_type("mentor") == "mentorship"
+
+    def test_parent_maps_to_kinship(self):
+        assert _coerce_relationship_type("parent") == "kinship"
+
+    def test_partner_maps_to_partnership(self):
+        assert _coerce_relationship_type("partner") == "partnership"
+
+    def test_lover_maps_to_romantic(self):
+        assert _coerce_relationship_type("lover") == "romantic"
+
+    def test_diplomatic_maps_to_political(self):
+        assert _coerce_relationship_type("diplomatic") == "political"
+
+    def test_guild_maps_to_factional(self):
+        assert _coerce_relationship_type("guild") == "factional"
+
+    def test_unmapped_passes_through(self):
+        assert _coerce_relationship_type("blood_oath") == "blood_oath"
+
+    def test_case_insensitive(self):
+        assert _coerce_relationship_type("ALLY") == "social"
+        assert _coerce_relationship_type("Captive Of") == "adversarial"
+
+    def test_strips_whitespace(self):
+        assert _coerce_relationship_type("  ally  ") == "social"
+
+    def test_schema_enum_values_pass_through(self):
+        schema_enums = [
+            "kinship", "partnership", "mentorship", "political",
+            "factional", "social", "adversarial", "romantic", "other",
+        ]
+        for val in schema_enums:
+            result = _coerce_relationship_type(val)
+            assert result == val or result in schema_enums
+
+    def test_coercion_applied_in_consolidate(self):
+        existing = {
+            "target_id": "char-beta",
+            "current_relationship": "working together",
+            "type": "other",
+            "status": "active",
+            "first_seen_turn": "turn-010",
+            "last_updated_turn": "turn-010",
+        }
+        update = {
+            "current_relationship": "close allies",
+            "type": "ally",
+            "last_updated_turn": "turn-020",
+        }
+        _consolidate_relationship(existing, update)
+        assert existing["type"] == "social"
+
+
+# ---------------------------------------------------------------------------
+# #127 — Event source_turns validation
+# ---------------------------------------------------------------------------
+
+class TestEventSourceTurnsValidation:
+    def test_corrects_mismatched_source_turns(self):
+        events = [
+            {
+                "id": "evt-346",
+                "source_turns": ["turn-001"],
+                "description": "Late game event",
+            }
+        ]
+        _fix_event_source_turns(events, "turn-300")
+        assert events[0]["source_turns"] == ["turn-300"]
+
+    def test_valid_source_turns_unchanged(self):
+        events = [
+            {
+                "id": "evt-100",
+                "source_turns": ["turn-050"],
+                "description": "Event near turn 050",
+            }
+        ]
+        _fix_event_source_turns(events, "turn-052")
+        assert events[0]["source_turns"] == ["turn-050"]
+
+    def test_boundary_within_tolerance(self):
+        events = [
+            {
+                "id": "evt-200",
+                "source_turns": ["turn-095"],
+                "description": "Within 5 turns",
+            }
+        ]
+        _fix_event_source_turns(events, "turn-100")
+        assert events[0]["source_turns"] == ["turn-095"]
+
+    def test_boundary_beyond_tolerance(self):
+        events = [
+            {
+                "id": "evt-201",
+                "source_turns": ["turn-094"],
+                "description": "Beyond 5 turns",
+            }
+        ]
+        _fix_event_source_turns(events, "turn-100")
+        assert events[0]["source_turns"] == ["turn-100"]
+
+    def test_multiple_source_turns_partial_fix(self):
+        events = [
+            {
+                "id": "evt-300",
+                "source_turns": ["turn-001", "turn-098"],
+                "description": "Mixed",
+            }
+        ]
+        _fix_event_source_turns(events, "turn-100")
+        assert "turn-100" in events[0]["source_turns"]
+        assert "turn-098" in events[0]["source_turns"]
+        assert "turn-001" not in events[0]["source_turns"]
+
+    def test_no_source_turns_is_noop(self):
+        events = [{"id": "evt-400", "description": "No source_turns"}]
+        _fix_event_source_turns(events, "turn-100")
+        assert "source_turns" not in events[0]
+
+    def test_deduplicates_after_correction(self):
+        events = [
+            {
+                "id": "evt-500",
+                "source_turns": ["turn-001", "turn-002"],
+                "description": "Both wrong",
+            }
+        ]
+        _fix_event_source_turns(events, "turn-300")
+        assert events[0]["source_turns"] == ["turn-300"]
+
+
+# ---------------------------------------------------------------------------
+# #128 — Stub backfill
+# ---------------------------------------------------------------------------
+
+class TestStubIdentification:
+    def test_stub_with_stub_in_notes(self):
+        entity = {"id": "char-lyra", "name": "Lyra", "notes": "Auto-created by event-stub."}
+        assert _is_stub_entity(entity) is True
+
+    def test_stub_with_empty_identity(self):
+        entity = {"id": "char-test", "name": "Test", "identity": "", "notes": "something"}
+        assert _is_stub_entity(entity) is True
+
+    def test_stub_with_missing_identity(self):
+        entity = {"id": "char-test", "name": "Test", "notes": "normal"}
+        assert _is_stub_entity(entity) is True
+
+    def test_full_entity_not_stub(self):
+        entity = {
+            "id": "char-grim",
+            "name": "Grim",
+            "identity": "A seasoned warrior.",
+            "notes": "Discovered turn 5.",
+        }
+        assert _is_stub_entity(entity) is False
+
+    def test_collect_context_from_events(self):
+        events = [
+            {
+                "id": "evt-001",
+                "related_entities": ["char-lyra"],
+                "source_turns": ["turn-010"],
+            },
+            {
+                "id": "evt-002",
+                "related_entities": ["char-other"],
+                "source_turns": ["turn-020"],
+            },
+        ]
+        turns = [
+            {"turn_id": "turn-010", "speaker": "DM", "text": "Lyra appeared at the gate."},
+            {"turn_id": "turn-020", "speaker": "DM", "text": "Other speaks."},
+        ]
+        context = _collect_stub_context("char-lyra", events, turns, "turn-010")
+        assert "Lyra appeared" in context
+        assert "Other speaks" not in context
+
+    def test_collect_context_includes_first_seen(self):
+        events = []  # no events reference this entity
+        turns = [
+            {"turn_id": "turn-005", "speaker": "DM", "text": "First appearance."},
+        ]
+        context = _collect_stub_context("char-unknown", events, turns, "turn-005")
+        assert "First appearance" in context
+
+    def test_backfill_preserves_first_seen_turn(self):
+        """Stub detection finds entities correctly before backfill."""
+        entity = {
+            "id": "char-lyra",
+            "name": "Lyra",
+            "first_seen_turn": "turn-003",
+            "notes": "Auto-created by event-stub.",
+            "identity": "Entity referenced in events (stub — auto-created from event data).",
+        }
+        # The stub should be identified for backfill
+        assert _is_stub_entity(entity) is True
+
+
+# ---------------------------------------------------------------------------
+# #129 — Levenshtein fuzzy dedup
+# ---------------------------------------------------------------------------
+
+def _make_entity(id_, name, turn="turn-001"):
+    return {
+        "id": id_,
+        "name": name,
+        "first_seen_turn": turn,
+        "attributes": {},
+        "relationships": [],
+    }
+
+
+class TestLevenshteinDedup:
+    def test_communal_vs_communial(self):
+        """Spelling variants with distance=1 should merge."""
+        catalogs = {
+            "locations.json": [
+                _make_entity("loc-communal-home", "Communal Home", "turn-005"),
+                _make_entity("loc-communial-home", "Communial Home", "turn-010"),
+            ]
+        }
+        count, merge_map = _dedup_catalogs(catalogs)
+        assert count == 1
+        assert len(catalogs["locations.json"]) == 1
+        survivor = catalogs["locations.json"][0]
+        assert survivor["id"] == "loc-communal-home"
+
+    def test_distinct_entities_not_merged(self):
+        """Truly distinct entities (distance > 2) should not merge."""
+        catalogs = {
+            "items.json": [
+                _make_entity("item-sword", "Sword", "turn-001"),
+                _make_entity("item-board", "Board", "turn-002"),
+            ]
+        }
+        count, merge_map = _dedup_catalogs(catalogs)
+        assert count == 0
+        assert len(catalogs["items.json"]) == 2
+
+    def test_levenshtein_respects_first_char(self):
+        """Entities whose stems start with different chars should not merge."""
+        catalogs = {
+            "locations.json": [
+                _make_entity("loc-cave", "Cave", "turn-001"),
+                _make_entity("loc-dave", "Dave", "turn-002"),
+            ]
+        }
+        count, merge_map = _dedup_catalogs(catalogs)
+        assert count == 0
+        assert len(catalogs["locations.json"]) == 2
+
+    def test_no_double_merge_with_existing_rules(self):
+        """Levenshtein dedup should not cause double-merges with token overlap."""
+        catalogs = {
+            "items.json": [
+                _make_entity("item-healing-potion", "Healing Potion", "turn-001"),
+                _make_entity("item-healng-potion", "Healng Potion", "turn-005"),
+            ]
+        }
+        count, merge_map = _dedup_catalogs(catalogs)
+        # Should merge exactly once (either by token overlap or levenshtein)
+        assert count == 1
+        assert len(catalogs["items.json"]) == 1
+
+    def test_length_difference_guard(self):
+        """Entities with large length difference should not merge even with low distance."""
+        catalogs = {
+            "locations.json": [
+                _make_entity("loc-ab", "Ab", "turn-001"),
+                _make_entity("loc-abcdef", "Abcdef", "turn-002"),
+            ]
+        }
+        count, merge_map = _dedup_catalogs(catalogs)
+        assert count == 0
+        assert len(catalogs["locations.json"]) == 2

--- a/tools/bootstrap_session.py
+++ b/tools/bootstrap_session.py
@@ -474,6 +474,11 @@ def main() -> None:
         default=None,
         help="Override the LLM API base URL from config/llm.json for this run.",
     )
+    parser.add_argument(
+        "--backfill-stubs",
+        action="store_true",
+        help="After extraction, re-extract hollow stub entities using gathered context.",
+    )
     args = parser.parse_args()
 
     # Validate --start-date format if provided
@@ -652,6 +657,22 @@ def main() -> None:
             turn_dicts, session_dir, framework_dir=args.framework, dry_run=args.dry_run,
             overrides=llm_overrides or None,
         )
+
+        # Stub backfill pass (#128)
+        if args.backfill_stubs:
+            from semantic_extraction import backfill_stubs
+            from catalog_merger import load_catalogs, load_events, save_catalogs, save_events
+            from llm_client import LLMClient
+
+            catalog_dir = os.path.join(args.framework, "catalogs")
+            catalogs = load_catalogs(catalog_dir)
+            events_list = load_events(catalog_dir)
+            llm = LLMClient("config/llm.json", overrides=llm_overrides or None)
+            count = backfill_stubs(turn_dicts, catalogs, events_list, llm)
+            if count and not args.dry_run:
+                save_catalogs(catalog_dir, catalogs)
+                save_events(catalog_dir, events_list)
+            print(f"  Stub backfill: {count} stub(s) enriched")
     except ModuleNotFoundError as exc:
         if exc.name == "semantic_extraction":
             print(

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -644,11 +644,16 @@ dedup_merge_entity = _update_existing_entity
 # ---------------------------------------------------------------------------
 
 _RELATIONSHIP_TYPE_MAP = {
+    # Schema enum identity mappings (pass-through)
+    "kinship": "kinship", "partnership": "partnership", "mentorship": "mentorship",
+    "political": "political", "factional": "factional", "social": "social",
+    "adversarial": "adversarial", "romantic": "romantic", "other": "other",
     # social
     "ally": "social", "ally_of": "social", "ally of": "social",
     "friend": "social", "companion": "social", "supporter": "social",
-    "supports": "social", "collaborating": "social", "collaborating with": "social",
-    "collaborator": "social",
+    "supports": "social",
+    "collaborating": "partnership", "collaborating with": "partnership",
+    "collaborator": "partnership",
     # adversarial
     "captive": "adversarial", "captive of": "adversarial",
     "prisoner": "adversarial", "captor": "adversarial",
@@ -679,7 +684,10 @@ _RELATIONSHIP_TYPE_MAP = {
 
 def _coerce_relationship_type(type_value: str) -> str:
     """Map common LLM relationship labels to schema enum values (#126)."""
-    return _RELATIONSHIP_TYPE_MAP.get(type_value.lower().strip(), type_value)
+    normalized = type_value.lower().strip()
+    if not normalized:
+        return "other"
+    return _RELATIONSHIP_TYPE_MAP.get(normalized, "other")
 
 
 def _merge_entity_relationships(existing_rels: list[dict], new_rels: list[dict]) -> None:
@@ -816,6 +824,8 @@ def merge_relationships(catalogs: dict, relationships: list, turn_id: str) -> No
                 new_rel["confidence"] = rel["confidence"]
             new_rel["first_seen_turn"] = turn_id
             new_rel["last_updated_turn"] = turn_id
+            # Coerce relationship type to schema enum (#126)
+            new_rel["type"] = _coerce_relationship_type(new_rel["type"])
             entity["relationships"].append(new_rel)
 
 

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -643,6 +643,45 @@ dedup_merge_entity = _update_existing_entity
 # Relationship consolidation
 # ---------------------------------------------------------------------------
 
+_RELATIONSHIP_TYPE_MAP = {
+    # social
+    "ally": "social", "ally_of": "social", "ally of": "social",
+    "friend": "social", "companion": "social", "supporter": "social",
+    "supports": "social", "collaborating": "social", "collaborating with": "social",
+    "collaborator": "social",
+    # adversarial
+    "captive": "adversarial", "captive of": "adversarial",
+    "prisoner": "adversarial", "captor": "adversarial",
+    "rival": "adversarial", "competitor": "adversarial",
+    "enemy": "adversarial", "caught by": "adversarial",
+    "ensnared by": "adversarial",
+    # mentorship
+    "mentor": "mentorship", "teacher": "mentorship",
+    "student": "mentorship", "apprentice": "mentorship",
+    "teaching": "mentorship",
+    # kinship
+    "family": "kinship", "parent": "kinship", "child": "kinship",
+    "sibling": "kinship", "kin": "kinship", "mother": "kinship",
+    "father": "kinship", "daughter": "kinship", "son": "kinship",
+    # partnership
+    "cooperating": "partnership", "partner": "partnership",
+    "working with": "partnership",
+    # romantic
+    "lover": "romantic", "romantic partner": "romantic",
+    # political
+    "diplomatic": "political",
+    # factional
+    "faction": "factional", "guild": "factional", "tribal": "factional",
+    # other — explicit task/using relationships stay as other
+    "task related to": "other", "using": "other",
+}
+
+
+def _coerce_relationship_type(type_value: str) -> str:
+    """Map common LLM relationship labels to schema enum values (#126)."""
+    return _RELATIONSHIP_TYPE_MAP.get(type_value.lower().strip(), type_value)
+
+
 def _merge_entity_relationships(existing_rels: list[dict], new_rels: list[dict]) -> None:
     """Merge new relationships into existing, consolidating per (target_id) pair.
 
@@ -671,6 +710,9 @@ def _merge_entity_relationships(existing_rels: list[dict], new_rels: list[dict])
             entry.setdefault("status", "active")
             if "current_relationship" not in entry and "relationship" in entry:
                 entry["current_relationship"] = entry.pop("relationship")
+            # Coerce relationship type to schema enum (#126)
+            if entry.get("type"):
+                entry["type"] = _coerce_relationship_type(entry["type"])
             existing_rels.append(entry)
             by_target[target_id] = len(existing_rels) - 1
 
@@ -680,6 +722,10 @@ def _consolidate_relationship(existing: dict, update: dict) -> None:
 
     Pushes the old current_relationship into history and updates to the new one.
     """
+    # Coerce relationship type to schema enum (#126)
+    if update.get("type"):
+        update["type"] = _coerce_relationship_type(update["type"])
+
     # Determine the new description
     new_desc = update.get("current_relationship") or update.get("relationship", "")
     old_desc = existing.get("current_relationship") or existing.get("relationship", "")

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -33,6 +33,7 @@ from catalog_merger import (
     TYPE_TO_PREFIX,
     _infer_type_from_prefix,
     _strip_any_prefix,
+    _levenshtein,
 )
 from llm_client import LLMClient, LLMExtractionError
 
@@ -315,6 +316,42 @@ def _validate_event(event_data: dict) -> bool:
     except jsonschema.ValidationError as e:
         print(f"  WARNING: Event failed schema validation: {e.message}", file=sys.stderr)
         return False
+
+
+# Maximum turn distance for event source_turns to be considered valid (#127)
+_MAX_SOURCE_TURN_DISTANCE = 5
+
+
+def _fix_event_source_turns(events: list[dict], current_turn_id: str) -> None:
+    """Validate and correct event source_turns that don't match the current turn (#127).
+
+    If an event's source_turns entries are more than _MAX_SOURCE_TURN_DISTANCE
+    before the current turn, replace them with the current turn ID.
+    """
+    current_num = _parse_turn_number(current_turn_id)
+    if current_num is None:
+        return
+
+    for event in events:
+        source_turns = event.get("source_turns")
+        if not isinstance(source_turns, list) or not source_turns:
+            continue
+        corrected = False
+        for i, st in enumerate(source_turns):
+            st_num = _parse_turn_number(st)
+            if st_num is None:
+                continue
+            if abs(current_num - st_num) > _MAX_SOURCE_TURN_DISTANCE:
+                source_turns[i] = current_turn_id
+                corrected = True
+        if corrected:
+            # Deduplicate after correction
+            event["source_turns"] = list(dict.fromkeys(source_turns))
+            print(
+                f"  WARNING: Corrected event {event.get('id', '?')} source_turns "
+                f"to [{current_turn_id}] (was mismatched by >{_MAX_SOURCE_TURN_DISTANCE} turns)",
+                file=sys.stderr,
+            )
 
 
 PLAYER_CHARACTER_SEED = {
@@ -691,38 +728,55 @@ def _pc_partial_merge(catalogs: dict, entity_data: dict, turn_id: str) -> None:
         return
     _, pc_entry = pc_result
 
+    attempted_fields = []
     merged_fields = []
 
     # Merge current_status if present and non-empty
-    if entity_data.get("current_status") and isinstance(entity_data["current_status"], str):
-        pc_entry["current_status"] = entity_data["current_status"]
-        merged_fields.append("current_status")
+    if entity_data.get("current_status"):
+        attempted_fields.append("current_status")
+        if isinstance(entity_data["current_status"], str):
+            pc_entry["current_status"] = entity_data["current_status"]
+            merged_fields.append("current_status")
+        else:
+            print(
+                f"  PC partial merge: current_status skipped (not a string) at {turn_id}",
+                file=sys.stderr,
+            )
 
     # Merge volatile_state if present
     vs = entity_data.get("volatile_state")
-    if isinstance(vs, dict) and vs:
-        if "volatile_state" not in pc_entry:
-            pc_entry["volatile_state"] = {}
-        for k, v in vs.items():
-            pc_entry["volatile_state"][k] = v
-        merged_fields.append("volatile_state")
+    if vs is not None:
+        attempted_fields.append("volatile_state")
+        if isinstance(vs, dict) and vs:
+            if "volatile_state" not in pc_entry:
+                pc_entry["volatile_state"] = {}
+            for k, v in vs.items():
+                pc_entry["volatile_state"][k] = v
+            merged_fields.append("volatile_state")
+        else:
+            print(
+                f"  PC partial merge: volatile_state skipped (empty or not a dict) at {turn_id}",
+                file=sys.stderr,
+            )
 
     # Merge individual stable_attributes that are in the allowed set
     # and conform to the expected entity schema shape.
     sa = entity_data.get("stable_attributes")
-    if isinstance(sa, dict) and sa:
-        stable_attr_merged = False
-        for k, v in sa.items():
-            if k not in PC_ALLOWED_ATTRS:
-                continue
-            if not isinstance(v, dict) or "value" not in v:
-                continue
-            if "stable_attributes" not in pc_entry:
-                pc_entry["stable_attributes"] = {}
-            pc_entry["stable_attributes"][k] = v
-            stable_attr_merged = True
-        if stable_attr_merged:
-            merged_fields.append("stable_attributes")
+    if sa is not None:
+        attempted_fields.append("stable_attributes")
+        if isinstance(sa, dict) and sa:
+            stable_attr_merged = False
+            for k, v in sa.items():
+                if k not in PC_ALLOWED_ATTRS:
+                    continue
+                if not isinstance(v, dict) or "value" not in v:
+                    continue
+                if "stable_attributes" not in pc_entry:
+                    pc_entry["stable_attributes"] = {}
+                pc_entry["stable_attributes"][k] = v
+                stable_attr_merged = True
+            if stable_attr_merged:
+                merged_fields.append("stable_attributes")
 
     # Update last_updated_turn if we merged anything
     if merged_fields:
@@ -730,7 +784,14 @@ def _pc_partial_merge(catalogs: dict, entity_data: dict, turn_id: str) -> None:
         if entity_data.get("status_updated_turn"):
             pc_entry["status_updated_turn"] = entity_data["status_updated_turn"]
         print(
-            f"  WARNING: PC validation failed — partial merge of {merged_fields} at {turn_id}",
+            f"  PC partial merge: merged {merged_fields} at {turn_id} "
+            f"(attempted: {attempted_fields}, last_updated_turn => {turn_id})",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"  WARNING: PC partial merge fired but merged_fields is empty at {turn_id} "
+            f"(attempted: {attempted_fields})",
             file=sys.stderr,
         )
 
@@ -879,6 +940,16 @@ def extract_and_merge(
     # Filter by confidence
     qualified = filter_by_confidence(discovered, min_confidence)
 
+    # Reject concept-prefix entities at discovery acceptance time (#124)
+    filtered_qualified = []
+    for entity_ref in qualified:
+        eid = get_entity_id(entity_ref)
+        if eid and eid.lower().startswith("concept-"):
+            print(f"  Skipping concept-prefix entity from discovery: {eid}", file=sys.stderr)
+            continue
+        filtered_qualified.append(entity_ref)
+    qualified = filtered_qualified
+
     # --- 2. Entity Detail Extraction (per entity above threshold) ---
     for entity_ref in qualified:
         entity_id = get_entity_id(entity_ref)
@@ -955,6 +1026,13 @@ def extract_and_merge(
                 _sanitize_pc_catalog_entry(catalogs)
             elif entity_data:
                 # Validation failed — attempt partial merge fallback (#107)
+                # Log structure of the raw response to aid diagnosis (#125)
+                _data_keys = sorted(entity_data.keys()) if isinstance(entity_data, dict) else "non-dict"
+                print(
+                    f"  PC detail extraction: validation failed at {turn_id}, "
+                    f"response keys={_data_keys}, falling back to partial merge",
+                    file=sys.stderr,
+                )
                 _pc_partial_merge(catalogs, entity_data, turn_id)
         except LLMExtractionError as e:
             print(f"  WARNING: PC detail extraction failed at {turn_id}: {e}", file=sys.stderr)
@@ -1007,6 +1085,9 @@ def extract_and_merge(
             user_prompt=format_event_prompt(turn, next_evt_id, entity_ids),
         )
         new_events = event_result.get("events", [])
+
+        # --- Phase 0: Validate event source_turns match processing turn (#127) ---
+        _fix_event_source_turns(new_events, turn_id)
 
         # --- Phase 1: Normalize event related_entities IDs (#108) ---
         known_ids = _collect_all_entity_ids(catalogs)
@@ -1147,6 +1228,18 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
                     if len(smaller_parts) >= 2 and (parts_a.issubset(parts_b) or parts_b.issubset(parts_a)):
                         union(idx_a, idx_b)
                         print(f"  DEDUP (id-stem): linking '{name_a}' ({id_a}) and '{name_b}' ({id_b}) as duplicates")
+                        continue
+
+                    # Rule 4: Levenshtein distance on ID stems (#129)
+                    dist = _levenshtein(stem_a, stem_b)
+                    if (dist <= 2
+                            and stem_a[0] == stem_b[0]
+                            and abs(len(stem_a) - len(stem_b)) <= 2):
+                        union(idx_a, idx_b)
+                        print(
+                            f"  DEDUP (levenshtein): linking '{name_a}' ({id_a}) "
+                            f"and '{name_b}' ({id_b}) as duplicates (distance={dist})"
+                        )
 
         # Group by root
         groups: dict[int, list[int]] = {}
@@ -1255,6 +1348,120 @@ def _post_batch_orphan_sweep(catalogs: dict, events_list: list) -> int:
         print(f"  POST-BATCH STUB: '{eid}' ({inferred_name}), {len(turn_ids)} event refs")
 
     return stubs_created
+
+
+# ---------------------------------------------------------------------------
+# Stub backfill (#128)
+# ---------------------------------------------------------------------------
+
+
+def _is_stub_entity(entity: dict) -> bool:
+    """Return True if the entity is a hollow stub needing backfill."""
+    notes = entity.get("notes", "")
+    if isinstance(notes, str) and "stub" in notes.lower():
+        return True
+    identity = entity.get("identity", "")
+    if not identity or identity == "":
+        return True
+    return False
+
+
+def _collect_stub_context(entity_id: str, events_list: list, turn_dicts: list,
+                          first_seen_turn: str | None) -> str:
+    """Gather turn text around an entity's event references for backfill context."""
+    # Find all turns that reference this entity via events
+    ref_turns: set[str] = set()
+    for event in events_list:
+        related = event.get("related_entities", [])
+        if entity_id in related:
+            for st in event.get("source_turns", []):
+                ref_turns.add(st)
+            st_single = event.get("source_turn")
+            if st_single:
+                ref_turns.add(st_single)
+
+    # Also include first_seen_turn and neighbors
+    if first_seen_turn:
+        ref_turns.add(first_seen_turn)
+
+    # Build a turn lookup
+    turn_lookup = {t["turn_id"]: t for t in turn_dicts}
+
+    # Collect context text from referenced turns
+    context_parts = []
+    for tid in sorted(ref_turns):
+        turn = turn_lookup.get(tid)
+        if turn:
+            context_parts.append(f"[{tid}] {turn['text'][:500]}")
+
+    return "\n".join(context_parts[:10])  # limit context size
+
+
+def backfill_stubs(
+    turn_dicts: list,
+    catalogs: dict,
+    events_list: list,
+    llm: "LLMClient",
+) -> int:
+    """Re-extract stub entities using gathered context (#128).
+
+    Returns the number of stubs successfully backfilled.
+    """
+    stubs: list[tuple[str, dict, str]] = []  # (catalog_file, entity, entity_id)
+    for filename, entities in catalogs.items():
+        for entity in entities:
+            if _is_stub_entity(entity):
+                stubs.append((filename, entity, entity.get("id", "")))
+
+    if not stubs:
+        return 0
+
+    print(f"  Backfill: found {len(stubs)} stub(s) to re-extract")
+    backfilled = 0
+
+    for _filename, entity, entity_id in stubs:
+        if not entity_id:
+            continue
+
+        first_seen = entity.get("first_seen_turn", "turn-001")
+        context_text = _collect_stub_context(entity_id, events_list, turn_dicts, first_seen)
+        if not context_text:
+            print(f"  Backfill: no context found for stub '{entity_id}', skipping")
+            continue
+
+        # Build a synthetic turn for detail extraction
+        synthetic_turn = {
+            "turn_id": first_seen,
+            "speaker": "DM",
+            "text": context_text,
+        }
+        entity_ref = {
+            "name": entity.get("name", ""),
+            "type": entity.get("type", "character"),
+            "existing_id": entity_id,
+            "is_new": False,
+        }
+
+        try:
+            detail_result = llm.extract_json(
+                system_prompt=load_template("entity-detail"),
+                user_prompt=format_detail_prompt(synthetic_turn, entity_ref, entity),
+            )
+            entity_data = detail_result.get("entity")
+            if entity_data:
+                entity_data = _coerce_entity_fields(entity_data)
+            if entity_data and _validate_entity(entity_data):
+                # Preserve first_seen_turn from original stub
+                entity_data["first_seen_turn"] = first_seen
+                merge_entity(catalogs, entity_data)
+                backfilled += 1
+                print(f"  Backfill: successfully enriched stub '{entity_id}'")
+        except LLMExtractionError as e:
+            print(f"  WARNING: Backfill failed for {entity_id}: {e}", file=sys.stderr)
+
+        llm.delay()
+
+    return backfilled
 
 
 def extract_semantic_batch(

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -326,7 +326,7 @@ def _fix_event_source_turns(events: list[dict], current_turn_id: str) -> None:
     """Validate and correct event source_turns that don't match the current turn (#127).
 
     If an event's source_turns entries are more than _MAX_SOURCE_TURN_DISTANCE
-    before the current turn, replace them with the current turn ID.
+    away from the current turn, replace them with the current turn ID.
     """
     current_num = _parse_turn_number(current_turn_id)
     if current_num is None:
@@ -1231,15 +1231,14 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
                         continue
 
                     # Rule 4: Levenshtein distance on ID stems (#129)
-                    dist = _levenshtein(stem_a, stem_b)
-                    if (dist <= 2
-                            and stem_a[0] == stem_b[0]
-                            and abs(len(stem_a) - len(stem_b)) <= 2):
-                        union(idx_a, idx_b)
-                        print(
-                            f"  DEDUP (levenshtein): linking '{name_a}' ({id_a}) "
-                            f"and '{name_b}' ({id_b}) as duplicates (distance={dist})"
-                        )
+                    if stem_a[0] == stem_b[0] and abs(len(stem_a) - len(stem_b)) <= 2:
+                        dist = _levenshtein(stem_a, stem_b)
+                        if dist <= 2:
+                            union(idx_a, idx_b)
+                            print(
+                                f"  DEDUP (levenshtein): linking '{name_a}' ({id_a}) "
+                                f"and '{name_b}' ({id_b}) as duplicates (distance={dist})"
+                            )
 
         # Group by root
         groups: dict[int, list[int]] = {}
@@ -1355,10 +1354,17 @@ def _post_batch_orphan_sweep(catalogs: dict, events_list: list) -> int:
 # ---------------------------------------------------------------------------
 
 
+# Known auto-created stub note values
+_STUB_NOTE_MARKERS = {
+    "auto-created by event-stub.",
+    "auto-created by post-batch orphan sweep.",
+}
+
+
 def _is_stub_entity(entity: dict) -> bool:
     """Return True if the entity is a hollow stub needing backfill."""
     notes = entity.get("notes", "")
-    if isinstance(notes, str) and "stub" in notes.lower():
+    if isinstance(notes, str) and notes.lower().strip().rstrip(".") + "." in _STUB_NOTE_MARKERS:
         return True
     identity = entity.get("identity", "")
     if not identity or identity == "":
@@ -1380,12 +1386,20 @@ def _collect_stub_context(entity_id: str, events_list: list, turn_dicts: list,
             if st_single:
                 ref_turns.add(st_single)
 
-    # Also include first_seen_turn and neighbors
+    # Build turn lookup and preserve transcript order for neighbor selection
+    turn_lookup = {t["turn_id"]: t for t in turn_dicts}
+    ordered_turn_ids = [t["turn_id"] for t in turn_dicts]
+    turn_index = {turn_id: idx for idx, turn_id in enumerate(ordered_turn_ids)}
+
+    # Also include first_seen_turn and its neighbors
     if first_seen_turn:
         ref_turns.add(first_seen_turn)
-
-    # Build a turn lookup
-    turn_lookup = {t["turn_id"]: t for t in turn_dicts}
+        idx = turn_index.get(first_seen_turn)
+        if idx is not None:
+            if idx > 0:
+                ref_turns.add(ordered_turn_ids[idx - 1])
+            if idx + 1 < len(ordered_turn_ids):
+                ref_turns.add(ordered_turn_ids[idx + 1])
 
     # Collect context text from referenced turns
     context_parts = []
@@ -1454,6 +1468,10 @@ def backfill_stubs(
                 # Preserve first_seen_turn from original stub
                 entity_data["first_seen_turn"] = first_seen
                 merge_entity(catalogs, entity_data)
+                # Clear stub marker so entity won't be re-flagged (#128)
+                merged = find_entity_by_id(catalogs, entity_id)
+                if merged:
+                    merged[1]["notes"] = "Backfilled from stub."
                 backfilled += 1
                 print(f"  Backfill: successfully enriched stub '{entity_id}'")
         except LLMExtractionError as e:


### PR DESCRIPTION
## Summary

Six quality fixes identified from Run 7 extraction (qwen3:14b). Addresses concept-prefix proliferation, PC tracking regression diagnostics, relationship type standardization, event attribution accuracy, stub entity backfill, and spelling-variant dedup.

## Issue #124 — Concept-prefix filter in discovery path

Filter concept-prefix entity IDs at discovery acceptance time, before detail extraction. Previously only guarded at stub creation and item-type check paths.

## Issue #125 — PC extraction resilience logging

Add field-level diagnostic logging to `_pc_partial_merge` and PC detail extraction fallback. Logs attempted fields, merged fields, empty-merge warnings, and validation failure response structure.

## Issue #126 — Relationship type coercion

Map common LLM relationship labels (ally, captive, mentor, etc.) to schema enum values via `_coerce_relationship_type()`. Applied in both `_consolidate_relationship` and new relationship insertion paths. Targets reducing "other" typed relationships from 56% to <25%.

## Issue #127 — Event source_turns validation

Validate and correct event `source_turns` that don't match the processing turn. Events claiming source turns >5 turns away from the current turn get corrected. Prevents late-game events from being attributed to early turns.

## Issue #128 — Stub backfill pass

Add `backfill_stubs()` function and `--backfill-stubs` CLI flag to `bootstrap_session.py`. Scans catalogs for hollow stub entities, gathers context from referencing events and nearby turns, then runs targeted detail extraction to enrich them.

## Issue #129 — Levenshtein fuzzy dedup

Add Levenshtein distance matching (Rule 4) to `_dedup_catalogs()` alongside existing token-overlap and ID-stem rules. Catches spelling variants like `communal` vs `communial` (distance=1). Reuses `_levenshtein()` from `catalog_merger.py`.

## Test Coverage

38 new tests in `tests/test_run7_quality.py` covering all 6 fixes. Full suite: 439 passed, 0 failed.

Closes #124
Closes #125
Closes #126
Closes #127
Closes #128
Closes #129
