### PR TITLE
fix: descriptive biography section titles (#135)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,6 +103,7 @@ An automated pipeline that uses an LLM to extract structured data from transcrip
 - Batch mode checkpoints progress every 50 turns for resume after interruption
 - Birth events trigger automatic entity creation for named children, with child IDs added to event `related_entities`
 - Stub backfill gathers context from both `related_entities` references and entity name mentions in event descriptions
+- Biography sections use LLM-generated descriptive titles (not generic "Phase" labels), cached in `.synthesis.json` sidecars
 
 ---
 

--- a/tests/test_narrative_synthesis.py
+++ b/tests/test_narrative_synthesis.py
@@ -34,6 +34,8 @@ from narrative_synthesis import (
     _build_infobox,
     _build_event_timeline,
     _build_current_status,
+    _parse_biography_response,
+    _normalize_subheadings,
 )
 
 from narrative_synthesis import _collect_critical_turns
@@ -625,6 +627,8 @@ class TestBiographyGeneration:
 
         assert "[turn-001]" in text
         assert meta["name"] == "Test Phase"
+        # No TITLE: prefix in mock response → title falls back to phase_name
+        assert meta["title"] == "Test Phase"
         assert meta["llm_model"] == "mock-model"
         assert meta["tokens_used"] > 0
         assert len(llm.calls) == 1
@@ -645,6 +649,7 @@ class TestBiographyGeneration:
 
         assert "Generation failed" in text
         assert "error" in meta
+        assert meta["title"] == "Test"
 
     def test_generate_lede(self):
         """Lede generation returns text."""
@@ -939,3 +944,103 @@ class TestFullPipelineIntegration:
 
             loaded = load_synthesis_sidecar(sidecar_path)
             assert loaded["entity_id"] == "char-player"
+
+
+# ---------------------------------------------------------------------------
+# Test biography title parsing and subheading normalization
+# ---------------------------------------------------------------------------
+
+
+class TestBiographyTitleParsing:
+
+    def test_parse_biography_response_with_title(self):
+        """TITLE: prefix is extracted as the section title."""
+        raw = "TITLE: Capture and Integration\n\nProse about the capture."
+        title, prose = _parse_biography_response(raw, "Fallback Name")
+        assert title == "Capture and Integration"
+        assert prose == "Prose about the capture."
+
+    def test_parse_biography_response_without_title(self):
+        """Missing TITLE: prefix uses fallback name."""
+        raw = "Prose without a title prefix."
+        title, prose = _parse_biography_response(raw, "Fallback Name")
+        assert title == "Fallback Name"
+        assert prose == "Prose without a title prefix."
+
+    def test_parse_biography_response_title_case_insensitive(self):
+        """TITLE: matching is case-insensitive."""
+        raw = "title: Awakening in the Snow\n\nSome text here."
+        title, prose = _parse_biography_response(raw, "Fallback")
+        assert title == "Awakening in the Snow"
+        assert prose == "Some text here."
+
+    def test_parse_biography_response_title_only(self):
+        """TITLE: line with no following prose returns empty prose."""
+        raw = "TITLE: Solo Title"
+        title, prose = _parse_biography_response(raw, "Fallback")
+        assert title == "Solo Title"
+        assert prose == ""
+
+    def test_normalize_subheadings_downgrades(self):
+        """### headings become #### headings."""
+        text = "### Sub-section A\nContent.\n### Sub-section B\nMore."
+        result = _normalize_subheadings(text)
+        assert "#### Sub-section A" in result
+        assert "#### Sub-section B" in result
+        # No lines start with exactly "### " (only "#### ")
+        for line in result.splitlines():
+            assert not line.startswith("### ")
+
+    def test_normalize_subheadings_keeps_h4(self):
+        """#### headings stay unchanged."""
+        text = "#### Already level 4\nContent."
+        result = _normalize_subheadings(text)
+        assert "#### Already level 4" in result
+        # No spurious extra # added
+        assert "##### Already level 4" not in result
+
+    def test_sidecar_caches_title(self):
+        """Phase metadata in sidecar includes the title field."""
+        llm = MockLLMClient(
+            "TITLE: Awakening in the Snow\n\n"
+            "The character awakened [turn-001] and was found [turn-005]."
+        )
+
+        page, sidecar = synthesize_entity(
+            "char-player", SAMPLE_EVENTS[:3], SAMPLE_CATALOG,
+            None, llm, entity_type="character")
+
+        assert len(sidecar["phases"]) >= 1
+        phase = sidecar["phases"][0]
+        assert phase["title"] == "Awakening in the Snow"
+
+    def test_no_generic_phase_titles(self):
+        """When LLM returns TITLE:, no generic 'Phase (turns' headings appear."""
+        llm = MockLLMClient(
+            "TITLE: Early Days\n\n"
+            "The character awakened [turn-001] and was found [turn-005]."
+        )
+
+        page, sidecar = synthesize_entity(
+            "char-player", SAMPLE_EVENTS[:3], SAMPLE_CATALOG,
+            None, llm, entity_type="character")
+
+        import re
+        assert not re.search(r"^### Phase \(turns", page, re.MULTILINE)
+        assert "### Early Days (turns" in page
+
+    def test_descriptive_title_in_full_pipeline(self):
+        """Full pipeline uses LLM title with turn range in heading."""
+        llm = MockLLMClient(
+            "TITLE: Capture and Integration\n\n"
+            "Events unfolded [turn-001] and [turn-005]."
+        )
+
+        page, sidecar = synthesize_entity(
+            "char-player", SAMPLE_EVENTS[:3], SAMPLE_CATALOG,
+            None, llm, entity_type="character")
+
+        # The heading should include the descriptive title and turn range
+        assert "### Capture and Integration (turns" in page
+        # The generic Phase label should NOT appear
+        assert "Phase (turns" not in page

--- a/tests/test_narrative_synthesis.py
+++ b/tests/test_narrative_synthesis.py
@@ -1044,3 +1044,36 @@ class TestBiographyTitleParsing:
         assert "### Capture and Integration (turns" in page
         # The generic Phase label should NOT appear
         assert "Phase (turns" not in page
+
+    def test_parse_biography_response_empty_title_uses_fallback(self):
+        """TITLE: with no content falls back to fallback_name."""
+        raw = "TITLE:   \n\nProse about something."
+        title, prose = _parse_biography_response(raw, "Fallback Name")
+        assert title == "Fallback Name"
+        assert prose == "Prose about something."
+
+    def test_needs_regeneration_missing_title_in_sidecar(self):
+        """Sidecar phases without 'title' trigger regeneration."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sidecar_path = os.path.join(tmpdir, "char-test.synthesis.json")
+
+            # Sidecar with matching event count but no title in phases
+            sidecar = {
+                "source_data": {"events_count": 5},
+                "phases": [
+                    {"name": "Phase (turns turn-001–turn-050)",
+                     "turn_range": ["turn-001", "turn-050"]}
+                ],
+            }
+            with open(sidecar_path, "w") as f:
+                json.dump(sidecar, f)
+
+            # Missing title → needs regeneration
+            assert needs_regeneration("char-test", 5, sidecar_path) is True
+
+            # Add title → skip regeneration
+            sidecar["phases"][0]["title"] = "Awakening"
+            with open(sidecar_path, "w") as f:
+                json.dump(sidecar, f)
+
+            assert needs_regeneration("char-test", 5, sidecar_path) is False

--- a/tools/narrative_synthesis.py
+++ b/tools/narrative_synthesis.py
@@ -61,7 +61,7 @@ Rules:
    Integration", "Building the Settlement"). Do NOT use generic labels
    like "Phase" or "Part". Do NOT include turn numbers in the title.
    Then write the biography prose below that line, without any markdown
-   headings.\
+   headings.
 """
 
 LEDE_SYSTEM_PROMPT = """\
@@ -457,6 +457,8 @@ def _parse_biography_response(raw_response: str, fallback_name: str) -> tuple[st
     if lines and lines[0].upper().startswith("TITLE:"):
         title = lines[0].split(":", 1)[1].strip()
         prose = lines[1].strip() if len(lines) > 1 else ""
+        if not title:
+            title = fallback_name
     else:
         title = fallback_name
         prose = raw_response.strip()
@@ -1096,4 +1098,12 @@ def needs_regeneration(entity_id: str, event_count: int,
         return True
 
     prev_count = existing.get("source_data", {}).get("events_count", 0)
-    return event_count != prev_count
+    if event_count != prev_count:
+        return True
+
+    # Regenerate if any cached phase is missing a descriptive title
+    for phase in existing.get("phases", []):
+        if "title" not in phase:
+            return True
+
+    return False

--- a/tools/narrative_synthesis.py
+++ b/tools/narrative_synthesis.py
@@ -55,7 +55,13 @@ Rules:
    micro-interactions.
 7. If uncertain about a connection (e.g., whether two entity IDs refer
    to the same person), note the uncertainty explicitly.
-8. Keep each biography phase to 3–6 sentences.\
+8. Keep each biography phase to 3–6 sentences.
+9. Begin your response with a single line "TITLE: <title>" where <title>
+   is a concise descriptive label for this phase (e.g., "Capture and
+   Integration", "Building the Settlement"). Do NOT use generic labels
+   like "Phase" or "Part". Do NOT include turn numbers in the title.
+   Then write the biography prose below that line, without any markdown
+   headings.\
 """
 
 LEDE_SYSTEM_PROMPT = """\
@@ -342,21 +348,26 @@ def generate_phase_biography(llm_client, synthesis_input: dict) -> tuple[str, di
         Tuple of (markdown_text, phase_metadata).
         On failure, returns a fallback message and metadata with error info.
     """
+    fallback_name = synthesis_input.get("phase_name", "")
     try:
-        text = llm_client.generate_text(
+        raw_text = llm_client.generate_text(
             system_prompt=synthesis_input["system_prompt"],
             user_prompt=synthesis_input["user_prompt"],
         )
         llm_client.delay()
 
+        title, prose = _parse_biography_response(raw_text, fallback_name)
+        prose = _normalize_subheadings(prose)
+
         metadata = {
             "name": synthesis_input.get("phase_name", ""),
+            "title": title,
             "turn_range": synthesis_input.get("turn_range", []),
             "events_used": synthesis_input.get("events_used", []),
             "llm_model": getattr(llm_client, "model", "unknown"),
-            "tokens_used": _estimate_tokens(synthesis_input["user_prompt"], text),
+            "tokens_used": _estimate_tokens(synthesis_input["user_prompt"], raw_text),
         }
-        return text, metadata
+        return prose, metadata
 
     except Exception as e:
         logger.error("Phase biography generation failed: %s", e)
@@ -364,6 +375,7 @@ def generate_phase_biography(llm_client, synthesis_input: dict) -> tuple[str, di
                     "timeline below]")
         metadata = {
             "name": synthesis_input.get("phase_name", ""),
+            "title": fallback_name,
             "turn_range": synthesis_input.get("turn_range", []),
             "events_used": synthesis_input.get("events_used", []),
             "llm_model": getattr(llm_client, "model", "unknown"),
@@ -432,6 +444,28 @@ def generate_item_summary(llm_client, item_input: dict) -> str:
 def _estimate_tokens(prompt: str, response: str) -> int:
     """Rough token estimate (~4 chars per token)."""
     return (len(prompt) + len(response)) // 4
+
+
+def _parse_biography_response(raw_response: str, fallback_name: str) -> tuple[str, str]:
+    """Extract title and prose from LLM biography response.
+
+    The LLM is instructed to begin with ``TITLE: <descriptive title>``
+    followed by the biography prose.  If the prefix is missing, the
+    *fallback_name* is used and the entire response is treated as prose.
+    """
+    lines = raw_response.strip().split("\n", 1)
+    if lines and lines[0].upper().startswith("TITLE:"):
+        title = lines[0].split(":", 1)[1].strip()
+        prose = lines[1].strip() if len(lines) > 1 else ""
+    else:
+        title = fallback_name
+        prose = raw_response.strip()
+    return title, prose
+
+
+def _normalize_subheadings(prose: str) -> str:
+    """Ensure LLM-generated subheadings don't conflict with phase headings."""
+    return re.sub(r'^###\s', '#### ', prose, flags=re.MULTILINE)
 
 
 # Critical event types that should be cited in the biography
@@ -918,8 +952,16 @@ def _synthesize_character(entity_id, entity_name, events, catalog_data,
             all_available_turns.add(t)
 
         text, meta = generate_phase_biography(llm_client, synth_input)
-        phase_name = synth_input["phase_name"]
-        phase_texts.append((phase_name, text))
+        turn_range = synth_input.get("turn_range", ["?", "?"])
+        title = meta.get("title", synth_input["phase_name"])
+        fallback = synth_input["phase_name"]
+        # Only append turn range if the title is descriptive (not the
+        # generic fallback which already contains the range).
+        if title != fallback:
+            display_name = f"{title} (turns {turn_range[0]}\u2013{turn_range[1]})"
+        else:
+            display_name = fallback
+        phase_texts.append((display_name, text))
         phase_metadata.append(meta)
 
     # Generate lede


### PR DESCRIPTION
## Summary

Replaces generic "Phase (turns X–Y)" biography headings with LLM-generated descriptive titles.
The LLM is instructed to return a `TITLE:` prefix line, which is parsed and used as the section
heading. Titles are cached in `.synthesis.json` sidecars. LLM sub-headings within prose are
downgraded to avoid heading level conflicts.

## Investigation Findings

- **20 generic `### Phase (turns...` headings** found across 9 character wiki pages
- Sidecar `.synthesis.json` files cache phase metadata but had no `title` field
- The LLM response was used as-is for prose; phase names were generated purely in code
- No caching invalidation needed — new `title` field is additive

## Changes

- Updated `BIOGRAPHY_SYSTEM_PROMPT` with Rule 9 (descriptive title requirement)
- Added `_parse_biography_response()` to extract title from LLM output
- Added `_normalize_subheadings()` to prevent heading level conflicts
- Updated `generate_phase_biography()` to parse titles and include them in metadata
- Updated `_synthesize_character()` to use descriptive titles with turn ranges in headings
- Updated sidecar metadata to cache phase titles
- Added 9 new tests for title parsing, subheading normalization, sidecar caching, and integration
- Updated `docs/architecture.md` with biography title documentation

Closes #135
