### PR TITLE
fix: child entity extraction from birth events and backfill context (#136)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,6 +101,8 @@ An automated pipeline that uses an LLM to extract structured data from transcrip
 - All extracted entities are validated against `schemas/entity.schema.json` before merging
 - Entities below a confidence threshold are logged but not cataloged
 - Batch mode checkpoints progress every 50 turns for resume after interruption
+- Birth events trigger automatic entity creation for named children, with child IDs added to event `related_entities`
+- Stub backfill gathers context from both `related_entities` references and entity name mentions in event descriptions
 
 ---
 

--- a/tests/test_birth_entities.py
+++ b/tests/test_birth_entities.py
@@ -1,0 +1,242 @@
+"""Tests for child entity extraction from birth events (#136)."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from semantic_extraction import (
+    _collect_stub_context,
+    _ensure_birth_entities,
+    _find_earliest_mention,
+    _create_orphan_stubs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event(eid, etype, desc, related, source_turns):
+    return {
+        "id": eid,
+        "type": etype,
+        "description": desc,
+        "related_entities": related,
+        "source_turns": source_turns,
+    }
+
+
+def _make_turn(turn_id, text):
+    return {"turn_id": turn_id, "speaker": "DM", "text": text}
+
+
+# ---------------------------------------------------------------------------
+# Test _collect_stub_context includes description mentions (Fix A)
+# ---------------------------------------------------------------------------
+
+def test_collect_stub_context_includes_description_mentions():
+    """Stub context for entity 'Lyrawyn' includes events where name appears in description."""
+    events = [
+        _make_event("evt-1", "birth", "A girl named Lyrawyn is born.", ["char-player"], ["turn-141"]),
+        _make_event("evt-2", "social", "Lyrawyn takes her first steps.", ["char-player"], ["turn-160"]),
+        _make_event("evt-3", "combat", "Wolves attack the camp.", ["char-player"], ["turn-170"]),
+    ]
+    turns = [
+        _make_turn("turn-141", "Birth turn text about Lyrawyn"),
+        _make_turn("turn-160", "Lyrawyn walking turn text"),
+        _make_turn("turn-170", "Combat turn text no child"),
+    ]
+    context = _collect_stub_context("char-lyrawyn", events, turns, "turn-141",
+                                    entity_name="Lyrawyn")
+    assert "turn-141" in context
+    assert "turn-160" in context
+    assert "turn-170" not in context
+
+
+def test_collect_stub_context_without_name_uses_related_entities_only():
+    """Without entity_name, only related_entities matches are used."""
+    events = [
+        _make_event("evt-1", "birth", "A girl named Lyrawyn is born.", ["char-player"], ["turn-141"]),
+        _make_event("evt-2", "social", "Lyrawyn plays.", ["char-lyrawyn"], ["turn-160"]),
+    ]
+    turns = [
+        _make_turn("turn-141", "Birth turn text"),
+        _make_turn("turn-160", "Play turn text"),
+    ]
+    # Without name, only evt-2 matches via related_entities
+    context = _collect_stub_context("char-lyrawyn", events, turns, None,
+                                    entity_name=None)
+    assert "turn-160" in context
+    assert "turn-141" not in context
+
+
+# ---------------------------------------------------------------------------
+# Test _find_earliest_mention (Fix B)
+# ---------------------------------------------------------------------------
+
+def test_first_seen_turn_uses_earliest_mention():
+    """Earliest mention by name should be returned even if ID isn't in related_entities."""
+    events = [
+        _make_event("evt-1", "birth", "A girl named Lyrawyn is born.", ["char-player"], ["turn-141"]),
+        _make_event("evt-2", "social", "Lyrawyn plays.", ["char-lyrawyn"], ["turn-160"]),
+    ]
+    result = _find_earliest_mention("char-lyrawyn", "Lyrawyn", events)
+    assert result == "turn-141"
+
+
+def test_first_seen_turn_id_only():
+    """When name doesn't appear in descriptions, use related_entities match."""
+    events = [
+        _make_event("evt-1", "social", "The child plays.", ["char-lyrawyn"], ["turn-160"]),
+    ]
+    result = _find_earliest_mention("char-lyrawyn", "Lyrawyn", events)
+    assert result == "turn-160"
+
+
+def test_first_seen_turn_no_mention():
+    """Returns None when entity is not mentioned anywhere."""
+    events = [
+        _make_event("evt-1", "combat", "Wolves attack.", ["char-player"], ["turn-100"]),
+    ]
+    result = _find_earliest_mention("char-lyrawyn", "Lyrawyn", events)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Test _ensure_birth_entities (Fix C)
+# ---------------------------------------------------------------------------
+
+def test_birth_event_creates_entity():
+    """A birth event with 'named Lyrawyn' creates a char-lyrawyn entity."""
+    events = [
+        _make_event("evt-1", "birth", "A girl named Lyrawyn is born.", ["char-player"], ["turn-141"]),
+    ]
+    catalogs = {"characters.json": [{"id": "char-player", "name": "Player"}]}
+    created = _ensure_birth_entities(events, catalogs)
+    assert "char-lyrawyn" in created
+    # Verify entity was added to catalogs
+    ids = [e["id"] for e in catalogs["characters.json"]]
+    assert "char-lyrawyn" in ids
+    entity = [e for e in catalogs["characters.json"] if e["id"] == "char-lyrawyn"][0]
+    assert entity["name"] == "Lyrawyn"
+    assert entity["first_seen_turn"] == "turn-141"
+    assert entity["type"] == "character"
+
+
+def test_birth_event_no_duplicate():
+    """If the entity already exists, _ensure_birth_entities does not duplicate it."""
+    events = [
+        _make_event("evt-1", "birth", "A girl named Lyrawyn is born.", ["char-player"], ["turn-141"]),
+    ]
+    catalogs = {"characters.json": [
+        {"id": "char-player", "name": "Player"},
+        {"id": "char-lyrawyn", "name": "Lyrawyn", "type": "character"},
+    ]}
+    created = _ensure_birth_entities(events, catalogs)
+    assert created == []
+    # Still only 2 entities
+    assert len(catalogs["characters.json"]) == 2
+
+
+def test_birth_event_no_named_pattern():
+    """Birth events without 'named X' pattern don't create entities."""
+    events = [
+        _make_event("evt-1", "birth", "A child is born in the village.", ["char-player"], ["turn-141"]),
+    ]
+    catalogs = {"characters.json": [{"id": "char-player", "name": "Player"}]}
+    created = _ensure_birth_entities(events, catalogs)
+    assert created == []
+
+
+def test_non_birth_event_ignored():
+    """Non-birth events are not processed even if they mention 'named'."""
+    events = [
+        _make_event("evt-1", "social", "A warrior named Kael arrives.", ["char-player"], ["turn-050"]),
+    ]
+    catalogs = {"characters.json": [{"id": "char-player", "name": "Player"}]}
+    created = _ensure_birth_entities(events, catalogs)
+    assert created == []
+
+
+# ---------------------------------------------------------------------------
+# Test birth event related_entities update (Fix D)
+# ---------------------------------------------------------------------------
+
+def test_birth_event_adds_related_entity():
+    """After processing, birth events have the child ID in related_entities."""
+    events = [
+        _make_event("evt-1", "birth", "A girl named Lyrawyn is born.", ["char-player"], ["turn-141"]),
+    ]
+    catalogs = {"characters.json": [{"id": "char-player", "name": "Player"}]}
+    _ensure_birth_entities(events, catalogs)
+    assert "char-lyrawyn" in events[0]["related_entities"]
+
+
+def test_birth_event_related_entity_no_duplicate():
+    """If child ID is already in related_entities, it isn't duplicated."""
+    events = [
+        _make_event("evt-1", "birth", "A girl named Lyrawyn is born.",
+                     ["char-player", "char-lyrawyn"], ["turn-141"]),
+    ]
+    catalogs = {"characters.json": [
+        {"id": "char-player", "name": "Player"},
+        {"id": "char-lyrawyn", "name": "Lyrawyn", "type": "character"},
+    ]}
+    _ensure_birth_entities(events, catalogs)
+    count = events[0]["related_entities"].count("char-lyrawyn")
+    assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# Test name matching (case insensitivity, short name guard)
+# ---------------------------------------------------------------------------
+
+def test_name_match_case_insensitive():
+    """Description matching is case-insensitive."""
+    events = [
+        _make_event("evt-1", "birth", "a girl named lyrawyn is born.", ["char-player"], ["turn-141"]),
+    ]
+    result = _find_earliest_mention("char-lyrawyn", "Lyrawyn", events)
+    assert result == "turn-141"
+
+
+def test_short_name_not_matched():
+    """Entity names shorter than 3 chars are not matched in descriptions."""
+    events = [
+        _make_event("evt-1", "social", "The bo appeared.", ["char-player"], ["turn-100"]),
+    ]
+    # Name "Bo" is only 2 chars — should not match in descriptions
+    result = _find_earliest_mention("char-bo", "Bo", events)
+    # Only ID match would work, but char-bo not in related_entities
+    assert result is None
+
+
+def test_short_name_not_matched_in_stub_context():
+    """Short entity names don't expand context via description matching."""
+    events = [
+        _make_event("evt-1", "social", "Bo the cat appeared.", ["char-player"], ["turn-100"]),
+    ]
+    turns = [_make_turn("turn-100", "Turn with Bo")]
+    context = _collect_stub_context("char-bo", events, turns, None, entity_name="Bo")
+    # No match: "Bo" is <3 chars, char-bo not in related_entities
+    assert context == ""
+
+
+# ---------------------------------------------------------------------------
+# Test _create_orphan_stubs uses earliest mention (Fix B integration)
+# ---------------------------------------------------------------------------
+
+def test_create_orphan_stubs_earliest_turn():
+    """Stubs pick up earliest mention turn, not the processing turn."""
+    events = [
+        _make_event("evt-1", "birth", "A girl named Lyrawyn is born.",
+                     ["char-player", "char-lyrawyn"], ["turn-141"]),
+        _make_event("evt-2", "social", "Lyrawyn plays.",
+                     ["char-lyrawyn"], ["turn-200"]),
+    ]
+    catalogs = {"characters.json": [{"id": "char-player", "name": "Player"}]}
+    _create_orphan_stubs(catalogs, events, "turn-999")
+    lyra = [e for e in catalogs["characters.json"] if e["id"] == "char-lyrawyn"]
+    assert len(lyra) == 1
+    assert lyra[0]["first_seen_turn"] == "turn-141"

--- a/tests/test_birth_entities.py
+++ b/tests/test_birth_entities.py
@@ -240,3 +240,78 @@ def test_create_orphan_stubs_earliest_turn():
     lyra = [e for e in catalogs["characters.json"] if e["id"] == "char-lyrawyn"]
     assert len(lyra) == 1
     assert lyra[0]["first_seen_turn"] == "turn-141"
+
+
+# ---------------------------------------------------------------------------
+# PR review comment fixes — additional tests
+# ---------------------------------------------------------------------------
+
+def test_earliest_mention_numeric_comparison():
+    """Turn IDs are compared numerically, not lexicographically.
+
+    'turn-999' should sort before 'turn-1000' even though string comparison
+    would place 'turn-1000' first.
+    """
+    events = [
+        _make_event("evt-1", "social", "Lyrawyn appears.", ["char-player"], ["turn-1000"]),
+        _make_event("evt-2", "social", "Lyrawyn again.", ["char-player"], ["turn-999"]),
+    ]
+    result = _find_earliest_mention("char-lyrawyn", "Lyrawyn", events)
+    assert result == "turn-999"
+
+
+def test_earliest_mention_multi_source_turns():
+    """When an event has multiple source_turns, the smallest is chosen."""
+    events = [
+        _make_event("evt-1", "birth", "A girl named Lyrawyn is born.",
+                     ["char-player"], ["turn-143", "turn-141", "turn-142"]),
+    ]
+    result = _find_earliest_mention("char-lyrawyn", "Lyrawyn", events)
+    assert result == "turn-141"
+
+
+def test_birth_entity_id_sanitized():
+    """Child names with apostrophes or special chars produce valid entity IDs."""
+    events = [
+        _make_event("evt-1", "birth", "A boy named Kel'thas is born.",
+                     ["char-player"], ["turn-200"]),
+    ]
+    catalogs = {"characters.json": [{"id": "char-player", "name": "Player"}]}
+    created = _ensure_birth_entities(events, catalogs)
+    assert len(created) == 1
+    # The apostrophe should be stripped, producing a valid schema ID
+    child_id = created[0]
+    import re
+    assert re.match(r'^char-[a-z0-9]+(-[a-z0-9]+)*$', child_id), f"Invalid ID: {child_id}"
+
+
+def test_birth_entity_picks_earliest_source_turn():
+    """Birth entity first_seen_turn uses the smallest source turn."""
+    events = [
+        _make_event("evt-1", "birth", "A girl named Lyrawyn is born.",
+                     ["char-player"], ["turn-143", "turn-141"]),
+    ]
+    catalogs = {"characters.json": [{"id": "char-player", "name": "Player"}]}
+    _ensure_birth_entities(events, catalogs)
+    entity = [e for e in catalogs["characters.json"] if e["id"] == "char-lyrawyn"][0]
+    assert entity["first_seen_turn"] == "turn-141"
+
+
+def test_create_orphan_stubs_uses_all_events():
+    """Stubs find earliest mention from all_events, not just current-turn events."""
+    # Historical event mentioning Lyrawyn by name (already merged)
+    historical = [
+        _make_event("evt-old", "birth", "A girl named Lyrawyn is born.",
+                     ["char-player"], ["turn-141"]),
+    ]
+    # Current turn event referencing char-lyrawyn by ID (orphan)
+    current = [
+        _make_event("evt-new", "social", "The child dances.",
+                     ["char-lyrawyn"], ["turn-200"]),
+    ]
+    catalogs = {"characters.json": [{"id": "char-player", "name": "Player"}]}
+    _create_orphan_stubs(catalogs, current, "turn-200",
+                         all_events=historical + current)
+    lyra = [e for e in catalogs["characters.json"] if e["id"] == "char-lyrawyn"]
+    assert len(lyra) == 1
+    assert lyra[0]["first_seen_turn"] == "turn-141"

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -873,17 +873,73 @@ def _create_orphan_stubs(catalogs: dict, events: list, turn_id: str) -> None:
         if not catalog_file:
             catalog_file = "characters.json"  # default fallback
 
+        earliest = _find_earliest_mention(eid, inferred_name, events)
+        effective_turn = earliest or turn_id
         stub = {
             "id": eid,
             "name": inferred_name,
             "type": inferred_type,
             "identity": f"Entity referenced in events (stub — auto-created from event data).",
-            "first_seen_turn": turn_id,
+            "first_seen_turn": effective_turn,
             "last_updated_turn": turn_id,
             "notes": "Auto-created by event-stub.",
         }
         catalogs.setdefault(catalog_file, []).append(stub)
         print(f"  STUB: Created stub entity '{eid}' ({inferred_name}) from event data at {turn_id}")
+
+
+def _ensure_birth_entities(events_list: list, catalogs: dict) -> list[str]:
+    """Ensure entities named in birth events exist as catalog entries.
+
+    For birth-type events, detects "named X" patterns in descriptions and
+    creates character entities if they don't already exist.  Also adds the
+    child ID to the event's ``related_entities`` so downstream consumers
+    (backfill, wiki, etc.) can find them.
+
+    Returns a list of newly created entity IDs.
+    """
+    known_ids = _collect_all_entity_ids(catalogs)
+    created: list[str] = []
+
+    for event in events_list:
+        if event.get("type") != "birth":
+            continue
+        desc = event.get("description", "")
+        # Look for "named X" pattern in birth descriptions
+        match = re.search(r'\bnamed\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)', desc)
+        if not match:
+            continue
+
+        child_name = match.group(1)
+        child_id = f"char-{child_name.lower().replace(' ', '-')}"
+        source_turns = event.get("source_turns", [])
+        first_turn = source_turns[0] if source_turns else event.get("source_turn")
+
+        # Ensure child is in related_entities regardless of whether entity exists
+        rel = event.get("related_entities", [])
+        if child_id not in rel:
+            event.setdefault("related_entities", []).append(child_id)
+
+        if child_id in known_ids:
+            continue
+
+        # Create a proper character entity (not a hollow stub)
+        catalog_file = TYPE_TO_CATALOG_V1.get("character", "characters.json")
+        entity = {
+            "id": child_id,
+            "name": child_name,
+            "type": "character",
+            "identity": f"Child born during the narrative, named {child_name}.",
+            "first_seen_turn": first_turn or "turn-001",
+            "last_updated_turn": first_turn or "turn-001",
+            "notes": "Auto-created from birth event.",
+        }
+        catalogs.setdefault(catalog_file, []).append(entity)
+        known_ids.add(child_id)
+        created.append(child_id)
+        print(f"  BIRTH: Created entity '{child_id}' ({child_name}) from birth event")
+
+    return created
 
 
 def extract_and_merge(
@@ -1150,6 +1206,9 @@ def extract_and_merge(
         if valid_events:
             _create_orphan_stubs(catalogs, valid_events, turn_id)
             merge_events(events_list, valid_events)
+
+        # --- Phase 3: Create entities for birth events (#136) ---
+        _ensure_birth_entities(events_list, catalogs)
     except LLMExtractionError as e:
         print(f"  WARNING: Event extraction failed for {turn_id}: {e}", file=sys.stderr)
 
@@ -1420,14 +1479,40 @@ def _is_stub_entity(entity: dict) -> bool:
     return False
 
 
+def _find_earliest_mention(entity_id: str, entity_name: str | None,
+                           events_list: list) -> str | None:
+    """Find the earliest turn where entity appears by ID or name in events."""
+    earliest: str | None = None
+    name_lower = entity_name.lower() if entity_name and len(entity_name) >= 3 else None
+    for event in events_list:
+        turns = event.get("source_turns", [])
+        st_single = event.get("source_turn")
+        if st_single and st_single not in turns:
+            turns = list(turns) + [st_single]
+        matched = False
+        if entity_id in event.get("related_entities", []):
+            matched = True
+        if name_lower and name_lower in event.get("description", "").lower():
+            matched = True
+        if matched:
+            for t in turns:
+                if earliest is None or t < earliest:
+                    earliest = t
+    return earliest
+
+
 def _collect_stub_context(entity_id: str, events_list: list, turn_dicts: list,
-                          first_seen_turn: str | None) -> str:
+                          first_seen_turn: str | None,
+                          entity_name: str | None = None) -> str:
     """Gather turn text around an entity's event references for backfill context."""
     # Find all turns that reference this entity via events
     ref_turns: set[str] = set()
+    name_lower = entity_name.lower() if entity_name and len(entity_name) >= 3 else None
     for event in events_list:
         related = event.get("related_entities", [])
-        if entity_id in related:
+        id_match = entity_id in related
+        name_match = name_lower and name_lower in event.get("description", "").lower()
+        if id_match or name_match:
             for st in event.get("source_turns", []):
                 ref_turns.add(st)
             st_single = event.get("source_turn")
@@ -1486,7 +1571,9 @@ def backfill_stubs(
             continue
 
         first_seen = entity.get("first_seen_turn", "turn-001")
-        context_text = _collect_stub_context(entity_id, events_list, turn_dicts, first_seen)
+        entity_name = entity.get("name", "")
+        context_text = _collect_stub_context(entity_id, events_list, turn_dicts, first_seen,
+                                             entity_name=entity_name)
         if not context_text:
             print(f"  Backfill: no context found for stub '{entity_id}', skipping")
             continue

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -841,12 +841,18 @@ _GENERIC_STEMS = {
 }
 
 
-def _create_orphan_stubs(catalogs: dict, events: list, turn_id: str) -> None:
+def _create_orphan_stubs(catalogs: dict, events: list, turn_id: str,
+                        all_events: list | None = None) -> None:
     """Create stub catalog entries for entity IDs referenced in events but missing from catalogs.
 
     Stubs contain id, inferred name (from ID), inferred type (from prefix),
     first_seen_turn, and a source marker.
+
+    *all_events* is the full accumulated event list used for earliest-mention
+    lookup.  When ``None``, falls back to *events* (current-turn only).
     """
+    if all_events is None:
+        all_events = events
     known_ids = _collect_all_entity_ids(catalogs)
 
     orphan_ids: set[str] = set()
@@ -873,7 +879,7 @@ def _create_orphan_stubs(catalogs: dict, events: list, turn_id: str) -> None:
         if not catalog_file:
             catalog_file = "characters.json"  # default fallback
 
-        earliest = _find_earliest_mention(eid, inferred_name, events)
+        earliest = _find_earliest_mention(eid, inferred_name, all_events)
         effective_turn = earliest or turn_id
         stub = {
             "id": eid,
@@ -911,9 +917,22 @@ def _ensure_birth_entities(events_list: list, catalogs: dict) -> list[str]:
             continue
 
         child_name = match.group(1)
-        child_id = f"char-{child_name.lower().replace(' ', '-')}"
+        # Sanitize to valid entity ID chars: lowercase alphanumeric + hyphens
+        slug = re.sub(r'[^a-z0-9]+', '-', child_name.lower()).strip('-')
+        if not slug:
+            continue
+        child_id = f"char-{slug}"
         source_turns = event.get("source_turns", [])
-        first_turn = source_turns[0] if source_turns else event.get("source_turn")
+        # Pick the earliest source turn (by parsed number) for accuracy
+        first_turn = None
+        first_turn_num = None
+        for st in source_turns:
+            sn = _parse_turn_number(st)
+            if sn is not None and (first_turn_num is None or sn < first_turn_num):
+                first_turn = st
+                first_turn_num = sn
+        if first_turn is None:
+            first_turn = event.get("source_turn")
 
         # Ensure child is in related_entities regardless of whether entity exists
         rel = event.get("related_entities", [])
@@ -934,7 +953,11 @@ def _ensure_birth_entities(events_list: list, catalogs: dict) -> list[str]:
             "last_updated_turn": first_turn or "turn-001",
             "notes": "Auto-created from birth event.",
         }
-        catalogs.setdefault(catalog_file, []).append(entity)
+        if not _validate_entity(entity):
+            print(f"  WARNING: Birth entity '{child_id}' failed validation, skipping",
+                  file=sys.stderr)
+            continue
+        merge_entity(catalogs, entity)
         known_ids.add(child_id)
         created.append(child_id)
         print(f"  BIRTH: Created entity '{child_id}' ({child_name}) from birth event")
@@ -1204,7 +1227,8 @@ def extract_and_merge(
 
         # --- Phase 2: Create stub entities for orphan IDs (#106) ---
         if valid_events:
-            _create_orphan_stubs(catalogs, valid_events, turn_id)
+            _create_orphan_stubs(catalogs, valid_events, turn_id,
+                                all_events=events_list + valid_events)
             merge_events(events_list, valid_events)
 
         # --- Phase 3: Create entities for birth events (#136) ---
@@ -1481,8 +1505,13 @@ def _is_stub_entity(entity: dict) -> bool:
 
 def _find_earliest_mention(entity_id: str, entity_name: str | None,
                            events_list: list) -> str | None:
-    """Find the earliest turn where entity appears by ID or name in events."""
+    """Find the earliest turn where entity appears by ID or name in events.
+
+    Uses parsed turn numbers for comparison so that turn-1000 sorts after
+    turn-999 regardless of string ordering.
+    """
     earliest: str | None = None
+    earliest_num: int | None = None
     name_lower = entity_name.lower() if entity_name and len(entity_name) >= 3 else None
     for event in events_list:
         turns = event.get("source_turns", [])
@@ -1496,8 +1525,12 @@ def _find_earliest_mention(entity_id: str, entity_name: str | None,
             matched = True
         if matched:
             for t in turns:
-                if earliest is None or t < earliest:
+                t_num = _parse_turn_number(t)
+                if t_num is None:
+                    continue
+                if earliest_num is None or t_num < earliest_num:
                     earliest = t
+                    earliest_num = t_num
     return earliest
 
 

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -943,7 +943,6 @@ def _ensure_birth_entities(events_list: list, catalogs: dict) -> list[str]:
             continue
 
         # Create a proper character entity (not a hollow stub)
-        catalog_file = TYPE_TO_CATALOG_V1.get("character", "characters.json")
         entity = {
             "id": child_id,
             "name": child_name,


### PR DESCRIPTION
## Summary

Fixes hollow stubs for important child characters (Lyrawyn: 106 transcript mentions, Faelan: 49)
by expanding backfill context gathering and adding birth event entity creation.

## Investigation Findings

**Birth events missing entity IDs:** All birth events (evt-088/089/090 for Lyrawyn, evt-112 for Faelan) contain the child's name in the description but only list `char-player` in `related_entities`. The child entity IDs are absent.

**Backfill context coverage:** `char-lyrawyn` appears in `related_entities` of only 2 events but is mentioned by name in 6 event descriptions. `char-faelan` appears in `related_entities` of 1 event but is mentioned by name in 2 descriptions. The old backfill only checked `related_entities`, missing most context.

**Entity discovery prompt:** No special handling for birth events, newborn characters, or family relationships.

**Stub `first_seen_turn` accuracy:** Lyrawyn shows `turn-149` (should be `turn-141`, her birth); Faelan shows `turn-339` (should be `turn-183`, his birth).

## Changes

### Backfill context expansion (`_collect_stub_context`)
- Now accepts optional `entity_name` parameter
- Searches event descriptions for entity name (case-insensitive, min 3 chars) in addition to `related_entities` ID matching
- Lyrawyn goes from 2 context events to 6+; Faelan from 1 to 2+

### `first_seen_turn` fix (`_create_orphan_stubs` + `_find_earliest_mention`)
- New `_find_earliest_mention()` helper scans all events for earliest turn where entity appears by ID or name
- Stubs use earliest event mention instead of processing turn
- Lyrawyn: `turn-141` (birth) instead of `turn-149`; Faelan: `turn-183` instead of `turn-339`

### Birth event entity creation (`_ensure_birth_entities`)
- New post-extraction pass detects `named X` patterns in birth-type events
- Creates proper character entities (not hollow stubs) with correct `first_seen_turn`
- Retroactively adds child ID to birth event `related_entities` for downstream consumers

### Tests (15 new)
- Stub context includes description mentions
- `first_seen_turn` uses earliest mention
- Birth events create entities and add `related_entities`
- Case-insensitive name matching
- Short name (<3 chars) guard against false positives

### Documentation
- Updated `docs/architecture.md` Semantic Extraction Layer section

Closes #136
