### PR TITLE
fix: segmented extraction with reconciliation (#141)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,11 +26,15 @@ sessions/*/transcript/turn-NNN-dm.md     (immutable append)
       v                                          v
 tools/update_state.py                  tools/semantic_extraction.py  (optional, LLM)
       |                                          |
-      +---> sessions/*/derived/state.json        +---> framework/catalogs/characters.json
-      +---> sessions/*/derived/objectives.json   +---> framework/catalogs/locations.json
-      +---> sessions/*/derived/evidence.json     +---> framework/catalogs/factions.json
-      +---> sessions/*/derived/turn-summary.md   +---> framework/catalogs/items.json
-      |                                          +---> framework/catalogs/events.json
+      +---> sessions/*/derived/state.json        +--- single-pass (default)
+      +---> sessions/*/derived/objectives.json   |     +---> framework/catalogs/*.json
+      +---> sessions/*/derived/evidence.json     |
+      +---> sessions/*/derived/turn-summary.md   +--- segmented (--segment-size N)
+      |                                          |     +---> segment 1..K catalogs (fresh)
+      |                                          |     +---> reconcile_segments()
+      |                                          |     +---> framework/catalogs/*.json
+      |                                          |
+      v                                          +---> framework/catalogs/events.json
       v                                          |
       +------------------------------------------+
       |
@@ -101,6 +105,7 @@ An automated pipeline that uses an LLM to extract structured data from transcrip
 - All extracted entities are validated against `schemas/entity.schema.json` before merging
 - Entities below a confidence threshold are logged but not cataloged
 - Batch mode checkpoints progress every 50 turns for resume after interruption
+- **Segmented extraction** (`--segment-size N`): For long sessions (300+ turns), extraction runs in segments of N turns, each starting with a fresh catalog. This prevents context window saturation in the entity discovery prompt, which includes the full known-entities table. After all segments complete, a reconciliation pass merges entities by ID and name, stitches event timelines, and joins relationships across segment boundaries. Segment size should be tuned to the model's effective context capacity (recommended: 100-150 for 14B models with 32K context).
 - Birth events trigger automatic entity creation for named children, with child IDs added to event `related_entities`
 - Stub backfill gathers context from both `related_entities` references and entity name mentions in event descriptions
 - Biography sections use LLM-generated descriptive titles (not generic "Phase" labels), cached in `.synthesis.json` sidecars

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -79,6 +79,7 @@ Remaining work:
 - Batch processing mode for unattended overnight extraction
 - Provider setup documentation in `docs/usage.md`
 - Quality validation of `qwen2.5:7b` as a faster alternative to 14B
+- **Segmented extraction** (#141): Long sessions (300+ turns) are extracted in configurable segments to stay within model context limits. Each segment starts with a clean entity catalog; a reconciliation pass merges the results. Naturally parallelizable across GPU instances.
 
 Design implications for earlier phases:
 - Keep context loading modular (catalog-first) so smaller local models can handle targeted tasks

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -234,6 +234,29 @@ The pipeline processes each turn through four agents:
 
 Progress is checkpointed every 50 turns and can resume after interruption.
 
+### Segmented Extraction
+
+For sessions with 200+ turns on models with ≤32K context windows, use
+segmented extraction to prevent quality degradation in late turns:
+
+```bash
+python tools/bootstrap_session.py \
+  --session sessions/session-001 \
+  --file sessions/_import/session-001-full-transcript.txt \
+  --segment-size 100
+```
+
+Each segment processes turns with a fresh entity catalog. After all segments
+complete, entities are automatically reconciled across segment boundaries by
+ID and name matching.
+
+Recommended segment sizes:
+- 7B models (8K context): 50 turns
+- 14B models (32K context): 100-150 turns
+- 70B+ models (128K context): 300+ turns (may not need segmentation)
+
+Segment size 0 (the default) preserves legacy single-pass behavior.
+
 ### Incremental Mode (Ingest)
 
 Pass `--extract` to `ingest_turn.py` to run semantic extraction on a single new turn:

--- a/tests/test_segmented_extraction.py
+++ b/tests/test_segmented_extraction.py
@@ -1,0 +1,327 @@
+"""Tests for segmented extraction with reconciliation (#141)."""
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from semantic_extraction import (
+    _find_canonical,
+    _merge_entity_across_segments,
+    _dedup_events,
+    _reconcile_segments,
+    _extract_segmented,
+    _ensure_player_character,
+    extract_semantic_batch,
+    _V1_FILENAMES,
+)
+
+
+def _make_entity(id_, name, turn="turn-001", etype="character", identity="", notes=""):
+    return {
+        "id": id_,
+        "name": name,
+        "type": etype,
+        "first_seen_turn": turn,
+        "last_updated_turn": turn,
+        "identity": identity,
+        "current_status": "active",
+        "stable_attributes": {},
+        "relationships": [],
+        "notes": notes,
+    }
+
+
+def _make_event(eid, desc, source_turn, related=None):
+    return {
+        "id": eid,
+        "description": desc,
+        "source_turns": [source_turn],
+        "related_entities": related or [],
+    }
+
+
+def _make_segment(seg_id, catalogs, events, turn_range):
+    return {
+        "id": seg_id,
+        "catalogs": catalogs,
+        "events": events,
+        "turn_range": turn_range,
+    }
+
+
+# --- _find_canonical ---
+
+def test_find_canonical_by_id():
+    entity_map = {"char-kael": _make_entity("char-kael", "Kael")}
+    result = _find_canonical("char-kael", "kael", entity_map, {})
+    assert result == "char-kael"
+
+
+def test_find_canonical_by_alias():
+    entity_map = {"char-kael": _make_entity("char-kael", "Kael")}
+    id_aliases = {"char-kael-2": "char-kael"}
+    result = _find_canonical("char-kael-2", "kael", entity_map, id_aliases)
+    assert result == "char-kael"
+
+
+def test_find_canonical_by_name():
+    entity_map = {"char-kael": _make_entity("char-kael", "Kael")}
+    result = _find_canonical("char-kael-warrior", "kael", entity_map, {})
+    assert result == "char-kael"
+
+
+def test_find_canonical_not_found():
+    entity_map = {"char-kael": _make_entity("char-kael", "Kael")}
+    result = _find_canonical("char-renn", "renn", entity_map, {})
+    assert result is None
+
+
+def test_find_canonical_empty_name_no_false_match():
+    entity_map = {"char-kael": _make_entity("char-kael", "")}
+    result = _find_canonical("char-other", "", entity_map, {})
+    assert result is None
+
+
+# --- _merge_entity_across_segments ---
+
+def test_merge_prefers_non_stub_identity():
+    target = _make_entity("char-kael", "Kael", "turn-001", identity="stub — discovered turn-001")
+    source = _make_entity("char-kael", "Kael", "turn-150", identity="A fierce warrior and leader of the settlement guard.")
+    _merge_entity_across_segments(target, source)
+    assert target["identity"] == "A fierce warrior and leader of the settlement guard."
+
+
+def test_merge_preserves_first_seen_turn():
+    target = _make_entity("char-kael", "Kael", "turn-050")
+    source = _make_entity("char-kael", "Kael", "turn-150")
+    _merge_entity_across_segments(target, source)
+    assert target["first_seen_turn"] == "turn-050"
+    assert target["last_updated_turn"] == "turn-150"
+
+
+def test_merge_updates_first_seen_if_earlier():
+    target = _make_entity("char-kael", "Kael", "turn-050")
+    source = _make_entity("char-kael", "Kael", "turn-010")
+    _merge_entity_across_segments(target, source)
+    assert target["first_seen_turn"] == "turn-010"
+
+
+def test_merge_current_status_from_later_segment():
+    target = _make_entity("char-kael", "Kael", "turn-050")
+    target["current_status"] = "active"
+    source = _make_entity("char-kael", "Kael", "turn-150")
+    source["current_status"] = "injured"
+    _merge_entity_across_segments(target, source)
+    assert target["current_status"] == "injured"
+
+
+def test_merge_stable_attributes_union():
+    target = _make_entity("char-kael", "Kael", "turn-050")
+    target["stable_attributes"] = {"race": "human"}
+    source = _make_entity("char-kael", "Kael", "turn-150")
+    source["stable_attributes"] = {"class": "warrior", "race": ""}
+    _merge_entity_across_segments(target, source)
+    assert target["stable_attributes"]["race"] == "human"
+    assert target["stable_attributes"]["class"] == "warrior"
+
+
+def test_merge_relationships_dedup():
+    target = _make_entity("char-kael", "Kael", "turn-050")
+    target["relationships"] = [{"target_id": "char-player", "type": "ally"}]
+    source = _make_entity("char-kael", "Kael", "turn-150")
+    source["relationships"] = [
+        {"target_id": "char-player", "type": "ally"},
+        {"target_id": "char-renn", "type": "friend"},
+    ]
+    _merge_entity_across_segments(target, source)
+    assert len(target["relationships"]) == 2
+    targets = {r["target_id"] for r in target["relationships"]}
+    assert targets == {"char-player", "char-renn"}
+
+
+def test_merge_replaces_stub_notes():
+    target = _make_entity("char-kael", "Kael", notes="Stub entity — needs enrichment")
+    source = _make_entity("char-kael", "Kael", notes="Guard captain of the northern settlement.")
+    _merge_entity_across_segments(target, source)
+    assert target["notes"] == "Guard captain of the northern settlement."
+
+
+# --- _dedup_events ---
+
+def test_dedup_events_removes_duplicates():
+    events = [
+        _make_event("evt-001", "Kael draws his sword", "turn-050"),
+        _make_event("evt-002", "Kael draws his sword", "turn-050"),
+        _make_event("evt-003", "Renn casts a spell", "turn-051"),
+    ]
+    result = _dedup_events(events)
+    assert len(result) == 2
+    descs = [e["description"] for e in result]
+    assert "Kael draws his sword" in descs
+    assert "Renn casts a spell" in descs
+
+
+def test_dedup_events_keeps_same_desc_different_turns():
+    events = [
+        _make_event("evt-001", "Combat begins", "turn-050"),
+        _make_event("evt-002", "Combat begins", "turn-150"),
+    ]
+    result = _dedup_events(events)
+    assert len(result) == 2
+
+
+# --- _reconcile_segments ---
+
+def test_reconcile_same_entity_across_segments():
+    seg1_catalogs = {
+        "characters.json": [_make_entity("char-kael", "Kael", "turn-001")],
+        "locations.json": [], "factions.json": [], "items.json": [],
+    }
+    seg2_catalogs = {
+        "characters.json": [_make_entity("char-kael", "Kael", "turn-150")],
+        "locations.json": [], "factions.json": [], "items.json": [],
+    }
+    segments = [
+        _make_segment("segment-1", seg1_catalogs, [], ("turn-001", "turn-100")),
+        _make_segment("segment-2", seg2_catalogs, [], ("turn-101", "turn-200")),
+    ]
+    catalogs, events = _reconcile_segments(segments)
+    # Should merge into one Kael entry
+    all_chars = catalogs["characters.json"]
+    kael_entries = [e for e in all_chars if e["name"] == "Kael"]
+    assert len(kael_entries) == 1
+    assert kael_entries[0]["first_seen_turn"] == "turn-001"
+    assert kael_entries[0]["last_updated_turn"] == "turn-150"
+
+
+def test_reconcile_new_entity_in_later_segment():
+    seg1_catalogs = {
+        "characters.json": [_make_entity("char-kael", "Kael", "turn-001")],
+        "locations.json": [], "factions.json": [], "items.json": [],
+    }
+    seg2_catalogs = {
+        "characters.json": [_make_entity("char-renn", "Renn", "turn-310")],
+        "locations.json": [], "factions.json": [], "items.json": [],
+    }
+    segments = [
+        _make_segment("segment-1", seg1_catalogs, [], ("turn-001", "turn-100")),
+        _make_segment("segment-2", seg2_catalogs, [], ("turn-301", "turn-345")),
+    ]
+    catalogs, events = _reconcile_segments(segments)
+    all_chars = catalogs["characters.json"]
+    names = {e["name"] for e in all_chars}
+    assert "Kael" in names
+    assert "Renn" in names
+
+
+def test_reconcile_preserves_first_seen_turn():
+    seg1_catalogs = {
+        "characters.json": [_make_entity("char-kael", "Kael", "turn-005")],
+        "locations.json": [], "factions.json": [], "items.json": [],
+    }
+    seg2_catalogs = {
+        "characters.json": [_make_entity("char-kael", "Kael", "turn-120")],
+        "locations.json": [], "factions.json": [], "items.json": [],
+    }
+    segments = [
+        _make_segment("segment-1", seg1_catalogs, [], ("turn-001", "turn-100")),
+        _make_segment("segment-2", seg2_catalogs, [], ("turn-101", "turn-200")),
+    ]
+    catalogs, events = _reconcile_segments(segments)
+    kael = [e for e in catalogs["characters.json"] if e["name"] == "Kael"][0]
+    assert kael["first_seen_turn"] == "turn-005"
+
+
+def test_reconcile_events_deduplicated():
+    seg1_events = [_make_event("evt-001", "Kael draws his sword", "turn-050")]
+    seg2_events = [_make_event("evt-010", "Kael draws his sword", "turn-050")]
+    seg1_catalogs = {fn: [] for fn in _V1_FILENAMES}
+    seg2_catalogs = {fn: [] for fn in _V1_FILENAMES}
+    segments = [
+        _make_segment("segment-1", seg1_catalogs, seg1_events, ("turn-001", "turn-100")),
+        _make_segment("segment-2", seg2_catalogs, seg2_events, ("turn-101", "turn-200")),
+    ]
+    catalogs, events = _reconcile_segments(segments)
+    assert len(events) == 1
+
+
+def test_reconcile_event_entity_ids_rewritten():
+    seg1_catalogs = {
+        "characters.json": [_make_entity("char-kael", "Kael", "turn-001")],
+        "locations.json": [], "factions.json": [], "items.json": [],
+    }
+    seg2_catalogs = {
+        "characters.json": [_make_entity("char-kael-warrior", "Kael", "turn-150")],
+        "locations.json": [], "factions.json": [], "items.json": [],
+    }
+    seg2_events = [
+        _make_event("evt-010", "Kael fights", "turn-150", related=["char-kael-warrior"]),
+    ]
+    segments = [
+        _make_segment("segment-1", seg1_catalogs, [], ("turn-001", "turn-100")),
+        _make_segment("segment-2", seg2_catalogs, seg2_events, ("turn-101", "turn-200")),
+    ]
+    catalogs, events = _reconcile_segments(segments)
+    # char-kael-warrior should be aliased to char-kael
+    assert events[0]["related_entities"] == ["char-kael"]
+
+
+def test_segment_size_zero_uses_legacy(monkeypatch):
+    """segment_size=0 should NOT call _extract_segmented."""
+    calls = []
+
+    def mock_extract_segmented(*a, **kw):
+        calls.append(1)
+
+    monkeypatch.setattr("semantic_extraction._extract_segmented", mock_extract_segmented)
+
+    # Also mock LLMClient to avoid needing config
+    from unittest.mock import MagicMock
+    monkeypatch.setattr("semantic_extraction.LLMClient", lambda *a, **kw: MagicMock())
+    monkeypatch.setattr("semantic_extraction.load_catalogs", lambda d: {fn: [] for fn in _V1_FILENAMES})
+    monkeypatch.setattr("semantic_extraction.load_events", lambda d: [])
+    monkeypatch.setattr("semantic_extraction.save_catalogs", lambda *a, **kw: None)
+    monkeypatch.setattr("semantic_extraction.save_events", lambda *a, **kw: None)
+    monkeypatch.setattr("semantic_extraction.extract_and_merge", lambda *a, **kw: ({fn: [] for fn in _V1_FILENAMES}, []))
+    monkeypatch.setattr("semantic_extraction._dedup_catalogs", lambda cats: (0, {}))
+    monkeypatch.setattr("semantic_extraction._post_batch_orphan_sweep", lambda cats, evts: 0)
+
+    turns = [{"turn_id": f"turn-{i:03d}", "speaker": "dm", "text": "hello"} for i in range(1, 11)]
+    extract_semantic_batch(turns, "sessions/test", dry_run=True, segment_size=0)
+    assert len(calls) == 0
+
+
+def test_segment_size_partitions_correctly():
+    """345 turns with segment_size=100 → 4 segments (100, 100, 100, 45)."""
+    turns = [{"turn_id": f"turn-{i:03d}", "speaker": "dm", "text": "text"} for i in range(1, 346)]
+    segment_size = 100
+
+    # Compute partitions the same way _extract_segmented does
+    segments = []
+    for start in range(0, len(turns), segment_size):
+        end = min(start + segment_size, len(turns))
+        segments.append(turns[start:end])
+
+    assert len(segments) == 4
+    assert len(segments[0]) == 100
+    assert len(segments[1]) == 100
+    assert len(segments[2]) == 100
+    assert len(segments[3]) == 45
+
+
+def test_player_character_seeded_each_segment():
+    """char-player should be seeded in every segment's catalog."""
+    seg_catalogs = {fn: [] for fn in _V1_FILENAMES}
+    _ensure_player_character(seg_catalogs, "turn-101")
+    chars = seg_catalogs["characters.json"]
+    pc = [e for e in chars if e["id"] == "char-player"]
+    assert len(pc) == 1
+    assert pc[0]["first_seen_turn"] == "turn-101"
+
+    # Second segment
+    seg_catalogs2 = {fn: [] for fn in _V1_FILENAMES}
+    _ensure_player_character(seg_catalogs2, "turn-201")
+    chars2 = seg_catalogs2["characters.json"]
+    pc2 = [e for e in chars2 if e["id"] == "char-player"]
+    assert len(pc2) == 1
+    assert pc2[0]["first_seen_turn"] == "turn-201"

--- a/tests/test_segmented_extraction.py
+++ b/tests/test_segmented_extraction.py
@@ -5,11 +5,12 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
 from semantic_extraction import (
+    _compare_turns,
     _find_canonical,
+    _is_empty_attr_value,
     _merge_entity_across_segments,
     _dedup_events,
     _reconcile_segments,
-    _extract_segmented,
     _ensure_player_character,
     extract_semantic_batch,
     _V1_FILENAMES,
@@ -125,18 +126,82 @@ def test_merge_stable_attributes_union():
     assert target["stable_attributes"]["class"] == "warrior"
 
 
+def test_merge_stable_attributes_v2_format():
+    """V2 dict-format stable_attributes are merged correctly."""
+    target = _make_entity("char-kael", "Kael", "turn-050")
+    target["stable_attributes"] = {
+        "race": {"value": "human", "source_turn": "turn-010"},
+    }
+    source = _make_entity("char-kael", "Kael", "turn-150")
+    source["stable_attributes"] = {
+        "class": {"value": "warrior", "source_turn": "turn-120"},
+        "race": {"value": "", "source_turn": "turn-005"},
+    }
+    _merge_entity_across_segments(target, source)
+    assert target["stable_attributes"]["race"]["value"] == "human"
+    assert target["stable_attributes"]["class"]["value"] == "warrior"
+
+
+def test_merge_stable_attributes_v2_newer_wins():
+    """V2 attr with later source_turn replaces earlier one."""
+    target = _make_entity("char-kael", "Kael", "turn-050")
+    target["stable_attributes"] = {
+        "role": {"value": "scout", "source_turn": "turn-010"},
+    }
+    source = _make_entity("char-kael", "Kael", "turn-150")
+    source["stable_attributes"] = {
+        "role": {"value": "captain", "source_turn": "turn-130"},
+    }
+    _merge_entity_across_segments(target, source)
+    assert target["stable_attributes"]["role"]["value"] == "captain"
+    assert target["stable_attributes"]["role"]["source_turn"] == "turn-130"
+
+
 def test_merge_relationships_dedup():
     target = _make_entity("char-kael", "Kael", "turn-050")
-    target["relationships"] = [{"target_id": "char-player", "type": "ally"}]
+    target["relationships"] = [
+        {"target_id": "char-player", "type": "social",
+         "current_relationship": "ally", "first_seen_turn": "turn-050",
+         "last_updated_turn": "turn-050"},
+    ]
     source = _make_entity("char-kael", "Kael", "turn-150")
     source["relationships"] = [
-        {"target_id": "char-player", "type": "ally"},
-        {"target_id": "char-renn", "type": "friend"},
+        {"target_id": "char-player", "type": "social",
+         "current_relationship": "trusted ally", "first_seen_turn": "turn-050",
+         "last_updated_turn": "turn-150"},
+        {"target_id": "char-renn", "type": "social",
+         "current_relationship": "friend", "first_seen_turn": "turn-120",
+         "last_updated_turn": "turn-120"},
     ]
     _merge_entity_across_segments(target, source)
     assert len(target["relationships"]) == 2
     targets = {r["target_id"] for r in target["relationships"]}
     assert targets == {"char-player", "char-renn"}
+
+
+def test_merge_relationships_updates_existing():
+    """Existing relationships are updated with later segment data."""
+    target = _make_entity("char-kael", "Kael", "turn-050")
+    target["relationships"] = [
+        {"target_id": "char-player", "type": "social",
+         "current_relationship": "ally", "first_seen_turn": "turn-050",
+         "last_updated_turn": "turn-050", "history": [
+             {"turn": "turn-050", "description": "Met during patrol"},
+         ]},
+    ]
+    source = _make_entity("char-kael", "Kael", "turn-150")
+    source["relationships"] = [
+        {"target_id": "char-player", "type": "social",
+         "current_relationship": "trusted ally", "first_seen_turn": "turn-050",
+         "last_updated_turn": "turn-150", "history": [
+             {"turn": "turn-150", "description": "Fought together in battle"},
+         ]},
+    ]
+    _merge_entity_across_segments(target, source)
+    rel = target["relationships"][0]
+    assert rel["current_relationship"] == "trusted ally"
+    assert rel["last_updated_turn"] == "turn-150"
+    assert len(rel["history"]) == 2
 
 
 def test_merge_replaces_stub_notes():
@@ -325,3 +390,89 @@ def test_player_character_seeded_each_segment():
     pc2 = [e for e in chars2 if e["id"] == "char-player"]
     assert len(pc2) == 1
     assert pc2[0]["first_seen_turn"] == "turn-201"
+
+
+# --- _compare_turns (numeric comparison) ---
+
+def test_compare_turns_numeric():
+    assert _compare_turns("turn-999", "turn-1000") < 0
+    assert _compare_turns("turn-1000", "turn-999") > 0
+    assert _compare_turns("turn-100", "turn-100") == 0
+
+
+def test_compare_turns_three_digit_padding():
+    assert _compare_turns("turn-010", "turn-050") < 0
+    assert _compare_turns("turn-345", "turn-100") > 0
+
+
+# --- Type-aware _find_canonical ---
+
+def test_find_canonical_type_mismatch_no_merge():
+    """Same name but different type should NOT match."""
+    entity_map = {
+        "loc-haven": _make_entity("loc-haven", "Haven", etype="location"),
+    }
+    result = _find_canonical("item-haven", "haven", entity_map, {})
+    assert result is None
+
+
+def test_find_canonical_type_match_succeeds():
+    """Same name and same type should match."""
+    entity_map = {
+        "char-kael": _make_entity("char-kael", "Kael", etype="character"),
+    }
+    result = _find_canonical("char-kael-warrior", "kael", entity_map, {})
+    assert result == "char-kael"
+
+
+# --- Reconciliation: relationship alias rewriting ---
+
+def test_reconcile_rewrites_relationship_target_ids():
+    """After reconciliation, relationship target_ids should use canonical IDs."""
+    seg1_catalogs = {
+        "characters.json": [
+            _make_entity("char-kael", "Kael", "turn-001"),
+            _make_entity("char-renn", "Renn", "turn-020"),
+        ],
+        "locations.json": [], "factions.json": [], "items.json": [],
+    }
+    seg2_entity = _make_entity("char-kael-warrior", "Kael", "turn-150")
+    seg2_entity["relationships"] = [
+        {"target_id": "char-renn-scout", "type": "social",
+         "current_relationship": "ally", "first_seen_turn": "turn-150"},
+    ]
+    seg2_catalogs = {
+        "characters.json": [
+            seg2_entity,
+            _make_entity("char-renn-scout", "Renn", "turn-150"),
+        ],
+        "locations.json": [], "factions.json": [], "items.json": [],
+    }
+    segments = [
+        _make_segment("segment-1", seg1_catalogs, [], ("turn-001", "turn-100")),
+        _make_segment("segment-2", seg2_catalogs, [], ("turn-101", "turn-200")),
+    ]
+    catalogs, events = _reconcile_segments(segments)
+    kael = [e for e in catalogs["characters.json"] if e["id"] == "char-kael"][0]
+    rel_targets = {r["target_id"] for r in kael.get("relationships", [])}
+    # char-renn-scout should have been rewritten to char-renn
+    assert "char-renn" in rel_targets
+    assert "char-renn-scout" not in rel_targets
+
+
+# --- Event numeric sort ---
+
+def test_reconcile_events_sorted_numerically():
+    """Events should sort by turn number, not lexicographically."""
+    events_input = [
+        _make_event("evt-001", "Event at 999", "turn-999"),
+        _make_event("evt-002", "Event at 1000", "turn-1000"),
+        _make_event("evt-003", "Event at 50", "turn-050"),
+    ]
+    seg_catalogs = {fn: [] for fn in _V1_FILENAMES}
+    segments = [
+        _make_segment("segment-1", seg_catalogs, events_input, ("turn-001", "turn-1000")),
+    ]
+    catalogs, events = _reconcile_segments(segments)
+    turn_order = [e.get("source_turns", [""])[0] for e in events]
+    assert turn_order == ["turn-050", "turn-999", "turn-1000"]

--- a/tests/test_segmented_extraction.py
+++ b/tests/test_segmented_extraction.py
@@ -7,7 +7,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 from semantic_extraction import (
     _compare_turns,
     _find_canonical,
-    _is_empty_attr_value,
     _merge_entity_across_segments,
     _dedup_events,
     _reconcile_segments,

--- a/tools/bootstrap_session.py
+++ b/tools/bootstrap_session.py
@@ -480,6 +480,13 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Skip the stub backfill pass after extraction.",
     )
+    parser.add_argument(
+        "--segment-size",
+        type=int,
+        default=0,
+        help="Extract in segments of N turns with fresh catalogs, then reconcile. "
+             "0 = no segmentation (legacy behavior). Recommended: 100-150 for 14B models.",
+    )
     return parser
 
 
@@ -662,6 +669,7 @@ def main() -> None:
         extract_semantic_batch(
             turn_dicts, session_dir, framework_dir=args.framework, dry_run=args.dry_run,
             overrides=llm_overrides or None,
+            segment_size=args.segment_size,
         )
 
         # Stub backfill pass (#128, #131 — now runs by default)

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -1771,33 +1771,71 @@ def _merge_pc_aliases(
 # Segmented extraction helpers (#141)
 # ---------------------------------------------------------------------------
 
+def _compare_turns(turn_a, turn_b):
+    """Compare two turn IDs numerically. Returns -1, 0, or 1.
+
+    Falls back to string comparison if parsing fails.
+    """
+    na = _parse_turn_number(turn_a)
+    nb = _parse_turn_number(turn_b)
+    if na is not None and nb is not None:
+        return (na > nb) - (na < nb)
+    # Fallback to string comparison for non-standard turn IDs
+    return (turn_a > turn_b) - (turn_a < turn_b)
+
+
 def _find_canonical(eid, ename, entity_map, id_aliases):
-    """Find canonical entity ID matching by ID or name."""
+    """Find canonical entity ID matching by ID or name within the same entity type."""
     # Direct ID match
     if eid in entity_map:
         return eid
     # Alias match
     if eid in id_aliases:
         return id_aliases[eid]
-    # Name match (case-insensitive) against existing entities
+
+    normalized_name = (ename or "").strip().lower()
+    if not normalized_name:
+        return None
+
+    incoming_type = _infer_type_from_prefix(eid) if eid else None
+    name_matches = []
+
+    # Name match (case-insensitive) against existing entities, scoped by type
     for existing_id, existing_entity in entity_map.items():
-        if existing_entity.get("name", "").lower() == ename and ename:
-            return existing_id
+        existing_name = existing_entity.get("name", "").strip().lower()
+        if existing_name != normalized_name:
+            continue
+
+        existing_type = existing_entity.get("type") or _infer_type_from_prefix(existing_id)
+        if incoming_type:
+            if existing_type == incoming_type:
+                return existing_id
+        else:
+            name_matches.append(existing_id)
+
+    # If the incoming ID does not reveal a type, only accept an unambiguous match
+    if len(name_matches) == 1:
+        return name_matches[0]
     return None
+
+
+def _is_empty_attr_value(value):
+    """Check if a stable_attribute value is empty/missing."""
+    return value is None or value == "" or value == [] or value == {}
 
 
 def _merge_entity_across_segments(target, source):
     """Merge a source entity into a target entity from a different segment."""
-    # Update last_updated_turn to the later of the two
+    # Update last_updated_turn to the later of the two (numeric comparison)
     src_turn = source.get("last_updated_turn", "")
     tgt_turn = target.get("last_updated_turn", "")
-    if src_turn > tgt_turn:
+    if _compare_turns(src_turn, tgt_turn) > 0:
         target["last_updated_turn"] = src_turn
 
-    # Update first_seen_turn to the earlier of the two
+    # Update first_seen_turn to the earlier of the two (numeric comparison)
     src_first = source.get("first_seen_turn", "")
     tgt_first = target.get("first_seen_turn", "")
-    if src_first and (not tgt_first or src_first < tgt_first):
+    if src_first and (not tgt_first or _compare_turns(src_first, tgt_first) < 0):
         target["first_seen_turn"] = src_first
 
     # Merge identity — prefer longer/non-stub
@@ -1807,23 +1845,77 @@ def _merge_entity_across_segments(target, source):
         target["identity"] = src_identity
 
     # Merge current_status — prefer the later segment's
-    if source.get("current_status") and src_turn >= tgt_turn:
+    if source.get("current_status") and _compare_turns(src_turn, tgt_turn) >= 0:
         target["current_status"] = source["current_status"]
 
-    # Merge stable_attributes — union, prefer non-empty values
+    # Merge stable_attributes — handles both V1 scalar and V2 dict formats
     src_attrs = source.get("stable_attributes", {})
     tgt_attrs = target.setdefault("stable_attributes", {})
     for key, val in src_attrs.items():
-        if key not in tgt_attrs or not tgt_attrs[key]:
-            tgt_attrs[key] = val
+        tgt_val = tgt_attrs.get(key)
 
-    # Merge relationships — append new, skip duplicates
+        # V1 scalar format (backward compatibility)
+        if not isinstance(val, dict):
+            if key not in tgt_attrs or not tgt_val:
+                tgt_attrs[key] = val
+            continue
+
+        # V2 dict format: {value, inference, confidence, source_turn}
+        if key not in tgt_attrs or not isinstance(tgt_val, dict):
+            # Target missing or legacy scalar — take the full V2 object
+            if key not in tgt_attrs or not tgt_val or not _is_empty_attr_value(val.get("value")):
+                tgt_attrs[key] = dict(val)
+            continue
+
+        src_value = val.get("value")
+        tgt_value = tgt_val.get("value")
+        src_attr_turn = val.get("source_turn", "")
+        tgt_attr_turn = tgt_val.get("source_turn", "")
+
+        # Prefer non-empty source value when target is empty or source is newer
+        if not _is_empty_attr_value(src_value) and (
+            _is_empty_attr_value(tgt_value) or _compare_turns(src_attr_turn, tgt_attr_turn) >= 0
+        ):
+            merged_attr = dict(tgt_val)
+            merged_attr["value"] = src_value
+            for meta_key in ("inference", "confidence", "source_turn"):
+                if meta_key in val and val.get(meta_key) is not None:
+                    merged_attr[meta_key] = val[meta_key]
+            tgt_attrs[key] = merged_attr
+        else:
+            # Preserve existing value, but backfill missing provenance
+            for meta_key in ("inference", "confidence", "source_turn"):
+                if (
+                    meta_key not in tgt_val or tgt_val.get(meta_key) is None
+                ) and val.get(meta_key) is not None:
+                    tgt_val[meta_key] = val[meta_key]
+
+    # Merge relationships — update existing by target_id, append new
     src_rels = source.get("relationships", [])
     tgt_rels = target.setdefault("relationships", [])
-    existing_targets = {r.get("target_id") for r in tgt_rels}
+    tgt_rel_index = {r.get("target_id"): i for i, r in enumerate(tgt_rels)}
     for rel in src_rels:
-        if rel.get("target_id") not in existing_targets:
+        tid = rel.get("target_id")
+        if tid in tgt_rel_index:
+            # Merge into existing relationship
+            existing = tgt_rels[tgt_rel_index[tid]]
+            rel_src_turn = rel.get("last_updated_turn", "")
+            rel_tgt_turn = existing.get("last_updated_turn", "")
+            if _compare_turns(rel_src_turn, rel_tgt_turn) >= 0:
+                existing["current_relationship"] = rel.get(
+                    "current_relationship", existing.get("current_relationship", "")
+                )
+                existing["last_updated_turn"] = rel_src_turn or rel_tgt_turn
+            # Merge history entries
+            src_history = rel.get("history", [])
+            tgt_history = existing.setdefault("history", [])
+            existing_descs = {(h.get("turn"), h.get("description")) for h in tgt_history}
+            for h in src_history:
+                if (h.get("turn"), h.get("description")) not in existing_descs:
+                    tgt_history.append(h)
+        else:
             tgt_rels.append(rel)
+            tgt_rel_index[tid] = len(tgt_rels) - 1
 
     # Replace stub notes with real data
     if "stub" in target.get("notes", "").lower() and "stub" not in source.get("notes", "").lower():
@@ -1884,6 +1976,17 @@ def _reconcile_segments(segments):
                 ]
             merged_events.append(event_copy)
 
+    # Rewrite relationship target_ids through alias map in merged entities
+    if id_aliases:
+        for entity in entity_map.values():
+            for rel in entity.get("relationships", []):
+                tid = rel.get("target_id")
+                if tid and tid in id_aliases:
+                    rel["target_id"] = id_aliases[tid]
+                sid = rel.get("source_id")
+                if sid and sid in id_aliases:
+                    rel["source_id"] = id_aliases[sid]
+
     # Distribute merged entities back into catalog structure
     for eid, entity in entity_map.items():
         target_file = entity.pop("_catalog_file", None)
@@ -1895,8 +1998,14 @@ def _reconcile_segments(segments):
     # Deduplicate events by (source_turn, description hash)
     merged_events = _dedup_events(merged_events)
 
-    # Re-sort events by source_turn
-    merged_events.sort(key=lambda e: e.get("source_turns", [""])[0])
+    # Re-sort events by source_turn (numeric, not lexicographic)
+    merged_events.sort(
+        key=lambda e: (
+            _parse_turn_number(e.get("source_turns", [""])[0])
+            if _parse_turn_number(e.get("source_turns", [""])[0]) is not None
+            else float("inf")
+        )
+    )
 
     return merged_catalogs, merged_events
 
@@ -1954,10 +2063,12 @@ def _extract_segmented(
             "turn_range": (segment_turns[0]["turn_id"], segment_turns[-1]["turn_id"]),
         })
 
-        # Save checkpoint after each segment
+        # Save checkpoint after each segment — use separate progress key
+        # so an interrupted segmented run cannot confuse the legacy resume logic
         _save_progress(progress_file, segment_turns[-1]["turn_id"], total,
                        seg_catalogs, dry_run,
-                       metadata={"segment": segment_id, "mode": "segmented"})
+                       metadata={"segment": segment_id, "mode": "segmented",
+                                 "completed": False})
 
     # Reconcile all segments into a single catalog
     print(f"\n  === Reconciliation: merging {len(segments)} segments ===")
@@ -2046,17 +2157,21 @@ def extract_semantic_batch(
         try:
             with open(progress_file, "r", encoding="utf-8") as f:
                 progress = json.load(f)
-            last_completed = progress.get("last_completed_turn", "")
-            if last_completed:
-                for i, t in enumerate(turn_dicts):
-                    if t["turn_id"] == last_completed:
-                        start_from = i + 1
-                        break
-                if start_from > 0:
-                    print(f"  Resuming from turn {start_from + 1} (after {last_completed})")
-                    # Reload catalogs since they may have been partially written
-                    catalogs = load_catalogs(catalog_dir)
-                    events_list = load_events(catalog_dir)
+            # Ignore incomplete segmented checkpoints — catalogs won't be on disk
+            if progress.get("mode") == "segmented" and not progress.get("completed"):
+                pass
+            else:
+                last_completed = progress.get("last_completed_turn", "")
+                if last_completed:
+                    for i, t in enumerate(turn_dicts):
+                        if t["turn_id"] == last_completed:
+                            start_from = i + 1
+                            break
+                    if start_from > 0:
+                        print(f"  Resuming from turn {start_from + 1} (after {last_completed})")
+                        # Reload catalogs since they may have been partially written
+                        catalogs = load_catalogs(catalog_dir)
+                        events_list = load_events(catalog_dir)
         except (json.JSONDecodeError, KeyError):
             pass  # Corrupted progress file; start from beginning
 

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -34,6 +34,7 @@ from catalog_merger import (
     _infer_type_from_prefix,
     _strip_any_prefix,
     _levenshtein,
+    _V1_FILENAMES,
 )
 from llm_client import LLMClient, LLMExtractionError
 
@@ -1766,6 +1767,222 @@ def _merge_pc_aliases(
     return merged
 
 
+# ---------------------------------------------------------------------------
+# Segmented extraction helpers (#141)
+# ---------------------------------------------------------------------------
+
+def _find_canonical(eid, ename, entity_map, id_aliases):
+    """Find canonical entity ID matching by ID or name."""
+    # Direct ID match
+    if eid in entity_map:
+        return eid
+    # Alias match
+    if eid in id_aliases:
+        return id_aliases[eid]
+    # Name match (case-insensitive) against existing entities
+    for existing_id, existing_entity in entity_map.items():
+        if existing_entity.get("name", "").lower() == ename and ename:
+            return existing_id
+    return None
+
+
+def _merge_entity_across_segments(target, source):
+    """Merge a source entity into a target entity from a different segment."""
+    # Update last_updated_turn to the later of the two
+    src_turn = source.get("last_updated_turn", "")
+    tgt_turn = target.get("last_updated_turn", "")
+    if src_turn > tgt_turn:
+        target["last_updated_turn"] = src_turn
+
+    # Update first_seen_turn to the earlier of the two
+    src_first = source.get("first_seen_turn", "")
+    tgt_first = target.get("first_seen_turn", "")
+    if src_first and (not tgt_first or src_first < tgt_first):
+        target["first_seen_turn"] = src_first
+
+    # Merge identity — prefer longer/non-stub
+    src_identity = source.get("identity", "")
+    tgt_identity = target.get("identity", "")
+    if len(src_identity) > len(tgt_identity) and "stub" not in src_identity.lower():
+        target["identity"] = src_identity
+
+    # Merge current_status — prefer the later segment's
+    if source.get("current_status") and src_turn >= tgt_turn:
+        target["current_status"] = source["current_status"]
+
+    # Merge stable_attributes — union, prefer non-empty values
+    src_attrs = source.get("stable_attributes", {})
+    tgt_attrs = target.setdefault("stable_attributes", {})
+    for key, val in src_attrs.items():
+        if key not in tgt_attrs or not tgt_attrs[key]:
+            tgt_attrs[key] = val
+
+    # Merge relationships — append new, skip duplicates
+    src_rels = source.get("relationships", [])
+    tgt_rels = target.setdefault("relationships", [])
+    existing_targets = {r.get("target_id") for r in tgt_rels}
+    for rel in src_rels:
+        if rel.get("target_id") not in existing_targets:
+            tgt_rels.append(rel)
+
+    # Replace stub notes with real data
+    if "stub" in target.get("notes", "").lower() and "stub" not in source.get("notes", "").lower():
+        target["notes"] = source.get("notes", "")
+
+
+def _dedup_events(events):
+    """Remove duplicate events across segments."""
+    seen = set()
+    unique = []
+    for event in events:
+        # Key: first source_turn + normalized description
+        key_turn = event.get("source_turns", [""])[0]
+        key_desc = event.get("description", "")[:100].strip().lower()
+        key = (key_turn, key_desc)
+        if key not in seen:
+            seen.add(key)
+            unique.append(event)
+    return unique
+
+
+def _reconcile_segments(segments):
+    """Merge catalogs and events from multiple extraction segments."""
+    merged_catalogs = {fn: [] for fn in _V1_FILENAMES}
+    merged_events = []
+
+    # Entity reconciliation: match across segments by ID and name
+    entity_map = {}  # canonical_id -> merged entity
+    id_aliases = {}  # segment_id -> canonical_id
+
+    for seg in segments:
+        for filename, entities in seg["catalogs"].items():
+            for entity in entities:
+                eid = entity["id"]
+                ename = entity.get("name", "").lower()
+
+                # Check for existing entity by ID or name
+                canonical = _find_canonical(eid, ename, entity_map, id_aliases)
+
+                if canonical:
+                    # Merge into existing entity
+                    _merge_entity_across_segments(entity_map[canonical], entity)
+                    if eid != canonical:
+                        id_aliases[eid] = canonical
+                else:
+                    # New entity — add to map, record which catalog file it belongs to
+                    entry = entity.copy()
+                    entry["_catalog_file"] = filename
+                    entity_map[eid] = entry
+
+        # Accumulate events, rewriting entity IDs through alias map
+        for event in seg["events"]:
+            event_copy = event.copy()
+            # Rewrite related_entities through alias map
+            if "related_entities" in event_copy:
+                event_copy["related_entities"] = [
+                    id_aliases.get(eid, eid) for eid in event_copy["related_entities"]
+                ]
+            merged_events.append(event_copy)
+
+    # Distribute merged entities back into catalog structure
+    for eid, entity in entity_map.items():
+        target_file = entity.pop("_catalog_file", None)
+        if not target_file:
+            etype = entity.get("type", "character")
+            target_file = TYPE_TO_CATALOG_V1.get(etype, "characters.json")
+        merged_catalogs[target_file].append(entity)
+
+    # Deduplicate events by (source_turn, description hash)
+    merged_events = _dedup_events(merged_events)
+
+    # Re-sort events by source_turn
+    merged_events.sort(key=lambda e: e.get("source_turns", [""])[0])
+
+    return merged_catalogs, merged_events
+
+
+def _extract_segmented(
+    turn_dicts, session_dir, framework_dir, catalog_dir,
+    llm, min_confidence, dry_run, segment_size,
+):
+    """Extract in segments with fresh catalogs, then reconcile."""
+    segments = []
+    total = len(turn_dicts)
+    progress_file = os.path.join(session_dir, "derived", "extraction-progress.json")
+
+    for start in range(0, total, segment_size):
+        end = min(start + segment_size, total)
+        segment_turns = turn_dicts[start:end]
+        segment_id = f"segment-{start // segment_size + 1}"
+
+        print(
+            f"\n  === {segment_id}: turns {segment_turns[0]['turn_id']}"
+            f" \u2013 {segment_turns[-1]['turn_id']} ({len(segment_turns)} turns) ==="
+        )
+
+        # Fresh catalog for each segment
+        seg_catalogs = {fn: [] for fn in _V1_FILENAMES}
+        seg_events = []
+
+        # Pre-seed player character (always present)
+        _ensure_player_character(seg_catalogs, segment_turns[0]["turn_id"])
+
+        # Process this segment's turns
+        for i, turn in enumerate(segment_turns):
+            turn_id = turn["turn_id"]
+
+            if i % 25 == 0 and i > 0:
+                entities_now = sum(len(v) for v in seg_catalogs.values())
+                print(f"  ... {turn_id} ({start + i + 1}/{total}, {entities_now} entities)")
+
+            try:
+                seg_catalogs, seg_events = extract_and_merge(
+                    turn, seg_catalogs, seg_events, llm, min_confidence,
+                    catalog_dir=None,
+                )
+            except Exception as e:
+                print(f"  ERROR at {turn_id}: {e}", file=sys.stderr)
+                continue
+
+        seg_entity_count = sum(len(v) for v in seg_catalogs.values())
+        print(f"  {segment_id} complete: {seg_entity_count} entities, {len(seg_events)} events")
+
+        segments.append({
+            "id": segment_id,
+            "catalogs": seg_catalogs,
+            "events": seg_events,
+            "turn_range": (segment_turns[0]["turn_id"], segment_turns[-1]["turn_id"]),
+        })
+
+        # Save checkpoint after each segment
+        _save_progress(progress_file, segment_turns[-1]["turn_id"], total,
+                       seg_catalogs, dry_run,
+                       metadata={"segment": segment_id, "mode": "segmented"})
+
+    # Reconcile all segments into a single catalog
+    print(f"\n  === Reconciliation: merging {len(segments)} segments ===")
+    final_catalogs, final_events = _reconcile_segments(segments)
+
+    # Run standard post-batch passes on the reconciled result
+    dupes_merged, merge_map = _dedup_catalogs(final_catalogs)
+    if dupes_merged:
+        _rewrite_stale_ids(final_catalogs, final_events, merge_map)
+        print(f"  Post-reconciliation dedup merged {dupes_merged} duplicate(s)")
+
+    orphan_stubs = _post_batch_orphan_sweep(final_catalogs, final_events)
+    if orphan_stubs:
+        print(f"  Post-reconciliation orphan sweep: {orphan_stubs} stub(s)")
+
+    entities_final = sum(len(v) for v in final_catalogs.values())
+    print(f"  Segmented extraction complete: {entities_final} entities, {len(final_events)} events")
+
+    if not dry_run:
+        save_catalogs(catalog_dir, final_catalogs)
+        save_events(catalog_dir, final_events)
+        _save_progress(progress_file, turn_dicts[-1]["turn_id"] if turn_dicts else "",
+                       total, final_catalogs, dry_run=False, completed=True)
+
+
 def extract_semantic_batch(
     turn_dicts: list,
     session_dir: str,
@@ -1774,6 +1991,7 @@ def extract_semantic_batch(
     dry_run: bool = False,
     min_confidence: float = DEFAULT_MIN_CONFIDENCE,
     overrides: dict | None = None,
+    segment_size: int = 0,
 ) -> None:
     """Run semantic extraction over all turns in batch mode.
 
@@ -1791,6 +2009,8 @@ def extract_semantic_batch(
             ``base_url``. Any keys supplied here take precedence over values
             loaded from ``config_path``; settings not provided in ``overrides``
             continue to use the configuration file values.
+        segment_size: Extract in segments of N turns with fresh catalogs, then
+            reconcile. 0 = no segmentation (legacy behavior).
     """
     _reset_pc_failure_tracking()
 
@@ -1801,6 +2021,15 @@ def extract_semantic_batch(
         return
 
     catalog_dir = os.path.join(framework_dir, "catalogs")
+
+    # Segmented extraction: process in chunks with fresh catalogs, then reconcile
+    if segment_size > 0 and len(turn_dicts) > segment_size:
+        _extract_segmented(
+            turn_dicts, session_dir, framework_dir, catalog_dir,
+            llm, min_confidence, dry_run, segment_size,
+        )
+        return
+
     catalogs = load_catalogs(catalog_dir)
     events_list = load_events(catalog_dir)
 
@@ -1958,6 +2187,7 @@ def _save_progress(
     catalogs: dict,
     dry_run: bool,
     completed: bool = False,
+    metadata: dict | None = None,
 ) -> None:
     """Save extraction progress for resumption."""
     if dry_run:
@@ -1969,6 +2199,8 @@ def _save_progress(
         "entities_discovered": entities,
         "completed": completed,
     }
+    if metadata:
+        progress.update(metadata)
     os.makedirs(os.path.dirname(progress_file), exist_ok=True)
     with open(progress_file, "w", encoding="utf-8") as f:
         json.dump(progress, f, indent=2)


### PR DESCRIPTION
## Summary

Fixes late-turn entity discovery failures (#141) caused by context window saturation.
The entity discovery prompt includes the full known-entities catalog every turn with no
windowing. For sessions with 80+ entities, this degrades LLM attention quality in turns 300+,
causing entities like Renn and Finn to be completely missed.

## Solution: Segmented Extraction

Extraction runs in configurable segments (e.g., 100 turns each), each starting with a
fresh, empty catalog. After all segments complete, a reconciliation pass:

1. Merges entities across segments by ID and name matching
2. Stitches event timelines chronologically
3. Joins relationships across segment boundaries
4. Corrects `first_seen_turn` / `last_updated_turn` spans
5. Runs existing dedup passes (Levenshtein, token overlap, PC alias) on merged result

### CLI Usage

```bash
python tools/bootstrap_session.py \
  --session sessions/session-001 \
  --file sessions/_import/session-001-full-transcript.txt \
  --segment-size 100
```

Segment size = 0 (default) preserves legacy single-pass behavior.

## Changes

- `tools/semantic_extraction.py`: Added `_extract_segmented()`, `_reconcile_segments()`,
  `_find_canonical()`, `_merge_entity_across_segments()`, `_dedup_events()`
- `tools/bootstrap_session.py`: Added `--segment-size` CLI flag, wired through to
  `extract_semantic_batch()`
- `tests/test_segmented_extraction.py`: 22 tests covering reconciliation, dedup,
  entity merging, partitioning, and legacy mode fallback
- `docs/architecture.md`: Documented segmented extraction in data flow diagram and
  semantic extraction layer description
- `docs/roadmap.md`: Added segmented extraction milestone under Phase 3
- `docs/usage.md`: Added usage guide with recommended segment sizes per model

## Investigation Findings

Phase 1 instrumentation deferred — the test session has only 2 turns, insufficient for
context growth measurement. The implementation uses segment sizes calibrated from the
prompt's analysis: 100-150 turns for 14B models with 32K context keeps the discovery
prompt under ~16K tokens with 50% headroom.

Closes #141
