### PR TITLE
fix: clear stub-marker notes after entity enrichment

### DIFF
--- a/tests/test_stub_notes_cleanup.py
+++ b/tests/test_stub_notes_cleanup.py
@@ -1,0 +1,115 @@
+"""Tests for stub note cleanup (#152)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from semantic_extraction import _clear_stub_notes
+
+
+class TestClearStubNotes:
+    """Unit tests for _clear_stub_notes()."""
+
+    def test_clears_event_stub_note(self):
+        entity = {"notes": "Auto-created by event-stub.", "identity": "A real identity"}
+        assert _clear_stub_notes(entity) is True
+        assert entity["notes"] == ""
+
+    def test_clears_backfilled_from_stub_note(self):
+        entity = {"notes": "Backfilled from stub.", "identity": "A real identity"}
+        assert _clear_stub_notes(entity) is True
+        assert entity["notes"] == ""
+
+    def test_clears_orphan_sweep_note(self):
+        entity = {"notes": "Auto-created by post-batch orphan sweep.", "identity": "Some identity"}
+        assert _clear_stub_notes(entity) is True
+        assert entity["notes"] == ""
+
+    def test_preserves_non_stub_notes(self):
+        entity = {"notes": "Important lore detail about this character.", "identity": "A wizard"}
+        assert _clear_stub_notes(entity) is False
+        assert entity["notes"] == "Important lore detail about this character."
+
+    def test_returns_false_for_empty_notes(self):
+        entity = {"notes": "", "identity": "Some identity"}
+        assert _clear_stub_notes(entity) is False
+
+    def test_returns_false_for_missing_notes(self):
+        entity = {"identity": "Some identity"}
+        assert _clear_stub_notes(entity) is False
+
+    def test_case_insensitive_match(self):
+        entity = {"notes": "AUTO-CREATED BY EVENT-STUB.", "identity": "Real"}
+        assert _clear_stub_notes(entity) is True
+        assert entity["notes"] == ""
+
+    def test_match_without_trailing_period(self):
+        entity = {"notes": "Auto-created by event-stub", "identity": "Real"}
+        assert _clear_stub_notes(entity) is True
+        assert entity["notes"] == ""
+
+    def test_match_with_whitespace(self):
+        entity = {"notes": "  Auto-created by event-stub.  ", "identity": "Real"}
+        assert _clear_stub_notes(entity) is True
+        assert entity["notes"] == ""
+
+
+class TestBackfillSweepClearsStubNotes:
+    """Integration-style test: the sweep after backfill clears enriched entities."""
+
+    def test_sweep_clears_enriched_entities(self):
+        """Enriched entities (identity=truthy) should have stub notes cleared."""
+        catalogs = {
+            "characters.json": [
+                {
+                    "id": "char-enriched",
+                    "name": "Enriched NPC",
+                    "identity": "A powerful wizard",
+                    "notes": "Backfilled from stub.",
+                },
+                {
+                    "id": "char-still-stub",
+                    "name": "Unknown NPC",
+                    "identity": "",
+                    "notes": "Auto-created by event-stub.",
+                },
+            ]
+        }
+
+        # Simulate the sweep logic from backfill_stubs
+        for entities in catalogs.values():
+            for entity in entities:
+                if entity.get("identity") and _clear_stub_notes(entity):
+                    pass  # would print in real code
+
+        # Enriched entity should have notes cleared
+        assert catalogs["characters.json"][0]["notes"] == ""
+        # Stub entity (no real identity) should keep its notes
+        assert catalogs["characters.json"][1]["notes"] == "Auto-created by event-stub."
+
+    def test_identity_false_entities_retain_stub_notes(self):
+        """Entities without identity data are real stubs and keep their notes."""
+        entity = {
+            "id": "char-stub",
+            "name": "Mystery Figure",
+            "identity": "",
+            "notes": "Auto-created by event-stub.",
+        }
+        # identity is falsy, so the sweep condition (entity.get("identity")) is False
+        # We should NOT call _clear_stub_notes for these
+        should_clear = bool(entity.get("identity"))
+        assert should_clear is False
+        # Notes preserved
+        assert entity["notes"] == "Auto-created by event-stub."
+
+    def test_identity_none_entities_retain_stub_notes(self):
+        """Entities with identity=None are stubs and keep their notes."""
+        entity = {
+            "id": "char-stub2",
+            "name": "Another Mystery",
+            "identity": None,
+            "notes": "Auto-created by post-batch orphan sweep.",
+        }
+        should_clear = bool(entity.get("identity"))
+        assert should_clear is False
+        assert entity["notes"] == "Auto-created by post-batch orphan sweep."

--- a/tests/test_stub_notes_cleanup.py
+++ b/tests/test_stub_notes_cleanup.py
@@ -4,7 +4,12 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
-from semantic_extraction import _clear_stub_notes
+from semantic_extraction import _clear_stub_notes, _has_real_identity
+
+
+# Real stub identity strings produced by semantic_extraction.py
+_EVENT_STUB_IDENTITY = "Entity referenced in events (stub — auto-created from event data)."
+_POST_BATCH_STUB_IDENTITY = "Entity referenced in 3 events (stub — auto-created post-batch)."
 
 
 class TestClearStubNotes:
@@ -20,8 +25,14 @@ class TestClearStubNotes:
         assert _clear_stub_notes(entity) is True
         assert entity["notes"] == ""
 
-    def test_clears_orphan_sweep_note(self):
+    def test_clears_orphan_sweep_note_spaced(self):
         entity = {"notes": "Auto-created by post-batch orphan sweep.", "identity": "Some identity"}
+        assert _clear_stub_notes(entity) is True
+        assert entity["notes"] == ""
+
+    def test_clears_orphan_sweep_note_hyphenated(self):
+        """The actual production note uses hyphens: 'post-batch-orphan-sweep'."""
+        entity = {"notes": "Auto-created by post-batch-orphan-sweep.", "identity": "Some identity"}
         assert _clear_stub_notes(entity) is True
         assert entity["notes"] == ""
 
@@ -54,11 +65,33 @@ class TestClearStubNotes:
         assert entity["notes"] == ""
 
 
+class TestHasRealIdentity:
+    """Tests for _has_real_identity() — distinguishes real vs stub identity."""
+
+    def test_real_identity(self):
+        assert _has_real_identity({"identity": "A powerful wizard of the north."}) is True
+
+    def test_stub_identity_event(self):
+        assert _has_real_identity({"identity": _EVENT_STUB_IDENTITY}) is False
+
+    def test_stub_identity_post_batch(self):
+        assert _has_real_identity({"identity": _POST_BATCH_STUB_IDENTITY}) is False
+
+    def test_empty_identity(self):
+        assert _has_real_identity({"identity": ""}) is False
+
+    def test_none_identity(self):
+        assert _has_real_identity({"identity": None}) is False
+
+    def test_missing_identity(self):
+        assert _has_real_identity({}) is False
+
+
 class TestBackfillSweepClearsStubNotes:
     """Integration-style test: the sweep after backfill clears enriched entities."""
 
     def test_sweep_clears_enriched_entities(self):
-        """Enriched entities (identity=truthy) should have stub notes cleared."""
+        """Enriched entities (non-stub identity) should have stub notes cleared."""
         catalogs = {
             "characters.json": [
                 {
@@ -70,46 +103,52 @@ class TestBackfillSweepClearsStubNotes:
                 {
                     "id": "char-still-stub",
                     "name": "Unknown NPC",
-                    "identity": "",
+                    "identity": _EVENT_STUB_IDENTITY,
                     "notes": "Auto-created by event-stub.",
                 },
             ]
         }
 
-        # Simulate the sweep logic from backfill_stubs
+        # Simulate the sweep logic from backfill_stubs (uses _has_real_identity)
         for entities in catalogs.values():
             for entity in entities:
-                if entity.get("identity") and _clear_stub_notes(entity):
+                if _has_real_identity(entity) and _clear_stub_notes(entity):
                     pass  # would print in real code
 
         # Enriched entity should have notes cleared
         assert catalogs["characters.json"][0]["notes"] == ""
-        # Stub entity (no real identity) should keep its notes
+        # Stub entity (placeholder stub identity) should keep its notes
         assert catalogs["characters.json"][1]["notes"] == "Auto-created by event-stub."
 
-    def test_identity_false_entities_retain_stub_notes(self):
-        """Entities without identity data are real stubs and keep their notes."""
+    def test_stub_identity_entities_retain_stub_notes(self):
+        """Entities with stub placeholder identity keep their notes."""
         entity = {
             "id": "char-stub",
             "name": "Mystery Figure",
-            "identity": "",
+            "identity": _EVENT_STUB_IDENTITY,
             "notes": "Auto-created by event-stub.",
         }
-        # identity is falsy, so the sweep condition (entity.get("identity")) is False
-        # We should NOT call _clear_stub_notes for these
-        should_clear = bool(entity.get("identity"))
-        assert should_clear is False
-        # Notes preserved
+        assert _has_real_identity(entity) is False
         assert entity["notes"] == "Auto-created by event-stub."
 
-    def test_identity_none_entities_retain_stub_notes(self):
-        """Entities with identity=None are stubs and keep their notes."""
+    def test_post_batch_stub_retains_notes(self):
+        """Post-batch stubs with hyphenated notes and stub identity keep their notes."""
         entity = {
             "id": "char-stub2",
             "name": "Another Mystery",
-            "identity": None,
-            "notes": "Auto-created by post-batch orphan sweep.",
+            "identity": _POST_BATCH_STUB_IDENTITY,
+            "notes": "Auto-created by post-batch-orphan-sweep.",
         }
-        should_clear = bool(entity.get("identity"))
-        assert should_clear is False
-        assert entity["notes"] == "Auto-created by post-batch orphan sweep."
+        assert _has_real_identity(entity) is False
+        assert entity["notes"] == "Auto-created by post-batch-orphan-sweep."
+
+    def test_empty_identity_entities_retain_stub_notes(self):
+        """Entities with empty identity are stubs and keep their notes."""
+        entity = {
+            "id": "char-stub3",
+            "name": "Yet Another Mystery",
+            "identity": "",
+            "notes": "Auto-created by event-stub.",
+        }
+        assert _has_real_identity(entity) is False
+        assert entity["notes"] == "Auto-created by event-stub."

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -1090,6 +1090,12 @@ def extract_and_merge(
         if entity_data and _validate_entity(entity_data):
             _filter_pc_attributes(entity_data)
             merge_entity(catalogs, entity_data)
+            # Clear residual stub notes from now-enriched entity (#152)
+            _eid = entity_data.get("id") or get_entity_id(entity_data)
+            if _eid:
+                _merged = find_entity_by_id(catalogs, _eid)
+                if _merged and _merged[1].get("identity"):
+                    _clear_stub_notes(_merged[1])
             # If this was char-player, also purge stale keys from catalog
             if entity_data.get("id") == "char-player":
                 _sanitize_pc_catalog_entry(catalogs)
@@ -1504,6 +1510,24 @@ _STUB_NOTE_MARKERS = {
     "auto-created by post-batch orphan sweep.",
 }
 
+# Notes to clear from enriched entities (#152) — includes backfill markers
+_STUB_CLEANUP_MARKERS = _STUB_NOTE_MARKERS | {
+    "backfilled from stub.",
+}
+
+
+def _clear_stub_notes(entity: dict) -> bool:
+    """Clear stub-marker notes from enriched entities. Returns True if notes were cleared."""
+    notes = entity.get("notes", "")
+    if not notes:
+        return False
+    notes_lower = notes.strip().lower().rstrip(".")
+    for marker in _STUB_CLEANUP_MARKERS:
+        if marker.lower().rstrip(".") in notes_lower:
+            entity["notes"] = ""
+            return True
+    return False
+
 
 def _is_stub_entity(entity: dict) -> bool:
     """Return True if the entity is a hollow stub needing backfill."""
@@ -1659,6 +1683,12 @@ def backfill_stubs(
             print(f"  WARNING: Backfill failed for {entity_id}: {e}", file=sys.stderr)
 
         llm.delay()
+
+    # Clear residual stub notes from enriched entities (#152)
+    for entities in catalogs.values():
+        for entity in entities:
+            if entity.get("identity") and _clear_stub_notes(entity):
+                print(f"  Cleared stub notes from enriched entity: {entity.get('id', 'unknown')}")
 
     return backfilled
 

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -1090,12 +1090,18 @@ def extract_and_merge(
         if entity_data and _validate_entity(entity_data):
             _filter_pc_attributes(entity_data)
             merge_entity(catalogs, entity_data)
-            # Clear residual stub notes from now-enriched entity (#152)
-            _eid = entity_data.get("id") or get_entity_id(entity_data)
-            if _eid:
-                _merged = find_entity_by_id(catalogs, _eid)
-                if _merged and _merged[1].get("identity"):
-                    _clear_stub_notes(_merged[1])
+            # Clear residual stub notes only when the effective identity is
+            # non-stub; placeholder stub identities still carry useful notes (#152).
+            _effective_identity = entity_data.get("identity")
+            if not _effective_identity and current_entry:
+                _effective_identity = current_entry.get("identity")
+            if (
+                current_entry
+                and isinstance(_effective_identity, str)
+                and _effective_identity.strip()
+                and "stub" not in _effective_identity.lower()
+            ):
+                _clear_stub_notes(current_entry)
             # If this was char-player, also purge stale keys from catalog
             if entity_data.get("id") == "char-player":
                 _sanitize_pc_catalog_entry(catalogs)
@@ -1508,12 +1514,19 @@ def _post_batch_orphan_sweep(catalogs: dict, events_list: list) -> int:
 _STUB_NOTE_MARKERS = {
     "auto-created by event-stub.",
     "auto-created by post-batch orphan sweep.",
+    "auto-created by post-batch-orphan-sweep.",
 }
 
 # Notes to clear from enriched entities (#152) — includes backfill markers
 _STUB_CLEANUP_MARKERS = _STUB_NOTE_MARKERS | {
     "backfilled from stub.",
 }
+
+
+def _has_real_identity(entity: dict) -> bool:
+    """Return True if the entity has a non-stub identity string."""
+    identity = entity.get("identity", "")
+    return bool(identity) and isinstance(identity, str) and "stub" not in identity.lower()
 
 
 def _clear_stub_notes(entity: dict) -> bool:
@@ -1687,7 +1700,7 @@ def backfill_stubs(
     # Clear residual stub notes from enriched entities (#152)
     for entities in catalogs.values():
         for entity in entities:
-            if entity.get("identity") and _clear_stub_notes(entity):
+            if _has_real_identity(entity) and _clear_stub_notes(entity):
                 print(f"  Cleared stub notes from enriched entity: {entity.get('id', 'unknown')}")
 
     return backfilled


### PR DESCRIPTION
## Summary

Clears residual "Auto-created by event-stub", "Auto-created by post-batch orphan sweep", and "Backfilled from stub." notes from entities that have been fully enriched.

## Issue #152 — Stub notes cleanup

- Added `_clear_stub_notes()` function to detect and clear stub-marker notes
- Created `_STUB_CLEANUP_MARKERS` superset (adds "Backfilled from stub.") separate from `_STUB_NOTE_MARKERS` so `_is_stub_entity()` detection is unaffected
- Sweep runs after backfill pass to clean all enriched entities
- Also clears during main extraction merge path when entities gain real data
- Only clears notes from entities with `identity` data (real stubs keep their notes)
- 12 new tests covering all marker variants, edge cases, and sweep logic

Closes #152
