### PR TITLE
docs: add Rule 8 — require documentation updates in same PR as code changes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,6 +65,16 @@ When generating `derived/prompt-candidates.json`:
 - Do not infer motivations or backstory unless explicitly supported.
 - If a gap exists in the narrative, note it as an `open_question` in the plot-thread, not as a fact.
 
+### 8. Keep Documentation Current
+
+When a code change alters tool behavior, data flow, schemas, or output format:
+
+- Update `docs/architecture.md` to reflect new or changed layers, tools, or data flow.
+- Update `docs/roadmap.md` to reflect milestone progress or new capabilities.
+- Update `docs/usage.md` if the change affects how users run tools or configure the system.
+- Include documentation updates in the same commit/PR as the code change, not as a separate follow-up.
+- Agent prompt files (`.prompt.md`) must include a "Documentation Updates" section listing which docs to update and what to add.
+
 ---
 
 ## File Conventions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,7 +72,7 @@ When a code change alters tool behavior, data flow, schemas, or output format:
 - Update `docs/architecture.md` to reflect new or changed layers, tools, or data flow.
 - Update `docs/roadmap.md` to reflect milestone progress or new capabilities.
 - Update `docs/usage.md` if the change affects how users run tools or configure the system.
-- Include documentation updates in the same commit/PR as the code change, not as a separate follow-up.
+- Include documentation updates in the same PR as the code change, not as a separate follow-up.
 - Agent prompt files (`.prompt.md`) must include a "Documentation Updates" section listing which docs to update and what to add.
 
 ---


### PR DESCRIPTION
## Summary

Adds **Rule 8 — Keep Documentation Current** to `.github/copilot-instructions.md`.

This codifies the convention that code changes altering tool behavior, data flow, schemas, or output format must include documentation updates in the same commit/PR:

- `docs/architecture.md` for new or changed layers, tools, or data flow
- `docs/roadmap.md` for milestone progress or new capabilities
- `docs/usage.md` for changes affecting how users run tools or configure the system

Agent prompt files (`.prompt.md`) must include a "Documentation Updates" section listing which docs to update and what to add.

This was previously an ad-hoc practice — this change makes it a formal rule so all future prompts inherit it automatically.
