### PR TITLE
fix: normalize unprefixed season names to schema-compliant enums

### DIFF
--- a/tests/test_season_normalization.py
+++ b/tests/test_season_normalization.py
@@ -1,0 +1,59 @@
+"""Tests for timeline season normalization (#151)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from extract_structured_data import _normalize_timeline_season, extract_temporal_markers
+
+
+class TestNormalizeTimelineSeason:
+    def test_fall_maps_to_mid_autumn(self):
+        assert _normalize_timeline_season("fall") == "mid_autumn"
+
+    def test_winter_maps_to_mid_winter(self):
+        assert _normalize_timeline_season("winter") == "mid_winter"
+
+    def test_autumn_maps_to_mid_autumn(self):
+        assert _normalize_timeline_season("autumn") == "mid_autumn"
+
+    def test_spring_maps_to_mid_spring(self):
+        assert _normalize_timeline_season("spring") == "mid_spring"
+
+    def test_summer_maps_to_mid_summer(self):
+        assert _normalize_timeline_season("summer") == "mid_summer"
+
+    def test_early_fall_maps_to_early_autumn(self):
+        assert _normalize_timeline_season("early_fall") == "early_autumn"
+
+    def test_mid_winter_passthrough(self):
+        assert _normalize_timeline_season("mid_winter") == "mid_winter"
+
+    def test_late_spring_passthrough(self):
+        assert _normalize_timeline_season("late_spring") == "late_spring"
+
+    def test_case_insensitive(self):
+        assert _normalize_timeline_season("Spring") == "mid_spring"
+
+    def test_whitespace_stripped(self):
+        assert _normalize_timeline_season("  winter  ") == "mid_winter"
+
+
+class TestExtractTemporalMarkersSeasonEnum:
+    def test_fall_transition_produces_mid_autumn(self):
+        text = "As fall arrives, the leaves change color."
+        entries = extract_temporal_markers(text, "turn-100")
+        assert len(entries) == 1
+        assert entries[0]["season"] == "mid_autumn"
+
+    def test_winter_transition_produces_mid_winter(self):
+        text = "Winter sets in across the land."
+        entries = extract_temporal_markers(text, "turn-101")
+        assert len(entries) == 1
+        assert entries[0]["season"] == "mid_winter"
+
+    def test_autumn_transition_produces_mid_autumn(self):
+        text = "Autumn arrives with cool winds."
+        entries = extract_temporal_markers(text, "turn-102")
+        assert len(entries) == 1
+        assert entries[0]["season"] == "mid_autumn"

--- a/tests/test_season_normalization.py
+++ b/tests/test_season_normalization.py
@@ -38,6 +38,12 @@ class TestNormalizeTimelineSeason:
     def test_whitespace_stripped(self):
         assert _normalize_timeline_season("  winter  ") == "mid_winter"
 
+    def test_spaced_prefix_form(self):
+        assert _normalize_timeline_season("Early winter") == "early_winter"
+
+    def test_spaced_prefix_fall_to_autumn(self):
+        assert _normalize_timeline_season("Late fall") == "late_autumn"
+
 
 class TestExtractTemporalMarkersSeasonEnum:
     def test_fall_transition_produces_mid_autumn(self):
@@ -57,3 +63,15 @@ class TestExtractTemporalMarkersSeasonEnum:
         entries = extract_temporal_markers(text, "turn-102")
         assert len(entries) == 1
         assert entries[0]["season"] == "mid_autumn"
+
+    def test_early_winter_has_come_produces_early_winter(self):
+        text = "Early winter has come to the northern reaches."
+        entries = extract_temporal_markers(text, "turn-103")
+        assert len(entries) == 1
+        assert entries[0]["season"] == "early_winter"
+
+    def test_late_summer_settled_produces_late_summer(self):
+        text = "Late summer has settled over the valley."
+        entries = extract_temporal_markers(text, "turn-104")
+        assert len(entries) == 1
+        assert entries[0]["season"] == "late_summer"

--- a/tools/extract_structured_data.py
+++ b/tools/extract_structured_data.py
@@ -154,7 +154,7 @@ SEASON_TRANSITION_PATTERNS = [
         re.IGNORECASE,
     ),
     re.compile(
-        r"(?:(?:Early|Mid|Late)\s+)?(" + _SEASON_ALT + r")\s+"
+        r"((?:(?:Early|Mid|Late)\s+)?(?:" + _SEASON_ALT + r"))\s+"
         r"(?:has\s+)?(?:come|arrived|begun|settled)",
         re.IGNORECASE,
     ),
@@ -186,8 +186,10 @@ def _normalize_timeline_season(name: str) -> str:
 
     Unprefixed names get a ``mid_`` prefix; already-prefixed names are
     passed through (with ``fall`` → ``autumn`` correction).
+    Accepts both underscored (``early_winter``) and spaced (``Early winter``)
+    forms.
     """
-    name = name.strip().lower()
+    name = name.strip().lower().replace(" ", "_")
     for prefix in ("early_", "mid_", "late_"):
         if name.startswith(prefix):
             base = name[len(prefix):]

--- a/tools/extract_structured_data.py
+++ b/tools/extract_structured_data.py
@@ -172,6 +172,31 @@ def _normalize_season(name: str) -> str:
     return "fall" if name == "autumn" else name
 
 
+_SEASON_PREFIX_MAP = {
+    "spring": "mid_spring",
+    "summer": "mid_summer",
+    "fall": "mid_autumn",
+    "autumn": "mid_autumn",
+    "winter": "mid_winter",
+}
+
+
+def _normalize_timeline_season(name: str) -> str:
+    """Normalize season name to a timeline-schema-compliant enum value.
+
+    Unprefixed names get a ``mid_`` prefix; already-prefixed names are
+    passed through (with ``fall`` → ``autumn`` correction).
+    """
+    name = name.strip().lower()
+    for prefix in ("early_", "mid_", "late_"):
+        if name.startswith(prefix):
+            base = name[len(prefix):]
+            if base == "fall":
+                return f"{prefix}autumn"
+            return name
+    return _SEASON_PREFIX_MAP.get(name, name)
+
+
 def _detect_year(text: str) -> int | None:
     """Try to extract an in-game year number from text."""
     m = YEAR_PATTERN_NUMERIC.search(text)
@@ -196,7 +221,7 @@ def extract_temporal_markers(
 
     for pattern in SEASON_TRANSITION_PATTERNS:
         for m in pattern.finditer(text):
-            season = _normalize_season(m.group(1))
+            season = _normalize_timeline_season(m.group(1))
             if season in seen_seasons:
                 continue
             seen_seasons.add(season)


### PR DESCRIPTION
## Summary

Fixes timeline season enum mismatch where LLM produces "fall"/"winter" instead of "mid_autumn"/"mid_winter", causing schema validation failures in `timeline.json`.

## Issue #151 — Timeline season enum mismatch

- Added `_normalize_timeline_season()` that maps unprefixed seasons to `mid_` prefixed values (e.g. "fall" → "mid_autumn", "winter" → "mid_winter")
- Handles "fall" → "mid_autumn" and "autumn" → "mid_autumn" normalization
- Preserves already-prefixed values like "early_winter" and corrects "early_fall" → "early_autumn"
- Applied in `extract_temporal_markers()` for timeline entries only
- Kept `_normalize_season()` unchanged for season summaries (which use the plain `season-summary.schema.json` enum)
- Added 13 tests covering normalization and integration with `extract_temporal_markers()`

Closes #151
