### PR TITLE
fix: Run 8 follow-up — backfill default, dedup guard, PC logging, alias merge (#131-#134)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,6 +40,12 @@ Divide session processing across multiple specialized agents, each with a focuse
 
 The **Catalog agent** is implemented as `tools/semantic_extraction.py` — a four-agent LLM pipeline (Entity Discovery → Entity Detail → Relationship Mapper → Event Extractor) that runs during bootstrap and incremental ingestion. It uses prompt templates in `templates/extraction/` and a provider-agnostic LLM client (`tools/llm_client.py`) supporting OpenAI and Ollama.
 
+Post-extraction quality passes include:
+- **Dedup** — name, token-overlap, ID-stem, and Levenshtein matching (with minimum 6-char stem guard, #132)
+- **Stub backfill** — re-extracts hollow stub entities using gathered context; runs by default (#128, #131)
+- **PC alias merge** — detects character entities that are aliases of char-player and merges them (#134)
+- **PC consecutive-failure logging** — warns when PC extraction fails for ≥10 consecutive turns (#133)
+
 Benefits:
 - Narrower per-agent context window → lower token cost
 - Agents can run in parallel on unrelated subtasks

--- a/tests/test_run7_quality.py
+++ b/tests/test_run7_quality.py
@@ -101,7 +101,7 @@ class TestPCPartialMergeLogging:
         entity_data = {"id": "char-player"}
         _pc_partial_merge(catalogs, entity_data, "turn-060")
         captured = capsys.readouterr()
-        assert "empty" in captured.err.lower()
+        assert "no fields could be merged" in captured.err.lower()
         assert "turn-060" in captured.err
 
     def test_logs_attempted_fields(self, capsys):

--- a/tests/test_run8_followup.py
+++ b/tests/test_run8_followup.py
@@ -231,7 +231,7 @@ class TestPCConsecutiveFailureTracking:
 # #134 — Post-extraction PC alias merge
 # ---------------------------------------------------------------------------
 
-class TestPCAliaseMerge:
+class TestPCAliasMerge:
     """Verify _merge_pc_aliases() identifies and merges PC aliases."""
 
     def test_merge_alias_with_multiple_events(self):

--- a/tests/test_run8_followup.py
+++ b/tests/test_run8_followup.py
@@ -4,17 +4,18 @@ import sys
 import json
 import tempfile
 import shutil
-from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
+import semantic_extraction as se
 from semantic_extraction import (
     _dedup_catalogs,
     _pc_partial_merge,
     _merge_pc_aliases,
-    _pc_consecutive_failures,
+    _reset_pc_failure_tracking,
     _PC_FAILURE_WARN_THRESHOLD,
 )
+from bootstrap_session import build_parser
 
 
 # ---------------------------------------------------------------------------
@@ -50,21 +51,15 @@ class TestBackfillDefault:
     """Verify that backfill runs by default (no flag needed)."""
 
     def test_skip_backfill_flag_exists(self):
-        """--skip-backfill should be defined in argparse."""
-        import bootstrap_session
-        import argparse
-        # Parse with --skip-backfill to verify it's recognized
-        parser = argparse.ArgumentParser()
-        parser.add_argument("--skip-backfill", action="store_true")
-        args = parser.parse_args(["--skip-backfill"])
+        """--skip-backfill should be defined in the real bootstrap parser."""
+        parser = build_parser()
+        args = parser.parse_args(["--session", "s", "--file", "f", "--skip-backfill"])
         assert args.skip_backfill is True
 
     def test_skip_backfill_default_false(self):
         """--skip-backfill should default to False (backfill ON)."""
-        import argparse
-        parser = argparse.ArgumentParser()
-        parser.add_argument("--skip-backfill", action="store_true")
-        args = parser.parse_args([])
+        parser = build_parser()
+        args = parser.parse_args(["--session", "s", "--file", "f"])
         assert args.skip_backfill is False
 
 
@@ -148,9 +143,18 @@ class TestPCConsecutiveFailureTracking:
         """Threshold should be 10."""
         assert _PC_FAILURE_WARN_THRESHOLD == 10
 
+    def test_reset_clears_counter(self):
+        """_reset_pc_failure_tracking should set counter to 0."""
+        original = se._pc_consecutive_failures
+        try:
+            se._pc_consecutive_failures = 7
+            _reset_pc_failure_tracking()
+            assert se._pc_consecutive_failures == 0
+        finally:
+            se._pc_consecutive_failures = original
+
     def test_warning_at_threshold(self, capsys):
         """WARNING should fire at 10 consecutive failures."""
-        import semantic_extraction as se
         original = se._pc_consecutive_failures
         try:
             # Simulate 10 failures
@@ -177,7 +181,6 @@ class TestPCConsecutiveFailureTracking:
 
     def test_counter_resets_on_success(self):
         """Counter should reset to 0 on successful extraction."""
-        import semantic_extraction as se
         original = se._pc_consecutive_failures
         try:
             se._pc_consecutive_failures = 5
@@ -187,8 +190,26 @@ class TestPCConsecutiveFailureTracking:
         finally:
             se._pc_consecutive_failures = original
 
-    def test_empty_merge_warning_includes_response_keys(self, capsys):
-        """Empty merge WARNING should include response keys."""
+    def test_partial_merge_returns_true_on_success(self):
+        """_pc_partial_merge should return True when fields are merged."""
+        catalogs = {
+            "characters.json": [
+                {
+                    "id": "char-player",
+                    "name": "Player Character",
+                    "type": "character",
+                    "identity": "The player character.",
+                    "first_seen_turn": "turn-001",
+                    "last_updated_turn": "turn-050",
+                }
+            ]
+        }
+        entity_data = {"id": "char-player", "current_status": "Fighting."}
+        result = _pc_partial_merge(catalogs, entity_data, "turn-100")
+        assert result is True
+
+    def test_partial_merge_returns_false_on_empty(self):
+        """_pc_partial_merge should return False when no fields merge."""
         catalogs = {
             "characters.json": [
                 {
@@ -202,31 +223,8 @@ class TestPCConsecutiveFailureTracking:
             ]
         }
         entity_data = {"id": "char-player", "garbage_field": "junk"}
-        _pc_partial_merge(catalogs, entity_data, "turn-060")
-        captured = capsys.readouterr()
-        assert "no fields could be merged" in captured.err.lower()
-        assert "Response keys:" in captured.err
-        assert "turn-060" in captured.err
-
-    def test_none_extraction_warning(self, capsys):
-        """When entity_data is None, a specific warning should fire."""
-        import semantic_extraction as se
-        original = se._pc_consecutive_failures
-        try:
-            se._pc_consecutive_failures = 3
-            # Simulate the None-extraction warning path
-            turn_id = "turn-200"
-            print(
-                f"  WARNING: PC detail extraction returned None at {turn_id}. "
-                f"Consecutive failures: {se._pc_consecutive_failures + 1}",
-                file=sys.stderr,
-            )
-            captured = capsys.readouterr()
-            assert "returned None" in captured.err
-            assert "turn-200" in captured.err
-            assert "4" in captured.err  # 3 + 1
-        finally:
-            se._pc_consecutive_failures = original
+        result = _pc_partial_merge(catalogs, entity_data, "turn-060")
+        assert result is False
 
 
 # ---------------------------------------------------------------------------
@@ -253,10 +251,12 @@ class TestPCAliaseMerge:
         merged = _merge_pc_aliases(catalogs, events, "")
         assert "char-fenouille-moonwind" in merged
         assert len(catalogs["characters.json"]) == 1
-        # Name should be added to aliases
+        # Name should be added to aliases with schema-compliant source_turn
         pc = catalogs["characters.json"][0]
-        aliases = pc.get("stable_attributes", {}).get("aliases", {}).get("value", [])
-        assert "Fenouille Moonwind" in aliases
+        aliases_attr = pc.get("stable_attributes", {}).get("aliases", {})
+        assert "Fenouille Moonwind" in aliases_attr.get("value", [])
+        assert "source_turn" in aliases_attr
+        assert "source_turns" not in aliases_attr  # schema compliance
 
     def test_no_merge_many_turns(self):
         """Entity with >3 turn span should NOT be merged even if name appears often."""
@@ -296,7 +296,6 @@ class TestPCAliaseMerge:
         try:
             chars_dir = os.path.join(tmpdir, "characters")
             os.makedirs(chars_dir)
-            # Write the candidate entity file
             candidate = _make_entity("char-fenouille-moonwind", "Fenouille Moonwind",
                                      "turn-059", "turn-059")
             with open(os.path.join(chars_dir, "char-fenouille-moonwind.json"), "w") as f:
@@ -315,6 +314,35 @@ class TestPCAliaseMerge:
             merged = _merge_pc_aliases(catalogs, events, tmpdir)
             assert "char-fenouille-moonwind" in merged
             assert not os.path.exists(os.path.join(chars_dir, "char-fenouille-moonwind.json"))
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_dry_run_preserves_entity_file(self):
+        """In dry_run mode, entity file should NOT be deleted."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            chars_dir = os.path.join(tmpdir, "characters")
+            os.makedirs(chars_dir)
+            candidate = _make_entity("char-fenouille-moonwind", "Fenouille Moonwind",
+                                     "turn-059", "turn-059")
+            entity_path = os.path.join(chars_dir, "char-fenouille-moonwind.json")
+            with open(entity_path, "w") as f:
+                json.dump(candidate, f)
+
+            catalogs = {
+                "characters.json": [
+                    _make_entity("char-player", "Player Character", "turn-001"),
+                    dict(candidate),
+                ]
+            }
+            events = [
+                _make_event("evt-1", "Fenouille Moonwind strikes", ["char-player"], "turn-253"),
+                _make_event("evt-2", "Fenouille Moonwind rests", ["char-player"], "turn-313"),
+            ]
+            merged = _merge_pc_aliases(catalogs, events, tmpdir, dry_run=True)
+            assert "char-fenouille-moonwind" in merged
+            # File should still exist in dry_run mode
+            assert os.path.exists(entity_path)
         finally:
             shutil.rmtree(tmpdir)
 
@@ -361,3 +389,40 @@ class TestPCAliaseMerge:
         ]
         merged = _merge_pc_aliases(catalogs, events, "")
         assert merged == []
+
+    def test_word_boundary_prevents_substring_match(self):
+        """'Ann' should NOT match inside 'Annabelle' — only whole-word matches."""
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-player", "Player Character", "turn-001"),
+                _make_entity("char-ann", "Ann", "turn-050", "turn-050"),
+            ]
+        }
+        events = [
+            _make_event("evt-1", "Annabelle walks forward", ["char-player"], "turn-100"),
+            _make_event("evt-2", "Annabelle casts a spell", ["char-player"], "turn-101"),
+            _make_event("evt-3", "Annabelle rests", ["char-player"], "turn-102"),
+        ]
+        merged = _merge_pc_aliases(catalogs, events, "")
+        assert merged == []
+
+    def test_stale_ids_rewritten_in_events(self):
+        """After alias merge, events referencing the alias ID should point to char-player."""
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-player", "Player Character", "turn-001"),
+                _make_entity("char-fenouille-moonwind", "Fenouille Moonwind",
+                             "turn-059", "turn-059"),
+            ]
+        }
+        events = [
+            _make_event("evt-1", "Fenouille Moonwind draws her sword",
+                        ["char-player", "char-fenouille-moonwind"], "turn-253"),
+            _make_event("evt-2", "Fenouille Moonwind casts healing word",
+                        ["char-player"], "turn-313"),
+        ]
+        merged = _merge_pc_aliases(catalogs, events, "")
+        assert "char-fenouille-moonwind" in merged
+        # The alias ID in evt-1's related_entities should now be char-player
+        assert "char-fenouille-moonwind" not in events[0]["related_entities"]
+        assert "char-player" in events[0]["related_entities"]

--- a/tests/test_run8_followup.py
+++ b/tests/test_run8_followup.py
@@ -1,0 +1,363 @@
+"""Tests for Run 8 follow-up fixes (#131-#134)."""
+import os
+import sys
+import json
+import tempfile
+import shutil
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from semantic_extraction import (
+    _dedup_catalogs,
+    _pc_partial_merge,
+    _merge_pc_aliases,
+    _pc_consecutive_failures,
+    _PC_FAILURE_WARN_THRESHOLD,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_entity(id_, name, turn="turn-001", last_turn=None):
+    return {
+        "id": id_,
+        "name": name,
+        "type": "character",
+        "identity": f"A character named {name}.",
+        "first_seen_turn": turn,
+        "last_updated_turn": last_turn or turn,
+        "relationships": [],
+    }
+
+
+def _make_event(event_id, description, related_entities, turn="turn-100"):
+    return {
+        "id": event_id,
+        "turn_id": turn,
+        "description": description,
+        "related_entities": related_entities,
+    }
+
+
+# ---------------------------------------------------------------------------
+# #131 — Stub backfill by default
+# ---------------------------------------------------------------------------
+
+class TestBackfillDefault:
+    """Verify that backfill runs by default (no flag needed)."""
+
+    def test_skip_backfill_flag_exists(self):
+        """--skip-backfill should be defined in argparse."""
+        import bootstrap_session
+        import argparse
+        # Parse with --skip-backfill to verify it's recognized
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--skip-backfill", action="store_true")
+        args = parser.parse_args(["--skip-backfill"])
+        assert args.skip_backfill is True
+
+    def test_skip_backfill_default_false(self):
+        """--skip-backfill should default to False (backfill ON)."""
+        import argparse
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--skip-backfill", action="store_true")
+        args = parser.parse_args([])
+        assert args.skip_backfill is False
+
+
+# ---------------------------------------------------------------------------
+# #132 — Minimum stem length guard for Levenshtein dedup
+# ---------------------------------------------------------------------------
+
+class TestLevenshteinStemLengthGuard:
+    """Verify minimum stem length prevents short-name false positives."""
+
+    def test_borin_vs_bran_not_merged(self):
+        """Short stems (5/4 chars) should NOT be merged despite edit distance 2."""
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-borin", "Borin"),
+                _make_entity("char-bran", "Bran"),
+            ]
+        }
+        count, merge_map = _dedup_catalogs(catalogs)
+        assert count == 0
+        assert len(catalogs["characters.json"]) == 2
+
+    def test_communal_vs_communial_merged(self):
+        """Longer stems (8/9 chars) with distance 1 should still merge."""
+        catalogs = {
+            "locations.json": [
+                _make_entity("loc-communal", "Communal Hall"),
+                _make_entity("loc-communial", "Communial Hall"),
+            ]
+        }
+        count, merge_map = _dedup_catalogs(catalogs)
+        assert count == 1
+        assert len(catalogs["locations.json"]) == 1
+
+    def test_younger_hunter_variants_merged(self):
+        """Long hyphenated stems should still merge."""
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-younger-hunter", "Younger Hunter"),
+                _make_entity("char-younger-huntr", "Younger Huntr"),
+            ]
+        }
+        count, merge_map = _dedup_catalogs(catalogs)
+        assert count == 1
+        assert len(catalogs["characters.json"]) == 1
+
+    def test_boundary_six_char_stems_merged(self):
+        """Stems of exactly 6 chars with distance 2 should merge."""
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-kaelon", "Kaelon"),
+                _make_entity("char-kaalbn", "Kaalbn"),
+            ]
+        }
+        count, merge_map = _dedup_catalogs(catalogs)
+        # Both stems are 6 chars, distance=2, same first char → should merge
+        assert count == 1
+        assert len(catalogs["characters.json"]) == 1
+
+    def test_five_char_stems_not_merged(self):
+        """Stems of 5 chars should NOT merge (below minimum of 6)."""
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-draen", "Draen"),
+                _make_entity("char-draan", "Draan"),
+            ]
+        }
+        count, merge_map = _dedup_catalogs(catalogs)
+        assert count == 0
+        assert len(catalogs["characters.json"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# #133 — PC extraction failure logging and recovery
+# ---------------------------------------------------------------------------
+
+class TestPCConsecutiveFailureTracking:
+    """Verify consecutive failure counter and warnings."""
+
+    def test_failure_threshold_constant(self):
+        """Threshold should be 10."""
+        assert _PC_FAILURE_WARN_THRESHOLD == 10
+
+    def test_warning_at_threshold(self, capsys):
+        """WARNING should fire at 10 consecutive failures."""
+        import semantic_extraction as se
+        original = se._pc_consecutive_failures
+        try:
+            # Simulate 10 failures
+            se._pc_consecutive_failures = _PC_FAILURE_WARN_THRESHOLD - 1
+            pc_entry = {"last_updated_turn": "turn-050"}
+
+            # Simulate one more failure
+            se._pc_consecutive_failures += 1
+            if se._pc_consecutive_failures >= _PC_FAILURE_WARN_THRESHOLD:
+                print(
+                    f"  WARNING: PC extraction has failed for {se._pc_consecutive_failures} "
+                    f"consecutive turns (last update: "
+                    f"{pc_entry.get('last_updated_turn', 'unknown')}). "
+                    f"Context may be too large for reliable extraction.",
+                    file=sys.stderr,
+                )
+            captured = capsys.readouterr()
+            assert "WARNING" in captured.err
+            assert "10" in captured.err
+            assert "consecutive turns" in captured.err
+            assert "turn-050" in captured.err
+        finally:
+            se._pc_consecutive_failures = original
+
+    def test_counter_resets_on_success(self):
+        """Counter should reset to 0 on successful extraction."""
+        import semantic_extraction as se
+        original = se._pc_consecutive_failures
+        try:
+            se._pc_consecutive_failures = 5
+            # Simulate success
+            se._pc_consecutive_failures = 0
+            assert se._pc_consecutive_failures == 0
+        finally:
+            se._pc_consecutive_failures = original
+
+    def test_empty_merge_warning_includes_response_keys(self, capsys):
+        """Empty merge WARNING should include response keys."""
+        catalogs = {
+            "characters.json": [
+                {
+                    "id": "char-player",
+                    "name": "Player Character",
+                    "type": "character",
+                    "identity": "The player character.",
+                    "first_seen_turn": "turn-001",
+                    "last_updated_turn": "turn-050",
+                }
+            ]
+        }
+        entity_data = {"id": "char-player", "garbage_field": "junk"}
+        _pc_partial_merge(catalogs, entity_data, "turn-060")
+        captured = capsys.readouterr()
+        assert "no fields could be merged" in captured.err.lower()
+        assert "Response keys:" in captured.err
+        assert "turn-060" in captured.err
+
+    def test_none_extraction_warning(self, capsys):
+        """When entity_data is None, a specific warning should fire."""
+        import semantic_extraction as se
+        original = se._pc_consecutive_failures
+        try:
+            se._pc_consecutive_failures = 3
+            # Simulate the None-extraction warning path
+            turn_id = "turn-200"
+            print(
+                f"  WARNING: PC detail extraction returned None at {turn_id}. "
+                f"Consecutive failures: {se._pc_consecutive_failures + 1}",
+                file=sys.stderr,
+            )
+            captured = capsys.readouterr()
+            assert "returned None" in captured.err
+            assert "turn-200" in captured.err
+            assert "4" in captured.err  # 3 + 1
+        finally:
+            se._pc_consecutive_failures = original
+
+
+# ---------------------------------------------------------------------------
+# #134 — Post-extraction PC alias merge
+# ---------------------------------------------------------------------------
+
+class TestPCAliaseMerge:
+    """Verify _merge_pc_aliases() identifies and merges PC aliases."""
+
+    def test_merge_alias_with_multiple_events(self):
+        """Entity named in >=2 char-player events with <=3 turn span → merged."""
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-player", "Player Character", "turn-001"),
+                _make_entity("char-fenouille-moonwind", "Fenouille Moonwind",
+                             "turn-059", "turn-059"),
+            ]
+        }
+        events = [
+            _make_event("evt-1", "Fenouille Moonwind draws her sword", ["char-player"], "turn-253"),
+            _make_event("evt-2", "You are Fenouille Moonwind, druid of the forest", ["char-player"], "turn-313"),
+            _make_event("evt-3", "Fenouille Moonwind casts healing word", ["char-player"], "turn-326"),
+        ]
+        merged = _merge_pc_aliases(catalogs, events, "")
+        assert "char-fenouille-moonwind" in merged
+        assert len(catalogs["characters.json"]) == 1
+        # Name should be added to aliases
+        pc = catalogs["characters.json"][0]
+        aliases = pc.get("stable_attributes", {}).get("aliases", {}).get("value", [])
+        assert "Fenouille Moonwind" in aliases
+
+    def test_no_merge_many_turns(self):
+        """Entity with >3 turn span should NOT be merged even if name appears often."""
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-player", "Player Character", "turn-001"),
+                _make_entity("char-kael", "Kael", "turn-010", "turn-060"),
+            ]
+        }
+        events = [
+            _make_event("evt-1", "Kael joins the party", ["char-player"], "turn-020"),
+            _make_event("evt-2", "Kael speaks to the elder", ["char-player"], "turn-030"),
+            _make_event("evt-3", "Kael draws a map", ["char-player"], "turn-040"),
+        ]
+        merged = _merge_pc_aliases(catalogs, events, "")
+        assert merged == []
+        assert len(catalogs["characters.json"]) == 2
+
+    def test_no_merge_insufficient_events(self):
+        """Entity name appearing in <2 PC events should NOT be merged."""
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-player", "Player Character", "turn-001"),
+                _make_entity("char-random-npc", "Random NPC", "turn-050", "turn-050"),
+            ]
+        }
+        events = [
+            _make_event("evt-1", "Something happens", ["char-player"], "turn-100"),
+        ]
+        merged = _merge_pc_aliases(catalogs, events, "")
+        assert merged == []
+        assert len(catalogs["characters.json"]) == 2
+
+    def test_merged_entity_file_deleted(self):
+        """Merged entity's JSON file should be removed from disk."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            chars_dir = os.path.join(tmpdir, "characters")
+            os.makedirs(chars_dir)
+            # Write the candidate entity file
+            candidate = _make_entity("char-fenouille-moonwind", "Fenouille Moonwind",
+                                     "turn-059", "turn-059")
+            with open(os.path.join(chars_dir, "char-fenouille-moonwind.json"), "w") as f:
+                json.dump(candidate, f)
+
+            catalogs = {
+                "characters.json": [
+                    _make_entity("char-player", "Player Character", "turn-001"),
+                    dict(candidate),
+                ]
+            }
+            events = [
+                _make_event("evt-1", "Fenouille Moonwind strikes", ["char-player"], "turn-253"),
+                _make_event("evt-2", "Fenouille Moonwind rests", ["char-player"], "turn-313"),
+            ]
+            merged = _merge_pc_aliases(catalogs, events, tmpdir)
+            assert "char-fenouille-moonwind" in merged
+            assert not os.path.exists(os.path.join(chars_dir, "char-fenouille-moonwind.json"))
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_alias_absorbs_relationships(self):
+        """Merged entity's unique relationships should transfer to char-player."""
+        catalogs = {
+            "characters.json": [
+                {
+                    **_make_entity("char-player", "Player Character", "turn-001"),
+                    "relationships": [
+                        {"target_id": "char-elder", "type": "ally"},
+                    ],
+                },
+                {
+                    **_make_entity("char-fenouille-moonwind", "Fenouille Moonwind",
+                                   "turn-059", "turn-059"),
+                    "relationships": [
+                        {"target_id": "char-grove-spirit", "type": "ally"},
+                    ],
+                },
+            ]
+        }
+        events = [
+            _make_event("evt-1", "Fenouille Moonwind is here", ["char-player"], "turn-253"),
+            _make_event("evt-2", "Fenouille Moonwind speaks", ["char-player"], "turn-313"),
+        ]
+        merged = _merge_pc_aliases(catalogs, events, "")
+        assert "char-fenouille-moonwind" in merged
+        pc = catalogs["characters.json"][0]
+        rel_targets = {r["target_id"] for r in pc["relationships"]}
+        assert "char-elder" in rel_targets
+        assert "char-grove-spirit" in rel_targets
+
+    def test_no_merge_short_name(self):
+        """Entity with name < 3 chars should be skipped."""
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-player", "Player Character", "turn-001"),
+                _make_entity("char-ab", "Ab", "turn-050", "turn-050"),
+            ]
+        }
+        events = [
+            _make_event("evt-1", "Ab Ab Ab", ["char-player"], "turn-100"),
+        ]
+        merged = _merge_pc_aliases(catalogs, events, "")
+        assert merged == []

--- a/tests/test_run8_followup.py
+++ b/tests/test_run8_followup.py
@@ -8,14 +8,14 @@ import shutil
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
 import semantic_extraction as se
-from semantic_extraction import (
-    _dedup_catalogs,
-    _pc_partial_merge,
-    _merge_pc_aliases,
-    _reset_pc_failure_tracking,
-    _PC_FAILURE_WARN_THRESHOLD,
-)
 from bootstrap_session import build_parser
+
+# Shorter aliases for frequently used functions
+_dedup_catalogs = se._dedup_catalogs
+_pc_partial_merge = se._pc_partial_merge
+_merge_pc_aliases = se._merge_pc_aliases
+_reset_pc_failure_tracking = se._reset_pc_failure_tracking
+_PC_FAILURE_WARN_THRESHOLD = se._PC_FAILURE_WARN_THRESHOLD
 
 
 # ---------------------------------------------------------------------------

--- a/tools/bootstrap_session.py
+++ b/tools/bootstrap_session.py
@@ -393,11 +393,11 @@ def ensure_exports_dir(session_dir: str, dry_run: bool) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
+    """Build and return the argument parser for bootstrap_session."""
     parser = argparse.ArgumentParser(
         description="Bootstrap a session from an existing large transcript file.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=__doc__,
     )
     parser.add_argument("--session", required=True, help="Path to the target session directory.")
     parser.add_argument("--file", required=True, help="Path to the source transcript file.")
@@ -479,6 +479,11 @@ def main() -> None:
         action="store_true",
         help="Skip the stub backfill pass after extraction.",
     )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
     args = parser.parse_args()
 
     # Validate --start-date format if provided
@@ -675,18 +680,20 @@ def main() -> None:
             print(f"  Stub backfill: {count} stub(s) enriched")
 
         # PC alias merge pass (#134)
-        from semantic_extraction import _merge_pc_aliases
-        from catalog_merger import load_catalogs, load_events, save_catalogs, save_events
+        if args.dry_run:
+            print("  PC alias merge: skipped during dry run")
+        else:
+            from semantic_extraction import _merge_pc_aliases
+            from catalog_merger import load_catalogs, load_events, save_catalogs, save_events
 
-        catalog_dir = os.path.join(args.framework, "catalogs")
-        catalogs = load_catalogs(catalog_dir)
-        events_list = load_events(catalog_dir)
-        merged_aliases = _merge_pc_aliases(catalogs, events_list, catalog_dir)
-        if merged_aliases and not args.dry_run:
-            save_catalogs(catalog_dir, catalogs)
-            save_events(catalog_dir, events_list)
-        if merged_aliases:
-            print(f"  PC alias merge: merged {len(merged_aliases)} alias(es): {merged_aliases}")
+            catalog_dir = os.path.join(args.framework, "catalogs")
+            catalogs = load_catalogs(catalog_dir)
+            events_list = load_events(catalog_dir)
+            merged_aliases = _merge_pc_aliases(catalogs, events_list, catalog_dir)
+            if merged_aliases:
+                save_catalogs(catalog_dir, catalogs)
+                save_events(catalog_dir, events_list)
+                print(f"  PC alias merge: merged {len(merged_aliases)} alias(es): {merged_aliases}")
     except ModuleNotFoundError as exc:
         if exc.name == "semantic_extraction":
             print(

--- a/tools/bootstrap_session.py
+++ b/tools/bootstrap_session.py
@@ -398,6 +398,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Bootstrap a session from an existing large transcript file.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
     )
     parser.add_argument("--session", required=True, help="Path to the target session directory.")
     parser.add_argument("--file", required=True, help="Path to the source transcript file.")
@@ -664,7 +665,11 @@ def main() -> None:
         )
 
         # Stub backfill pass (#128, #131 — now runs by default)
-        if not args.skip_backfill:
+        if args.skip_backfill:
+            pass  # Explicitly skipped via --skip-backfill
+        elif args.dry_run:
+            print("  Stub backfill: skipped during dry run")
+        else:
             from semantic_extraction import backfill_stubs
             from catalog_merger import load_catalogs, load_events, save_catalogs, save_events
             from llm_client import LLMClient
@@ -674,7 +679,7 @@ def main() -> None:
             events_list = load_events(catalog_dir)
             llm = LLMClient("config/llm.json", overrides=llm_overrides or None)
             count = backfill_stubs(turn_dicts, catalogs, events_list, llm)
-            if count and not args.dry_run:
+            if count:
                 save_catalogs(catalog_dir, catalogs)
                 save_events(catalog_dir, events_list)
             print(f"  Stub backfill: {count} stub(s) enriched")

--- a/tools/bootstrap_session.py
+++ b/tools/bootstrap_session.py
@@ -475,9 +475,9 @@ def main() -> None:
         help="Override the LLM API base URL from config/llm.json for this run.",
     )
     parser.add_argument(
-        "--backfill-stubs",
+        "--skip-backfill",
         action="store_true",
-        help="After extraction, re-extract hollow stub entities using gathered context.",
+        help="Skip the stub backfill pass after extraction.",
     )
     args = parser.parse_args()
 
@@ -658,8 +658,8 @@ def main() -> None:
             overrides=llm_overrides or None,
         )
 
-        # Stub backfill pass (#128)
-        if args.backfill_stubs:
+        # Stub backfill pass (#128, #131 — now runs by default)
+        if not args.skip_backfill:
             from semantic_extraction import backfill_stubs
             from catalog_merger import load_catalogs, load_events, save_catalogs, save_events
             from llm_client import LLMClient
@@ -673,6 +673,20 @@ def main() -> None:
                 save_catalogs(catalog_dir, catalogs)
                 save_events(catalog_dir, events_list)
             print(f"  Stub backfill: {count} stub(s) enriched")
+
+        # PC alias merge pass (#134)
+        from semantic_extraction import _merge_pc_aliases
+        from catalog_merger import load_catalogs, load_events, save_catalogs, save_events
+
+        catalog_dir = os.path.join(args.framework, "catalogs")
+        catalogs = load_catalogs(catalog_dir)
+        events_list = load_events(catalog_dir)
+        merged_aliases = _merge_pc_aliases(catalogs, events_list, catalog_dir)
+        if merged_aliases and not args.dry_run:
+            save_catalogs(catalog_dir, catalogs)
+            save_events(catalog_dir, events_list)
+        if merged_aliases:
+            print(f"  PC alias merge: merged {len(merged_aliases)} alias(es): {merged_aliases}")
     except ModuleNotFoundError as exc:
         if exc.name == "semantic_extraction":
             print(

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -908,6 +908,7 @@ def extract_and_merge(
     Returns:
         Updated (catalogs, events_list) tuple.
     """
+    global _pc_consecutive_failures
     turn_id = turn["turn_id"]
 
     # Load arc sidecar for PC relationship compaction (#120)
@@ -1021,7 +1022,6 @@ def extract_and_merge(
         get_entity_id(e) == "char-player" for e in qualified
     )
     if not pc_already_extracted:
-        global _pc_consecutive_failures
         pc_result = find_entity_by_id(catalogs, "char-player")
         pc_entry = pc_result[1] if pc_result else dict(PLAYER_CHARACTER_SEED)
         # Sanitize existing entry before sending to LLM so stale keys
@@ -1609,7 +1609,7 @@ def _merge_pc_aliases(
                     if candidate_num < existing_num:
                         aliases["source_turn"] = alias_source_turn
                 except ValueError:
-                    pass
+                    pass  # Non-numeric turn IDs — keep existing source_turn
 
         # Absorb unique relationships from the candidate
         pc_rels = pc_entry.get("relationships", [])

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -51,6 +51,10 @@ PC_ALLOWED_ATTRS = {
     "condition", "equipment", "quest", "allegiance", "status", "aliases",
 }
 
+# Consecutive PC extraction failure tracking (#133)
+_pc_consecutive_failures = 0
+_PC_FAILURE_WARN_THRESHOLD = 10
+
 
 def _filter_pc_attributes(entity_data: dict) -> dict:
     """Strip non-allowed attribute keys from char-player entities.
@@ -789,9 +793,10 @@ def _pc_partial_merge(catalogs: dict, entity_data: dict, turn_id: str) -> None:
             file=sys.stderr,
         )
     else:
+        _resp_keys = sorted(entity_data.keys()) if isinstance(entity_data, dict) else "non-dict"
         print(
-            f"  WARNING: PC partial merge fired but merged_fields is empty at {turn_id} "
-            f"(attempted: {attempted_fields})",
+            f"  WARNING: PC partial merge at {turn_id}: no fields could be merged. "
+            f"Response keys: {_resp_keys} (attempted: {attempted_fields})",
             file=sys.stderr,
         )
 
@@ -1000,6 +1005,7 @@ def extract_and_merge(
         get_entity_id(e) == "char-player" for e in qualified
     )
     if not pc_already_extracted:
+        global _pc_consecutive_failures
         pc_result = find_entity_by_id(catalogs, "char-player")
         pc_entry = pc_result[1] if pc_result else dict(PLAYER_CHARACTER_SEED)
         # Sanitize existing entry before sending to LLM so stale keys
@@ -1009,6 +1015,7 @@ def extract_and_merge(
                   "existing_id": "char-player", "is_new": False}
         # Use extended timeout for PC extraction — context is larger (#107)
         pc_timeout = max(llm.default_timeout * 2, 120)
+        pc_updated = False
         try:
             detail_result = llm.extract_json(
                 system_prompt=load_template("entity-detail"),
@@ -1024,6 +1031,7 @@ def extract_and_merge(
                 merge_entity(catalogs, entity_data)
                 # Purge any stale keys that survived the merge
                 _sanitize_pc_catalog_entry(catalogs)
+                pc_updated = True
             elif entity_data:
                 # Validation failed — attempt partial merge fallback (#107)
                 # Log structure of the raw response to aid diagnosis (#125)
@@ -1034,8 +1042,30 @@ def extract_and_merge(
                     file=sys.stderr,
                 )
                 _pc_partial_merge(catalogs, entity_data, turn_id)
+                # Partial merge may or may not succeed; count as update attempt
+            else:
+                # entity_data is None — extraction returned nothing (#133)
+                print(
+                    f"  WARNING: PC detail extraction returned None at {turn_id}. "
+                    f"Consecutive failures: {_pc_consecutive_failures + 1}",
+                    file=sys.stderr,
+                )
         except LLMExtractionError as e:
             print(f"  WARNING: PC detail extraction failed at {turn_id}: {e}", file=sys.stderr)
+
+        # Track consecutive PC extraction failures (#133)
+        if pc_updated:
+            _pc_consecutive_failures = 0
+        else:
+            _pc_consecutive_failures += 1
+            if _pc_consecutive_failures >= _PC_FAILURE_WARN_THRESHOLD:
+                print(
+                    f"  WARNING: PC extraction has failed for {_pc_consecutive_failures} "
+                    f"consecutive turns (last update: "
+                    f"{pc_entry.get('last_updated_turn', 'unknown')}). "
+                    f"Context may be too large for reliable extraction.",
+                    file=sys.stderr,
+                )
         llm.delay()
 
     # --- 3. Relationship Mapping ---
@@ -1230,8 +1260,10 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
                         print(f"  DEDUP (id-stem): linking '{name_a}' ({id_a}) and '{name_b}' ({id_b}) as duplicates")
                         continue
 
-                    # Rule 4: Levenshtein distance on ID stems (#129)
-                    if stem_a[0] == stem_b[0] and abs(len(stem_a) - len(stem_b)) <= 2:
+                    # Rule 4: Levenshtein distance on ID stems (#129, #132)
+                    if (len(stem_a) >= 6 and len(stem_b) >= 6
+                            and stem_a[0] == stem_b[0]
+                            and abs(len(stem_a) - len(stem_b)) <= 2):
                         dist = _levenshtein(stem_a, stem_b)
                         if dist <= 2:
                             union(idx_a, idx_b)
@@ -1480,6 +1512,97 @@ def backfill_stubs(
         llm.delay()
 
     return backfilled
+
+
+def _merge_pc_aliases(
+    catalogs: dict,
+    events_list: list,
+    catalog_dir: str,
+) -> list[str]:
+    """Identify and merge character entities that are aliases of char-player (#134).
+
+    Scans event descriptions involving char-player for proper names, then checks
+    whether any other character entity's name appears frequently enough to be an alias.
+
+    Returns list of entity IDs that were merged.
+    """
+    pc_result = find_entity_by_id(catalogs, "char-player")
+    if not pc_result:
+        return []
+    _, pc_entry = pc_result
+
+    # Collect text from events that reference char-player
+    pc_events = [
+        e for e in events_list
+        if "char-player" in e.get("related_entities", [])
+    ]
+    pc_text = " ".join(e.get("description", "") for e in pc_events)
+    if not pc_text:
+        return []
+
+    merged = []
+    chars_catalog = "characters.json"
+    entities = catalogs.get(chars_catalog, [])
+
+    for entity in list(entities):
+        eid = entity.get("id", "")
+        if eid == "char-player" or not eid:
+            continue
+
+        name = entity.get("name", "")
+        if not name or len(name) < 3:
+            continue
+
+        # Count occurrences of the entity name in PC event text
+        occurrences = pc_text.count(name)
+        if occurrences < 2:
+            continue
+
+        # Check candidate has minimal data (≤3 turns span)
+        first = entity.get("first_seen_turn", "")
+        last = entity.get("last_updated_turn", "")
+        if first and last:
+            try:
+                first_num = int(first.replace("turn-", ""))
+                last_num = int(last.replace("turn-", ""))
+                if last_num - first_num > 3:
+                    continue  # Too much independent data — likely a real NPC
+            except ValueError:
+                continue
+
+        # Merge into char-player: add name as alias
+        sa = pc_entry.setdefault("stable_attributes", {})
+        aliases = sa.setdefault("aliases", {"value": [], "source_turns": []})
+        alias_list = aliases.get("value", [])
+        if isinstance(alias_list, list) and name not in alias_list:
+            alias_list.append(name)
+            aliases["value"] = alias_list
+
+        # Absorb unique relationships from the candidate
+        pc_rels = pc_entry.get("relationships", [])
+        for rel in entity.get("relationships", []):
+            target = rel.get("target_id", "")
+            rel_type = rel.get("type", "")
+            if target and not any(
+                r.get("target_id") == target and r.get("type") == rel_type
+                for r in pc_rels
+            ):
+                pc_rels.append(rel)
+        pc_entry["relationships"] = pc_rels
+
+        # Remove the candidate entity from the catalog
+        entities.remove(entity)
+
+        # Delete entity file from disk if it exists (V2 layout)
+        if catalog_dir:
+            entity_file = os.path.join(catalog_dir, "characters", f"{eid}.json")
+            if os.path.isfile(entity_file):
+                os.remove(entity_file)
+
+        merged.append(eid)
+        print(f"  PC alias merge: merged '{eid}' ({name}) into char-player")
+
+    return merged
 
 
 def extract_semantic_batch(

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -56,6 +56,18 @@ _pc_consecutive_failures = 0
 _PC_FAILURE_WARN_THRESHOLD = 10
 
 
+def _reset_pc_failure_tracking() -> None:
+    """Reset per-run char-player extraction failure state.
+
+    This counter is module-level state, so top-level extraction entry points
+    must call this at the start of each new batch/single run to avoid
+    carrying failure counts across unrelated invocations in long-lived
+    processes.
+    """
+    global _pc_consecutive_failures
+    _pc_consecutive_failures = 0
+
+
 def _filter_pc_attributes(entity_data: dict) -> dict:
     """Strip non-allowed attribute keys from char-player entities.
 
@@ -720,16 +732,18 @@ def get_entity_id(entity_ref: dict) -> str:
     return entity_ref.get("existing_id") or entity_ref.get("proposed_id") or ""
 
 
-def _pc_partial_merge(catalogs: dict, entity_data: dict, turn_id: str) -> None:
+def _pc_partial_merge(catalogs: dict, entity_data: dict, turn_id: str) -> bool:
     """Attempt to merge valid individual fields from a near-valid PC extraction.
 
     When full schema validation fails for char-player, this function extracts
     whatever valid fields are present and merges them into the existing
     catalog entry rather than losing the entire response (#107).
+
+    Returns True if at least one field was successfully merged.
     """
     pc_result = find_entity_by_id(catalogs, "char-player")
     if not pc_result:
-        return
+        return False
     _, pc_entry = pc_result
 
     attempted_fields = []
@@ -792,6 +806,7 @@ def _pc_partial_merge(catalogs: dict, entity_data: dict, turn_id: str) -> None:
             f"(attempted: {attempted_fields}, last_updated_turn => {turn_id})",
             file=sys.stderr,
         )
+        return True
     else:
         _resp_keys = sorted(entity_data.keys()) if isinstance(entity_data, dict) else "non-dict"
         print(
@@ -799,6 +814,7 @@ def _pc_partial_merge(catalogs: dict, entity_data: dict, turn_id: str) -> None:
             f"Response keys: {_resp_keys} (attempted: {attempted_fields})",
             file=sys.stderr,
         )
+        return False
 
 
 def _collect_all_entity_ids(catalogs: dict) -> set[str]:
@@ -1041,8 +1057,8 @@ def extract_and_merge(
                     f"response keys={_data_keys}, falling back to partial merge",
                     file=sys.stderr,
                 )
-                _pc_partial_merge(catalogs, entity_data, turn_id)
-                # Partial merge may or may not succeed; count as update attempt
+                # Partial merge success counts as an update (#133)
+                pc_updated = _pc_partial_merge(catalogs, entity_data, turn_id)
             else:
                 # entity_data is None — extraction returned nothing (#133)
                 print(
@@ -1518,6 +1534,7 @@ def _merge_pc_aliases(
     catalogs: dict,
     events_list: list,
     catalog_dir: str,
+    dry_run: bool = False,
 ) -> list[str]:
     """Identify and merge character entities that are aliases of char-player (#134).
 
@@ -1541,6 +1558,7 @@ def _merge_pc_aliases(
         return []
 
     merged = []
+    merge_map: dict[str, str] = {}
     chars_catalog = "characters.json"
     entities = catalogs.get(chars_catalog, [])
 
@@ -1553,8 +1571,10 @@ def _merge_pc_aliases(
         if not name or len(name) < 3:
             continue
 
-        # Count occurrences of the entity name in PC event text
-        occurrences = pc_text.count(name)
+        # Count whole-name occurrences in PC event text, case-insensitively,
+        # to avoid matching substrings inside larger words or names.
+        name_pattern = r"(?<!\w)" + re.escape(name) + r"(?!\w)"
+        occurrences = len(re.findall(name_pattern, pc_text, re.IGNORECASE))
         if occurrences < 2:
             continue
 
@@ -1571,12 +1591,25 @@ def _merge_pc_aliases(
                 continue
 
         # Merge into char-player: add name as alias
+        alias_source_turn = first or last or ""
         sa = pc_entry.setdefault("stable_attributes", {})
-        aliases = sa.setdefault("aliases", {"value": [], "source_turns": []})
+        aliases = sa.setdefault("aliases", {"value": [], "source_turn": alias_source_turn})
         alias_list = aliases.get("value", [])
         if isinstance(alias_list, list) and name not in alias_list:
             alias_list.append(name)
             aliases["value"] = alias_list
+            # Keep source_turn pointing to the earliest alias origin
+            existing_source = aliases.get("source_turn", "")
+            if not existing_source:
+                aliases["source_turn"] = alias_source_turn
+            elif alias_source_turn:
+                try:
+                    existing_num = int(existing_source.replace("turn-", ""))
+                    candidate_num = int(alias_source_turn.replace("turn-", ""))
+                    if candidate_num < existing_num:
+                        aliases["source_turn"] = alias_source_turn
+                except ValueError:
+                    pass
 
         # Absorb unique relationships from the candidate
         pc_rels = pc_entry.get("relationships", [])
@@ -1594,13 +1627,18 @@ def _merge_pc_aliases(
         entities.remove(entity)
 
         # Delete entity file from disk if it exists (V2 layout)
-        if catalog_dir:
+        if catalog_dir and not dry_run:
             entity_file = os.path.join(catalog_dir, "characters", f"{eid}.json")
             if os.path.isfile(entity_file):
                 os.remove(entity_file)
 
+        merge_map[eid] = "char-player"
         merged.append(eid)
         print(f"  PC alias merge: merged '{eid}' ({name}) into char-player")
+
+    # Rewrite dangling references to merged alias IDs across events and relationships
+    if merge_map:
+        _rewrite_stale_ids(catalogs, events_list, merge_map)
 
     return merged
 
@@ -1631,6 +1669,8 @@ def extract_semantic_batch(
             loaded from ``config_path``; settings not provided in ``overrides``
             continue to use the configuration file values.
     """
+    _reset_pc_failure_tracking()
+
     try:
         llm = LLMClient(config_path, overrides=overrides)
     except (ImportError, LLMExtractionError, FileNotFoundError) as e:
@@ -1753,6 +1793,8 @@ def extract_semantic_single(
         overrides: Optional dictionary of config key/value overrides passed to
             ``LLMClient`` to override settings loaded from ``config_path``.
     """
+    _reset_pc_failure_tracking()
+
     try:
         llm = LLMClient(config_path, overrides=overrides)
     except (ImportError, LLMExtractionError, FileNotFoundError) as e:

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -1048,7 +1048,7 @@ def extract_and_merge(
                 # Purge any stale keys that survived the merge
                 _sanitize_pc_catalog_entry(catalogs)
                 pc_updated = True
-            elif entity_data:
+            elif entity_data is not None:
                 # Validation failed — attempt partial merge fallback (#107)
                 # Log structure of the raw response to aid diagnosis (#125)
                 _data_keys = sorted(entity_data.keys()) if isinstance(entity_data, dict) else "non-dict"
@@ -1593,7 +1593,11 @@ def _merge_pc_aliases(
         # Merge into char-player: add name as alias
         alias_source_turn = first or last or ""
         sa = pc_entry.setdefault("stable_attributes", {})
-        aliases = sa.setdefault("aliases", {"value": [], "source_turn": alias_source_turn})
+        # Only include source_turn if it's a valid turn ID (schema requires turn-NNN pattern)
+        alias_default = {"value": []}
+        if alias_source_turn:
+            alias_default["source_turn"] = alias_source_turn
+        aliases = sa.setdefault("aliases", alias_default)
         alias_list = aliases.get("value", [])
         if isinstance(alias_list, list) and name not in alias_list:
             alias_list.append(name)


### PR DESCRIPTION
## Summary

Four follow-up fixes from Run 8 extraction results. Addresses stub backfill not triggering, Levenshtein false positive on short names, PC extraction coverage drop-off diagnostics, and PC alias detection.

## Issue #131 — Enable stub backfill by default

Changed backfill from opt-in (`--backfill-stubs`) to default-on (`--skip-backfill` to opt out). The backfill pass only processes stub entities, making it safe to always run. This ensures stubs are enriched without requiring an explicit flag.

## Issue #132 — Levenshtein minimum stem length guard

Added `len(stem) >= 6` requirement for Levenshtein dedup. Prevents false positives like `borin` / `bran` (distance=2, 4-5 char names) while preserving correct matches on longer names like `communal` / `communial`.

## Issue #133 — PC extraction failure logging

Added consecutive-failure counter with WARNING at threshold (10 turns), empty-merge WARNING with response keys, and None-extraction detail logging. Makes PC coverage drop-offs diagnosable from logs alone.

## Issue #134 — Post-extraction PC alias merge

Added `_merge_pc_aliases()` that detects character entities whose name appears in char-player's event text (>=2 occurrences) and have minimal independent data (<=3 turns span). Merges alias into char-player: adds name to aliases, absorbs unique relationships, deletes duplicate entity file.

Closes #131
Closes #132
Closes #133
Closes #134
