### PR TITLE
feat: cross-page entity links in synthesis wiki pages (#139)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,6 +104,7 @@ An automated pipeline that uses an LLM to extract structured data from transcrip
 - Birth events trigger automatic entity creation for named children, with child IDs added to event `related_entities`
 - Stub backfill gathers context from both `related_entities` references and entity name mentions in event descriptions
 - Biography sections use LLM-generated descriptive titles (not generic "Phase" labels), cached in `.synthesis.json` sidecars
+- Wiki pages include cross-page entity links: the first mention of each known entity in biography prose, relationship tables, event timelines, and member/connection lists is a clickable markdown link to that entity's wiki page. Link resolution uses relative paths across entity types.
 
 ---
 

--- a/tests/test_cross_page_links.py
+++ b/tests/test_cross_page_links.py
@@ -315,3 +315,83 @@ class TestNoLinksFallback:
         page = assemble_item_page(
             "item-sword", "Magic Sword", "Important.", None, None, [])
         assert "# Magic Sword" in page
+
+
+# ---------------------------------------------------------------------------
+# Cross-section deduplication
+# ---------------------------------------------------------------------------
+
+class TestCrossSectionDedup:
+    def test_biography_links_prevent_relationship_relink(self):
+        """Entity linked in biography should NOT be linked again in relationships."""
+        arcs = {"arcs": {
+            "char-kael": {"current_relationship": "ally", "interaction_count": 5},
+        }}
+        page = assemble_character_page(
+            "char-player", "Player Character", "",
+            [("Phase 1", "Kael helped build the settlement.")],
+            None, None, arcs, [],
+            name_index=NAME_INDEX, source_type_dir=CHARACTERS_DIR)
+        # Only one link to Kael across the whole page
+        assert page.count("[Kael]") == 1
+
+    def test_biography_links_prevent_timeline_relink(self):
+        """Entity linked in biography should NOT be linked again in timeline."""
+        events = [_evt("Kael arrived at Haven",
+                       related=["char-kael", "loc-haven"])]
+        page = assemble_character_page(
+            "char-player", "Player Character", "",
+            [("Phase 1", "Kael helped build the settlement.")],
+            None, None, None, events,
+            name_index=NAME_INDEX, source_type_dir=CHARACTERS_DIR)
+        assert page.count("[Kael]") == 1
+
+    def test_faction_history_links_prevent_member_relink(self):
+        """Entity linked in faction history should NOT relink in members list."""
+        events = [_evt("Kael joined", related=["char-kael"])]
+        page = assemble_faction_page(
+            "faction-guild", "The Guild", "Kael founded the guild.",
+            None, None, events,
+            name_index=NAME_INDEX, source_type_dir=FACTIONS_DIR)
+        assert page.count("[Kael]") == 1
+
+    def test_location_significance_prevents_connected_relink(self):
+        """Entity linked in significance should NOT relink in connected entities."""
+        catalog = {
+            "relationships": [
+                {"target_id": "char-kael", "current_relationship": "resident"},
+            ],
+        }
+        page = assemble_location_page(
+            "loc-haven", "Haven", "Kael founded Haven.",
+            catalog, None, [],
+            name_index=NAME_INDEX, source_type_dir=LOCATIONS_DIR)
+        assert page.count("[Kael]") == 1
+
+
+# ---------------------------------------------------------------------------
+# Alias ID resolution
+# ---------------------------------------------------------------------------
+
+class TestAliasIDResolution:
+    def test_event_timeline_resolves_alias(self):
+        """Alias IDs (e.g. char-Kael) should be canonicalized and still link."""
+        events = [_evt("Kael arrived", related=["char-Kael"])]
+        table = _build_event_timeline(
+            events, name_index=NAME_INDEX,
+            source_type_dir=CHARACTERS_DIR, self_id="char-player")
+        assert "[Kael]" in table
+
+    def test_connected_entities_resolves_alias(self):
+        """Alias target_id in relationships should resolve and link."""
+        from narrative_synthesis import assemble_location_page
+        catalog = {
+            "relationships": [
+                {"target_id": "char-Kael", "current_relationship": "visitor"},
+            ],
+        }
+        page = assemble_location_page(
+            "loc-haven", "Haven", "A settlement.",
+            catalog, None, [],
+            name_index=NAME_INDEX, source_type_dir=LOCATIONS_DIR)
+        assert "[Kael]" in page

--- a/tests/test_cross_page_links.py
+++ b/tests/test_cross_page_links.py
@@ -1,0 +1,317 @@
+"""Tests for cross-page entity links in synthesis wiki pages (#139)."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from narrative_synthesis import (
+    _resolve_link,
+    _safe_replace_first,
+    _linkify_prose,
+    _build_event_timeline,
+    _build_relationship_table,
+    assemble_character_page,
+    assemble_location_page,
+    assemble_faction_page,
+    assemble_item_page,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+NAME_INDEX = {
+    "char-kael": ("Kael", "../characters/char-kael.md"),
+    "char-player": ("Player Character", "../characters/char-player.md"),
+    "char-elder-lyra": ("Elder Lyra", "../characters/char-elder-lyra.md"),
+    "char-lyra": ("Lyra", "../characters/char-lyra.md"),
+    "loc-haven": ("Haven", "../locations/loc-haven.md"),
+    "faction-guild": ("The Guild", "../factions/faction-guild.md"),
+    "char-al": ("Al", "../characters/char-al.md"),  # short name, < 4 chars
+}
+
+CHARACTERS_DIR = "/fake/catalogs/characters"
+LOCATIONS_DIR = "/fake/catalogs/locations"
+FACTIONS_DIR = "/fake/catalogs/factions"
+ITEMS_DIR = "/fake/catalogs/items"
+
+
+def _evt(desc, related=None, turns=None, etype="decision"):
+    return {
+        "id": "evt-1",
+        "source_turns": turns or ["turn-001"],
+        "type": etype,
+        "description": desc,
+        "related_entities": related or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# _resolve_link
+# ---------------------------------------------------------------------------
+
+class TestResolveLink:
+    def test_cross_type_link(self):
+        link = _resolve_link("loc-haven", NAME_INDEX, CHARACTERS_DIR)
+        assert link == "[Haven](../locations/loc-haven.md)"
+
+    def test_same_type_link(self):
+        link = _resolve_link("char-kael", NAME_INDEX, CHARACTERS_DIR)
+        assert link == "[Kael](char-kael.md)"
+
+    def test_unknown_id_returns_none(self):
+        assert _resolve_link("char-unknown", NAME_INDEX, CHARACTERS_DIR) is None
+
+    def test_none_name_index(self):
+        assert _resolve_link("char-kael", None, CHARACTERS_DIR) is None
+
+    def test_none_source_dir(self):
+        assert _resolve_link("char-kael", NAME_INDEX, None) is None
+
+
+# ---------------------------------------------------------------------------
+# _safe_replace_first
+# ---------------------------------------------------------------------------
+
+class TestSafeReplaceFirst:
+    def test_replaces_first_occurrence(self):
+        result = _safe_replace_first("Kael went to Kael", "Kael", "[Kael](k.md)")
+        assert result == "[Kael](k.md) went to Kael"
+
+    def test_skips_inside_existing_link(self):
+        text = "[Elder Lyra](elder.md) met Kael"
+        result = _safe_replace_first(text, "Elder Lyra", "[Elder Lyra](x.md)")
+        # Already inside a link bracket — should skip and not find another
+        assert result == text
+
+    def test_no_match_returns_unchanged(self):
+        result = _safe_replace_first("no match here", "Kael", "[Kael](k.md)")
+        assert result == "no match here"
+
+    def test_replaces_outside_link(self):
+        text = "[Other](o.md) and Kael walked"
+        result = _safe_replace_first(text, "Kael", "[Kael](k.md)")
+        assert "[Kael](k.md)" in result
+
+
+# ---------------------------------------------------------------------------
+# _linkify_prose
+# ---------------------------------------------------------------------------
+
+class TestLinkifyProse:
+    def test_links_first_mention(self):
+        prose = "Kael arrived at Haven. Kael explored."
+        linked = set()
+        result = _linkify_prose(prose, NAME_INDEX, CHARACTERS_DIR,
+                                "char-player", linked)
+        assert "[Kael](char-kael.md)" in result
+        # Second mention should NOT be linked
+        assert result.count("[Kael]") == 1
+        assert "char-kael" in linked
+
+    def test_no_self_links(self):
+        prose = "Player Character went to Haven."
+        linked = set()
+        result = _linkify_prose(prose, NAME_INDEX, CHARACTERS_DIR,
+                                "char-player", linked)
+        assert "[Player Character]" not in result
+
+    def test_short_names_skipped(self):
+        prose = "Al went to Haven."
+        linked = set()
+        result = _linkify_prose(prose, NAME_INDEX, CHARACTERS_DIR,
+                                "char-player", linked)
+        assert "[Al]" not in result
+        assert "char-al" not in linked
+
+    def test_longest_name_first(self):
+        prose = "Elder Lyra spoke to Lyra."
+        linked = set()
+        result = _linkify_prose(prose, NAME_INDEX, CHARACTERS_DIR,
+                                "char-player", linked)
+        assert "[Elder Lyra]" in result
+        # "Lyra" should still be linkable separately (different entity)
+        assert "[Lyra]" in result
+
+    def test_already_linked_skipped(self):
+        prose = "Kael arrived."
+        linked = {"char-kael"}
+        result = _linkify_prose(prose, NAME_INDEX, CHARACTERS_DIR,
+                                "char-player", linked)
+        assert "[Kael]" not in result
+
+    def test_none_name_index_passthrough(self):
+        prose = "Kael arrived."
+        result = _linkify_prose(prose, None, CHARACTERS_DIR,
+                                "char-player", set())
+        assert result == prose
+
+    def test_cross_type_relative_path(self):
+        prose = "Haven is a settlement."
+        linked = set()
+        result = _linkify_prose(prose, NAME_INDEX, CHARACTERS_DIR,
+                                "char-player", linked)
+        assert "[Haven](../locations/loc-haven.md)" in result
+
+
+# ---------------------------------------------------------------------------
+# _build_relationship_table with links
+# ---------------------------------------------------------------------------
+
+class TestRelationshipTableLinks:
+    def test_has_links(self):
+        arcs = {"arcs": {
+            "char-kael": {"current_relationship": "ally", "interaction_count": 5},
+        }}
+        table = _build_relationship_table(
+            arcs, name_index=NAME_INDEX,
+            source_type_dir=CHARACTERS_DIR, self_id="char-player")
+        assert "[Kael](char-kael.md)" in table
+        assert "char-kael)" not in table.split("[Kael]")[0]  # old format gone
+
+    def test_no_name_index_fallback(self):
+        arcs = {"arcs": {
+            "char-kael": {"current_relationship": "ally", "interaction_count": 5},
+        }}
+        table = _build_relationship_table(arcs)
+        assert "Kael (char-kael)" in table
+
+
+# ---------------------------------------------------------------------------
+# _build_event_timeline with links
+# ---------------------------------------------------------------------------
+
+class TestEventTimelineLinks:
+    def test_links_related_entities(self):
+        events = [_evt("Kael arrived at Haven",
+                       related=["char-kael", "loc-haven"])]
+        table = _build_event_timeline(
+            events, name_index=NAME_INDEX,
+            source_type_dir=CHARACTERS_DIR, self_id="char-player")
+        assert "[Kael]" in table
+
+    def test_no_self_links_in_timeline(self):
+        events = [_evt("Player Character spoke",
+                       related=["char-player"])]
+        table = _build_event_timeline(
+            events, name_index=NAME_INDEX,
+            source_type_dir=CHARACTERS_DIR, self_id="char-player")
+        assert "[Player Character]" not in table
+
+
+# ---------------------------------------------------------------------------
+# Full page assembly with links
+# ---------------------------------------------------------------------------
+
+class TestCharacterPageLinks:
+    def test_biography_prose_linked(self):
+        page = assemble_character_page(
+            "char-player", "Player Character", "",
+            [("Phase 1", "Kael helped the Player Character at Haven.")],
+            None, None, None, [],
+            name_index=NAME_INDEX, source_type_dir=CHARACTERS_DIR)
+        assert "[Kael](char-kael.md)" in page
+
+    def test_no_self_links(self):
+        page = assemble_character_page(
+            "char-player", "Player Character", "",
+            [("Phase 1", "Player Character walked.")],
+            None, None, None, [],
+            name_index=NAME_INDEX, source_type_dir=CHARACTERS_DIR)
+        assert "[Player Character]" not in page
+
+    def test_no_duplicate_links(self):
+        page = assemble_character_page(
+            "char-player", "Player Character", "",
+            [("Phase 1", "Kael spoke."), ("Phase 2", "Kael returned.")],
+            None, None, None, [],
+            name_index=NAME_INDEX, source_type_dir=CHARACTERS_DIR)
+        assert page.count("[Kael]") == 1
+
+    def test_relationship_table_linked(self):
+        arcs = {"arcs": {
+            "loc-haven": {"current_relationship": "home", "interaction_count": 3},
+        }}
+        page = assemble_character_page(
+            "char-player", "Player Character", "", [],
+            None, None, arcs, [],
+            name_index=NAME_INDEX, source_type_dir=CHARACTERS_DIR)
+        assert "[Haven](../locations/loc-haven.md)" in page
+
+
+class TestLocationPageLinks:
+    def test_connected_entities_linked(self):
+        catalog = {
+            "relationships": [
+                {"target_id": "char-kael", "current_relationship": "resident"},
+            ],
+        }
+        page = assemble_location_page(
+            "loc-haven", "Haven", "A settlement.",
+            catalog, None, [],
+            name_index=NAME_INDEX, source_type_dir=LOCATIONS_DIR)
+        assert "[Kael](../characters/char-kael.md)" in page
+
+    def test_significance_prose_linked(self):
+        page = assemble_location_page(
+            "loc-haven", "Haven", "Kael founded Haven.",
+            None, None, [],
+            name_index=NAME_INDEX, source_type_dir=LOCATIONS_DIR)
+        assert "[Kael](../characters/char-kael.md)" in page
+
+
+class TestFactionPageLinks:
+    def test_member_list_linked(self):
+        events = [_evt("Kael joined", related=["char-kael"])]
+        page = assemble_faction_page(
+            "faction-guild", "The Guild", "",
+            None, None, events,
+            name_index=NAME_INDEX, source_type_dir=FACTIONS_DIR)
+        assert "[Kael](../characters/char-kael.md)" in page
+
+    def test_history_prose_linked(self):
+        page = assemble_faction_page(
+            "faction-guild", "The Guild", "Kael led the founding.",
+            None, None, [],
+            name_index=NAME_INDEX, source_type_dir=FACTIONS_DIR)
+        assert "[Kael](../characters/char-kael.md)" in page
+
+
+class TestItemPageLinks:
+    def test_significance_prose_linked(self):
+        page = assemble_item_page(
+            "item-sword", "Magic Sword", "Kael wielded the sword.",
+            None, None, [],
+            name_index=NAME_INDEX, source_type_dir=ITEMS_DIR)
+        assert "[Kael](../characters/char-kael.md)" in page
+
+
+# ---------------------------------------------------------------------------
+# Template path still works (no name_index = no links, no crash)
+# ---------------------------------------------------------------------------
+
+class TestNoLinksFallback:
+    def test_character_page_no_index(self):
+        page = assemble_character_page(
+            "char-player", "Player Character", "",
+            [("Phase 1", "Kael helped.")],
+            None, None, None, [])
+        assert "# Player Character" in page
+        assert "[Kael]" not in page  # no linkification without name_index
+
+    def test_location_page_no_index(self):
+        page = assemble_location_page(
+            "loc-haven", "Haven", "Significance.", None, None, [])
+        assert "# Haven" in page
+
+    def test_faction_page_no_index(self):
+        page = assemble_faction_page(
+            "faction-guild", "The Guild", "History.", None, None, [])
+        assert "# The Guild" in page
+
+    def test_item_page_no_index(self):
+        page = assemble_item_page(
+            "item-sword", "Magic Sword", "Important.", None, None, [])
+        assert "# Magic Sword" in page

--- a/tools/generate_wiki_pages.py
+++ b/tools/generate_wiki_pages.py
@@ -806,7 +806,8 @@ def run_synthesis_pipeline(framework_dir: str, catalog_dir: str,
                       file=sys.stderr)
                 page, sidecar = synthesize_entity(
                     eid, entity_events, entity, arc_summaries,
-                    llm_client, entity_type=etype_str)
+                    llm_client, entity_type=etype_str,
+                    name_index=name_index, source_type_dir=type_dir)
 
                 md_path = os.path.join(type_dir, f"{eid}.md")
                 with open(md_path, "w", encoding="utf-8") as f:
@@ -846,7 +847,8 @@ def run_synthesis_pipeline(framework_dir: str, catalog_dir: str,
                           file=sys.stderr)
                     page, sidecar = synthesize_entity(
                         eid, entity_events, None, None,
-                        llm_client, entity_type=etype_str)
+                        llm_client, entity_type=etype_str,
+                        name_index=name_index, source_type_dir=type_dir)
 
                     md_path = os.path.join(type_dir, f"{eid}.md")
                     with open(md_path, "w", encoding="utf-8") as f:

--- a/tools/narrative_synthesis.py
+++ b/tools/narrative_synthesis.py
@@ -630,7 +630,8 @@ def _build_event_timeline(events: list[dict], *,
         desc = evt.get("description", "")
         # Linkify related entities in description
         if name_index and source_type_dir:
-            for eid in evt.get("related_entities", []):
+            for raw_eid in evt.get("related_entities", []):
+                eid = resolve_entity_id(raw_eid)
                 if eid == self_id or eid in linked_entities:
                     continue
                 if eid not in name_index:
@@ -667,13 +668,14 @@ def _build_relationship_table(arc_summaries: dict | None, *,
              "|---|---|---|"]
     for target_id in sorted(arcs.keys()):
         arc = arcs[target_id]
+        if target_id == self_id:
+            continue
+        name = _infer_name_from_id(target_id)
+        display = f"{name} ({target_id})"
         link = _resolve_link(target_id, name_index, source_type_dir) if name_index else None
-        if link:
+        if link and target_id not in linked_entities:
             display = link
             linked_entities.add(target_id)
-        else:
-            name = _infer_name_from_id(target_id)
-            display = f"{name} ({target_id})"
         current = _escape_table_cell(arc.get("current_relationship", ""))
         count = arc.get("interaction_count", 0)
         lines.append(f"| {display} | {current} | {count} |")
@@ -721,7 +723,8 @@ def assemble_character_page(entity_id: str, entity_name: str,
         arc_summaries: Arc sidecar data or None.
         all_events: All events for this entity (for timeline).
         name_index: Entity ID → (name, relative_md_path) mapping.
-        source_type_dir: Directory name of this entity's type.
+        source_type_dir: Directory path for this entity type's catalog
+            (for example, ``.../catalogs/characters``).
 
     Returns:
         Complete markdown page string.
@@ -811,13 +814,15 @@ def assemble_location_page(entity_id: str, entity_name: str,
                   "| Entity | Connection |", "|---|---|"]
         for rel in catalog_data["relationships"]:
             target = rel.get("target_id", "")
-            link = _resolve_link(target, name_index, source_type_dir) if name_index else None
+            canonical_target = resolve_entity_id(target) or target
+            link = (_resolve_link(canonical_target, name_index, source_type_dir)
+                    if name_index and canonical_target not in linked else None)
             if link:
                 display = link
-                linked.add(target)
+                linked.add(canonical_target)
             else:
-                name = _infer_name_from_id(target)
-                display = f"{name} ({target})"
+                name = _infer_name_from_id(canonical_target)
+                display = f"{name} ({canonical_target})"
             cur = _escape_table_cell(rel.get("current_relationship", ""))
             lines.append(f"| {display} | {cur} |")
         lines.append("")
@@ -864,13 +869,13 @@ def assemble_faction_page(entity_id: str, entity_name: str,
         lines += ["## Known Members", "",
                   "| Member | First Seen |", "|---|---|"]
         for mid in sorted(member_ids):
-            link = _resolve_link(mid, name_index, source_type_dir) if name_index else None
-            if link:
-                display = link
-                linked.add(mid)
-            else:
-                name = _infer_name_from_id(mid)
-                display = f"{name} ({mid})"
+            name = _infer_name_from_id(mid)
+            display = f"{name} ({mid})"
+            if mid not in linked and name_index:
+                link = _resolve_link(mid, name_index, source_type_dir)
+                if link:
+                    display = link
+                    linked.add(mid)
             # Find first event with this member
             first_turn = ""
             for evt in all_events:

--- a/tools/narrative_synthesis.py
+++ b/tools/narrative_synthesis.py
@@ -506,6 +506,64 @@ def should_synthesize(entity_id: str, event_count: int, entity_type: str) -> boo
 # Step 4: Page Assembly
 # ---------------------------------------------------------------------------
 
+
+# -- Cross-page link helpers ------------------------------------------------
+
+def _resolve_link(target_id: str, name_index: dict[str, tuple[str, str]],
+                  source_type_dir: str) -> str | None:
+    """Return a markdown link string for *target_id*, or None."""
+    if not name_index or not source_type_dir or target_id not in name_index:
+        return None
+    name, generic_path = name_index[target_id]
+    # generic_path is always ../type/id.md — use simple id.md for same-dir
+    target_type_dir = generic_path.split("/")[1] if "/" in generic_path else ""
+    src_dir = os.path.basename(source_type_dir)
+    if target_type_dir == src_dir:
+        return f"[{name}]({target_id}.md)"
+    return f"[{name}]({generic_path})"
+
+
+def _safe_replace_first(text: str, name: str, link: str) -> str:
+    """Replace first occurrence of *name* that isn't inside a markdown link."""
+    idx = 0
+    while True:
+        pos = text.find(name, idx)
+        if pos == -1:
+            return text
+        before = text[:pos]
+        if before.count("[") > before.count("]"):
+            idx = pos + len(name)
+            continue
+        return text[:pos] + link + text[pos + len(name):]
+
+
+def _linkify_prose(prose: str, name_index: dict[str, tuple[str, str]] | None,
+                   source_type_dir: str | None, self_id: str,
+                   linked_entities: set[str]) -> str:
+    """Link first mention of each known entity name in *prose*."""
+    if not name_index or not source_type_dir:
+        return prose
+
+    candidates: list[tuple[str, str, str]] = []  # (name, eid, link)
+    for eid, (name, _rel) in name_index.items():
+        if eid == self_id or eid in linked_entities or len(name) < 4:
+            continue
+        link = _resolve_link(eid, name_index, source_type_dir)
+        if link:
+            candidates.append((name, eid, link))
+
+    # Longest-first to avoid partial matches
+    candidates.sort(key=lambda x: len(x[0]), reverse=True)
+
+    for name, eid, link in candidates:
+        new_prose = _safe_replace_first(prose, name, link)
+        if new_prose != prose:
+            prose = new_prose
+            linked_entities.add(eid)
+
+    return prose
+
+
 def _escape_table_cell(text: str) -> str:
     """Escape text for safe inclusion in a markdown table cell."""
     text = str(text)
@@ -556,19 +614,44 @@ def _build_infobox(entity_id: str, catalog_data: dict | None,
     return "\n".join(lines)
 
 
-def _build_event_timeline(events: list[dict]) -> str:
+def _build_event_timeline(events: list[dict], *,
+                          name_index: dict[str, tuple[str, str]] | None = None,
+                          source_type_dir: str | None = None,
+                          self_id: str = "",
+                          linked_entities: set[str] | None = None) -> str:
     """Build a chronological event timeline table."""
+    if linked_entities is None:
+        linked_entities = set()
     lines = ["| Turn | Type | Description |", "|---|---|---|"]
     for evt in events:
         turns = evt.get("source_turns", [])
         turn_str = ", ".join(turns) if turns else "—"
         etype = _escape_table_cell(evt.get("type", "other"))
-        desc = _escape_table_cell(evt.get("description", ""))
+        desc = evt.get("description", "")
+        # Linkify related entities in description
+        if name_index and source_type_dir:
+            for eid in evt.get("related_entities", []):
+                if eid == self_id or eid in linked_entities:
+                    continue
+                if eid not in name_index:
+                    continue
+                ename, _ = name_index[eid]
+                if len(ename) < 4:
+                    continue
+                link = _resolve_link(eid, name_index, source_type_dir)
+                if link and ename in desc:
+                    desc = _safe_replace_first(desc, ename, link)
+                    linked_entities.add(eid)
+        desc = _escape_table_cell(desc)
         lines.append(f"| {turn_str} | {etype} | {desc} |")
     return "\n".join(lines)
 
 
-def _build_relationship_table(arc_summaries: dict | None) -> str:
+def _build_relationship_table(arc_summaries: dict | None, *,
+                              name_index: dict[str, tuple[str, str]] | None = None,
+                              source_type_dir: str | None = None,
+                              self_id: str = "",
+                              linked_entities: set[str] | None = None) -> str:
     """Build a relationship arcs table from sidecar data."""
     if not arc_summaries:
         return ""
@@ -577,14 +660,23 @@ def _build_relationship_table(arc_summaries: dict | None) -> str:
     if not arcs:
         return ""
 
+    if linked_entities is None:
+        linked_entities = set()
+
     lines = ["| Entity | Current Relationship | Interactions |",
              "|---|---|---|"]
     for target_id in sorted(arcs.keys()):
         arc = arcs[target_id]
-        name = _infer_name_from_id(target_id)
+        link = _resolve_link(target_id, name_index, source_type_dir) if name_index else None
+        if link:
+            display = link
+            linked_entities.add(target_id)
+        else:
+            name = _infer_name_from_id(target_id)
+            display = f"{name} ({target_id})"
         current = _escape_table_cell(arc.get("current_relationship", ""))
         count = arc.get("interaction_count", 0)
-        lines.append(f"| {name} ({target_id}) | {current} | {count} |")
+        lines.append(f"| {display} | {current} | {count} |")
 
     return "\n".join(lines)
 
@@ -614,7 +706,9 @@ def assemble_character_page(entity_id: str, entity_name: str,
                             catalog_data: dict | None,
                             derived_profile: dict | None,
                             arc_summaries: dict | None,
-                            all_events: list[dict]) -> str:
+                            all_events: list[dict], *,
+                            name_index: dict[str, tuple[str, str]] | None = None,
+                            source_type_dir: str | None = None) -> str:
     """Assemble a full character wiki page.
 
     Args:
@@ -626,10 +720,14 @@ def assemble_character_page(entity_id: str, entity_name: str,
         derived_profile: Event-derived profile or None.
         arc_summaries: Arc sidecar data or None.
         all_events: All events for this entity (for timeline).
+        name_index: Entity ID → (name, relative_md_path) mapping.
+        source_type_dir: Directory name of this entity's type.
 
     Returns:
         Complete markdown page string.
     """
+    linked: set[str] = set()
+
     lines = [f"# {entity_name}", ""]
 
     if lede:
@@ -639,15 +737,20 @@ def assemble_character_page(entity_id: str, entity_name: str,
     lines += ["## Overview", "",
               _build_infobox(entity_id, catalog_data, derived_profile), ""]
 
-    # Biography
+    # Biography — linkify prose
     lines += ["## Biography", ""]
     for phase_name, text in phase_texts:
         if phase_name:
             lines += [f"### {phase_name}", ""]
+        text = _linkify_prose(text, name_index, source_type_dir,
+                              entity_id, linked)
         lines += [text, ""]
 
     # Relationships
-    rel_table = _build_relationship_table(arc_summaries)
+    rel_table = _build_relationship_table(
+        arc_summaries, name_index=name_index,
+        source_type_dir=source_type_dir, self_id=entity_id,
+        linked_entities=linked)
     if rel_table:
         lines += ["## Relationships", "", rel_table, ""]
 
@@ -658,7 +761,10 @@ def assemble_character_page(entity_id: str, entity_name: str,
 
     # Event Timeline
     lines += ["## Event Timeline", "",
-              _build_event_timeline(all_events), ""]
+              _build_event_timeline(all_events, name_index=name_index,
+                                    source_type_dir=source_type_dir,
+                                    self_id=entity_id,
+                                    linked_entities=linked), ""]
 
     # Footer
     lines += ["---",
@@ -671,8 +777,11 @@ def assemble_location_page(entity_id: str, entity_name: str,
                            significance: str,
                            catalog_data: dict | None,
                            derived_profile: dict | None,
-                           all_events: list[dict]) -> str:
+                           all_events: list[dict], *,
+                           name_index: dict[str, tuple[str, str]] | None = None,
+                           source_type_dir: str | None = None) -> str:
     """Assemble a location wiki page."""
+    linked: set[str] = set()
     lines = [f"# {entity_name}", ""]
 
     identity = (catalog_data or {}).get("identity", "")
@@ -683,13 +792,18 @@ def assemble_location_page(entity_id: str, entity_name: str,
     lines += ["## Overview", "",
               _build_infobox(entity_id, catalog_data, derived_profile), ""]
 
-    # Significance
+    # Significance — linkify prose
     if significance:
+        significance = _linkify_prose(significance, name_index,
+                                      source_type_dir, entity_id, linked)
         lines += ["## Significance", "", significance, ""]
 
     # Key Events
     lines += ["## Key Events", "",
-              _build_event_timeline(all_events), ""]
+              _build_event_timeline(all_events, name_index=name_index,
+                                    source_type_dir=source_type_dir,
+                                    self_id=entity_id,
+                                    linked_entities=linked), ""]
 
     # Connected entities (from catalog relationships)
     if catalog_data and catalog_data.get("relationships"):
@@ -697,9 +811,15 @@ def assemble_location_page(entity_id: str, entity_name: str,
                   "| Entity | Connection |", "|---|---|"]
         for rel in catalog_data["relationships"]:
             target = rel.get("target_id", "")
-            name = _infer_name_from_id(target)
+            link = _resolve_link(target, name_index, source_type_dir) if name_index else None
+            if link:
+                display = link
+                linked.add(target)
+            else:
+                name = _infer_name_from_id(target)
+                display = f"{name} ({target})"
             cur = _escape_table_cell(rel.get("current_relationship", ""))
-            lines.append(f"| {name} ({target}) | {cur} |")
+            lines.append(f"| {display} | {cur} |")
         lines.append("")
 
     lines += ["---",
@@ -711,8 +831,11 @@ def assemble_faction_page(entity_id: str, entity_name: str,
                           history: str,
                           catalog_data: dict | None,
                           derived_profile: dict | None,
-                          all_events: list[dict]) -> str:
+                          all_events: list[dict], *,
+                          name_index: dict[str, tuple[str, str]] | None = None,
+                          source_type_dir: str | None = None) -> str:
     """Assemble a faction wiki page."""
+    linked: set[str] = set()
     lines = [f"# {entity_name}", ""]
 
     identity = (catalog_data or {}).get("identity", "")
@@ -723,8 +846,10 @@ def assemble_faction_page(entity_id: str, entity_name: str,
     lines += ["## Overview", "",
               _build_infobox(entity_id, catalog_data, derived_profile), ""]
 
-    # History
+    # History — linkify prose
     if history:
+        history = _linkify_prose(history, name_index, source_type_dir,
+                                 entity_id, linked)
         lines += ["## History", "", history, ""]
 
     # Members (from event co-occurrences)
@@ -739,7 +864,13 @@ def assemble_faction_page(entity_id: str, entity_name: str,
         lines += ["## Known Members", "",
                   "| Member | First Seen |", "|---|---|"]
         for mid in sorted(member_ids):
-            name = _infer_name_from_id(mid)
+            link = _resolve_link(mid, name_index, source_type_dir) if name_index else None
+            if link:
+                display = link
+                linked.add(mid)
+            else:
+                name = _infer_name_from_id(mid)
+                display = f"{name} ({mid})"
             # Find first event with this member
             first_turn = ""
             for evt in all_events:
@@ -748,12 +879,15 @@ def assemble_faction_page(entity_id: str, entity_name: str,
                     turns = evt.get("source_turns", [])
                     first_turn = turns[0] if turns else ""
                     break
-            lines.append(f"| {name} ({mid}) | {first_turn} |")
+            lines.append(f"| {display} | {first_turn} |")
         lines.append("")
 
     # Key Events
     lines += ["## Key Events", "",
-              _build_event_timeline(all_events), ""]
+              _build_event_timeline(all_events, name_index=name_index,
+                                    source_type_dir=source_type_dir,
+                                    self_id=entity_id,
+                                    linked_entities=linked), ""]
 
     lines += ["---",
               f"*Generated from events data — do not edit manually.*"]
@@ -764,8 +898,11 @@ def assemble_item_page(entity_id: str, entity_name: str,
                        significance: str,
                        catalog_data: dict | None,
                        derived_profile: dict | None,
-                       all_events: list[dict]) -> str:
+                       all_events: list[dict], *,
+                       name_index: dict[str, tuple[str, str]] | None = None,
+                       source_type_dir: str | None = None) -> str:
     """Assemble an item wiki page."""
+    linked: set[str] = set()
     lines = [f"# {entity_name}", ""]
 
     identity = (catalog_data or {}).get("identity", "")
@@ -776,13 +913,18 @@ def assemble_item_page(entity_id: str, entity_name: str,
     lines += ["## Overview", "",
               _build_infobox(entity_id, catalog_data, derived_profile), ""]
 
-    # Significance
+    # Significance — linkify prose
     if significance:
+        significance = _linkify_prose(significance, name_index,
+                                      source_type_dir, entity_id, linked)
         lines += ["## Significance", "", significance, ""]
 
     # Key Events
     lines += ["## Key Events", "",
-              _build_event_timeline(all_events), ""]
+              _build_event_timeline(all_events, name_index=name_index,
+                                    source_type_dir=source_type_dir,
+                                    self_id=entity_id,
+                                    linked_entities=linked), ""]
 
     lines += ["---",
               f"*Generated from events data — do not edit manually.*"]
@@ -905,7 +1047,9 @@ def synthesize_entity(entity_id: str, entity_events: list[dict],
                       catalog_data: dict | None,
                       arc_summaries: dict | None,
                       llm_client,
-                      entity_type: str | None = None) -> tuple[str, dict]:
+                      entity_type: str | None = None, *,
+                      name_index: dict[str, tuple[str, str]] | None = None,
+                      source_type_dir: str | None = None) -> tuple[str, dict]:
     """Run the full synthesis pipeline for a single entity.
 
     Args:
@@ -915,6 +1059,8 @@ def synthesize_entity(entity_id: str, entity_events: list[dict],
         arc_summaries: Arc sidecar data or None.
         llm_client: LLMClient instance.
         entity_type: Override entity type (otherwise inferred).
+        name_index: Entity ID → (name, relative_md_path) mapping.
+        source_type_dir: Directory name of this entity's type.
 
     Returns:
         Tuple of (markdown_page, sidecar_dict).
@@ -923,23 +1069,30 @@ def synthesize_entity(entity_id: str, entity_events: list[dict],
     entity_name = (catalog_data or {}).get("name") or _infer_name_from_id(entity_id)
     derived_profile = None if catalog_data else build_event_derived_profile(entity_id, entity_events)
 
+    link_kw = dict(name_index=name_index, source_type_dir=source_type_dir)
+
     if etype == "location":
         return _synthesize_location(entity_id, entity_name, entity_events,
-                                    catalog_data, derived_profile, llm_client)
+                                    catalog_data, derived_profile, llm_client,
+                                    **link_kw)
     elif etype == "faction":
         return _synthesize_faction(entity_id, entity_name, entity_events,
-                                   catalog_data, derived_profile, llm_client)
+                                   catalog_data, derived_profile, llm_client,
+                                   **link_kw)
     elif etype == "item":
         return _synthesize_item(entity_id, entity_name, entity_events,
-                                catalog_data, derived_profile, llm_client)
+                                catalog_data, derived_profile, llm_client,
+                                **link_kw)
     else:
         return _synthesize_character(entity_id, entity_name, entity_events,
                                      catalog_data, derived_profile,
-                                     arc_summaries, llm_client)
+                                     arc_summaries, llm_client,
+                                     **link_kw)
 
 
 def _synthesize_character(entity_id, entity_name, events, catalog_data,
-                          derived_profile, arc_summaries, llm_client):
+                          derived_profile, arc_summaries, llm_client, *,
+                          name_index=None, source_type_dir=None):
     """Synthesize a character page with per-phase biography."""
     phases = segment_phases(events, entity_id)
 
@@ -974,7 +1127,8 @@ def _synthesize_character(entity_id, entity_name, events, catalog_data,
     # Assemble page
     page = assemble_character_page(
         entity_id, entity_name, lede, phase_texts,
-        catalog_data, derived_profile, arc_summaries, events)
+        catalog_data, derived_profile, arc_summaries, events,
+        name_index=name_index, source_type_dir=source_type_dir)
 
     # Provenance validation across all phases
     available = sorted(all_available_turns, key=_parse_turn_number)
@@ -996,13 +1150,16 @@ def _synthesize_character(entity_id, entity_name, events, catalog_data,
 
 
 def _synthesize_location(entity_id, entity_name, events, catalog_data,
-                         derived_profile, llm_client):
+                         derived_profile, llm_client, *,
+                         name_index=None, source_type_dir=None):
     """Synthesize a location page."""
     loc_input = assemble_location_input(entity_id, events, catalog_data)
     significance = generate_location_summary(llm_client, loc_input)
 
     page = assemble_location_page(entity_id, entity_name, significance,
-                                  catalog_data, derived_profile, events)
+                                  catalog_data, derived_profile, events,
+                                  name_index=name_index,
+                                  source_type_dir=source_type_dir)
 
     available_turns = set()
     for evt in events:
@@ -1022,13 +1179,16 @@ def _synthesize_location(entity_id, entity_name, events, catalog_data,
 
 
 def _synthesize_faction(entity_id, entity_name, events, catalog_data,
-                        derived_profile, llm_client):
+                        derived_profile, llm_client, *,
+                        name_index=None, source_type_dir=None):
     """Synthesize a faction page."""
     fac_input = assemble_faction_input(entity_id, events, catalog_data)
     history = generate_faction_history(llm_client, fac_input)
 
     page = assemble_faction_page(entity_id, entity_name, history,
-                                 catalog_data, derived_profile, events)
+                                 catalog_data, derived_profile, events,
+                                 name_index=name_index,
+                                 source_type_dir=source_type_dir)
 
     available_turns = set()
     for evt in events:
@@ -1048,13 +1208,16 @@ def _synthesize_faction(entity_id, entity_name, events, catalog_data,
 
 
 def _synthesize_item(entity_id, entity_name, events, catalog_data,
-                     derived_profile, llm_client):
+                     derived_profile, llm_client, *,
+                     name_index=None, source_type_dir=None):
     """Synthesize an item page."""
     item_input = assemble_item_input(entity_id, events, catalog_data)
     significance = generate_item_summary(llm_client, item_input)
 
     page = assemble_item_page(entity_id, entity_name, significance,
-                              catalog_data, derived_profile, events)
+                              catalog_data, derived_profile, events,
+                              name_index=name_index,
+                              source_type_dir=source_type_dir)
 
     available_turns = set()
     for evt in events:


### PR DESCRIPTION
## Summary

Adds cross-page markdown links to wiki pages generated by the LLM synthesis path.
The first mention of each known entity in biography prose, relationship tables, event
timelines, and member/connection lists becomes a clickable link to that entity's wiki page.

## Changes

### Structured sections (relationship tables, member lists)
- Pass `name_index` from `generate_wiki_pages.py` into synthesis assembly functions
- Replace `Name (entity-id)` format with `[Name](relative_path.md)` links in relationship tables, faction member lists, and location connected-entity lists

### Event timeline descriptions
- Use `related_entities` from event data to identify linkable entity names
- Replace first occurrence in description with markdown link

### Biography prose
- Post-process LLM biography text with name-matching pass
- Sort candidates by name length (longest first) to prevent partial matches
- Skip self-links, short names (<4 chars), and already-linked entities
- Guard against double-linking inside existing markdown links

### Safeguards
- Each entity linked at most once per page
- No self-links
- Names < 4 characters not auto-linked
- Longest-name-first matching prevents partial matches
- Names inside existing `[...]()` blocks are not double-linked

### Tests
- 33 new tests in `tests/test_cross_page_links.py` covering all link scenarios

### Documentation
- Updated `docs/architecture.md` with wiki cross-page link behavior

Closes #139
