### PR TITLE
feat: post-extraction validation framework with full-session ground truth

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,6 +153,7 @@ All data structures are defined in `schemas/`. See each schema file for field de
 | `tools/update_state.py` | Regenerate session-local derived scaffolds, turn summaries, and structured extraction outputs |
 | `tools/analyze_next_move.py` | Generate next-move analysis and prompt candidates |
 | `tools/validate.py` | Validate all JSON files against schemas |
+| `tools/validate_extraction.py` | Post-extraction validation against curated ground truth (alias merges, missing entities, staleness) |
 | `tools/semantic_extraction.py` | LLM-based entity/relationship/event extraction pipeline |
 | `tools/temporal_extraction.py` | Pattern-based temporal signal extraction and day estimation |
 | `tools/catalog_merger.py` | Merge extracted entities into framework catalog files |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,6 +46,7 @@ Post-extraction quality passes include:
 - **Stub backfill** — re-extracts hollow stub entities using gathered context; runs by default (#128, #131)
 - **PC alias merge** — detects character entities that are aliases of char-player and merges them (#134)
 - **PC consecutive-failure logging** — warns when PC extraction fails for ≥10 consecutive turns (#133)
+- **Extraction validation** — post-extraction ground truth comparison that catches false alias merges, missing entities, coreference fragmentation, and staleness (#159). Uses curated fixtures in `tests/fixtures/` and runs via `tools/validate_extraction.py`.
 
 **Timeline tracking** (#137): The pipeline extracts temporal signals (season transitions,
 biological markers, construction milestones) and estimates in-game day offsets from a

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -415,6 +415,43 @@ Do not edit unless the data model needs to change. If schemas change, re-validat
 
 ---
 
+## Post-Extraction Validation
+
+After running semantic extraction, validate the output against curated ground truth to catch entity-level problems that schema validation alone cannot detect (false alias merges, missing characters, coreference fragmentation, entity staleness).
+
+### Running
+
+```bash
+# Default: validates framework-local/catalogs against full-session ground truth
+python tools/validate_extraction.py --catalog-dir framework-local/catalogs
+
+# Custom ground truth fixture
+python tools/validate_extraction.py --catalog-dir framework-local/catalogs \
+    --ground-truth tests/fixtures/extraction-ground-truth-full-session.json
+```
+
+### Interpreting the Scorecard
+
+The script checks 7 categories and prints a scorecard with PASS/WARN/FAIL for each item:
+
+| Category | What it checks |
+|---|---|
+| Independent Characters | Expected NPCs exist as separate catalog entities |
+| PC Aliases | Only legitimate aliases appear on char-player |
+| Must-Not-Merge | Named entities were not incorrectly absorbed into other entities |
+| Coreference Groups | Pre-naming descriptions merged into the canonical entity |
+| Staleness | Entity `last_updated_turn` is within expected range |
+| Locations (late-game) | Expected late-game locations exist in catalogs |
+| Factions (late-game) | Expected late-game factions exist in catalogs |
+
+Exit code 0 means no FAILs; exit code 1 means at least one FAIL was found.
+
+### Ground Truth Fixtures
+
+Ground truth files live in `tests/fixtures/` and define the expected extraction output for a session or turn range. The full-session fixture (`extraction-ground-truth-full-session.json`) covers turns 1–345 of `session-import` and is derived from `docs/design-synthesis-layer.md`.
+
+---
+
 ## Example Session
 
 See `examples/demo-session/` for a complete worked example with 6 turns, 3 entities, 2 plot threads, and annotated analysis.

--- a/tests/fixtures/extraction-ground-truth-full-session.json
+++ b/tests/fixtures/extraction-ground-truth-full-session.json
@@ -1,0 +1,194 @@
+{
+  "description": "Ground truth for full-session extraction validation — session-import turns 1-345. Derived from docs/design-synthesis-layer.md §1.2-§1.6.",
+  "source_session": "session-import",
+  "turn_range": [1, 345],
+
+  "expected_pc_aliases": ["Fenouille Moonwind"],
+
+  "expected_independent_characters": [
+    {
+      "name": "Lyrawyn",
+      "role": "PC's firstborn daughter",
+      "id_patterns": ["char-lyrawyn"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [70, 72],
+      "expected_last_updated_min": 300,
+      "relationship_to_pc": "kinship",
+      "notes": "Born turn-071; named explicitly; appears 50+ turns; has kinship to PC and Kael"
+    },
+    {
+      "name": "Faelan",
+      "role": "PC's firstborn son",
+      "id_patterns": ["char-faelan"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [183, 185],
+      "expected_last_updated_min": 300,
+      "relationship_to_pc": "kinship",
+      "notes": "Born turn-183; PC's second child; arcane power catalyst"
+    },
+    {
+      "name": "Rune",
+      "role": "PC's third child",
+      "id_patterns": ["char-rune"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [306, 308],
+      "expected_last_updated_min": 306,
+      "relationship_to_pc": "kinship",
+      "notes": "Born turn-306; miniature snowflake in eyes; arcane alignment"
+    },
+    {
+      "name": "Kael",
+      "role": "PC's partner, tribe warrior-leader",
+      "id_patterns": ["char-kael"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [5, 15],
+      "expected_last_updated_min": 300,
+      "relationship_to_pc": "romantic",
+      "coreference_variants": ["broad figure", "young hunter", "brave warrior", "young warrior", "my hunter"],
+      "notes": "Major NPC present in 16+ events; appears from turn-009 as unnamed captor through turn-343 as tribal leader. Pre-naming descriptions should merge into char-kael, not remain as separate entities."
+    },
+    {
+      "name": "The Elder",
+      "role": "Tribal elder/authority figure",
+      "id_patterns": ["char-elder-figure-by-fire", "char-elder"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [8, 15],
+      "expected_last_updated_min": 300,
+      "notes": "Authority figure from turn-015 through turn-340 (winter council). Grizzled man with eyes like chips of flint."
+    },
+    {
+      "name": "The Shaman",
+      "role": "Tribal spiritual leader",
+      "id_patterns": ["char-shaman"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [40, 60],
+      "expected_last_updated_min": 250,
+      "notes": "Distinct from The Healer. Appears turn-059+, has earthy magic, performs rituals. Active through turn-340."
+    },
+    {
+      "name": "Anya",
+      "role": "PC's apprentice/student",
+      "id_patterns": ["char-anya"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [189, 195],
+      "expected_last_updated_min": 250,
+      "notes": "Trained by PC in subtle energy sensing. Active in plague crisis and disruption field experiments."
+    },
+    {
+      "name": "Lena",
+      "role": "Co-teacher, education leader",
+      "id_patterns": ["char-lena"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [155, 165],
+      "expected_last_updated_min": 250,
+      "notes": "Recruited as co-teacher turn-157. Later formally delegated as learning leader turn-301."
+    },
+    {
+      "name": "Tala",
+      "role": "Mead apprentice",
+      "id_patterns": ["char-tala"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [145, 155],
+      "expected_last_updated_min": 300,
+      "notes": "Mead-making apprentice. Present at winter council turn-339."
+    },
+    {
+      "name": "Borin",
+      "role": "Ceramics apprentice, kiln master",
+      "id_patterns": ["char-borin"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [175, 180],
+      "expected_last_updated_min": 300,
+      "notes": "Kiln apprentice turn-178. Accepts Faelan's tutelage turn-324."
+    },
+    {
+      "name": "The Healer",
+      "role": "Tribal healer (distinct from shaman)",
+      "id_patterns": ["char-healer"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [225, 250],
+      "expected_last_updated_min": 250,
+      "notes": "Active in plague crisis. Distinct role from shaman — healer for recognition, shaman for rites."
+    },
+    {
+      "name": "Gorok",
+      "role": "Warrior-Chief, external leader",
+      "id_patterns": ["char-warrior-chief-gorok", "char-gorok"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [313, 316],
+      "expected_last_updated_min": 330,
+      "notes": "Warrior-Chief Gorok. Arrives at settlement turn-314. Paired with Maelis as dual forces turn-343."
+    },
+    {
+      "name": "Chief Thorne",
+      "role": "Ironwood Clan leader",
+      "id_patterns": ["char-chief-thorne", "char-thorne"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [313, 316],
+      "expected_last_updated_min": 314,
+      "notes": "Leader of the Ironwood Clan. Accepts food and sends trackers turn-316."
+    },
+    {
+      "name": "Elder Lyra",
+      "role": "Riverfolk elder (NOT same as Lyrawyn)",
+      "id_patterns": ["char-lyra", "char-elder-lyra"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [313, 316],
+      "expected_last_updated_min": 314,
+      "notes": "CRITICAL DISAMBIGUATION: Elder Lyra (Riverfolk elder, turn-314+) vs Lyrawyn (PC's daughter, turn-071+). Two different people."
+    },
+    {
+      "name": "Maelis",
+      "role": "Swift Arrows hunter-scout",
+      "id_patterns": ["char-maelis"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [330, 335],
+      "expected_last_updated_min": 332,
+      "notes": "Maelis of the Swift Arrows. Riverfolk hunter-scout. Arrives turn-332."
+    },
+    {
+      "name": "Rurik",
+      "role": "Eastern expedition companion",
+      "id_patterns": ["char-rurik"],
+      "must_not_be_pc_alias": true,
+      "expected_first_seen_range": [194, 196],
+      "expected_last_updated_min": 194,
+      "notes": "Minor character. Accompanies PC on eastern expedition turns 194-204."
+    }
+  ],
+
+  "must_not_merge": [
+    {"pair": ["Lyrawyn", "char-player"], "reason": "Lyrawyn is PC's daughter, not an alias"},
+    {"pair": ["Faelan", "char-player"], "reason": "Faelan is PC's son, not an alias"},
+    {"pair": ["Chief Thorne", "char-player"], "reason": "Thorne is Ironwood Clan leader, not PC"},
+    {"pair": ["the shaman", "char-player"], "reason": "Shaman is a distinct tribal NPC"},
+    {"pair": ["Elder Lyra", "Lyrawyn"], "reason": "Elder Lyra (Riverfolk) is different from Lyrawyn (PC's daughter)"}
+  ],
+
+  "coreference_groups": [
+    {
+      "canonical_name": "Kael",
+      "expected_id": "char-kael",
+      "variants_to_merge": ["broad figure", "young hunter", "brave warrior", "young warrior", "my hunter"],
+      "notes": "Kael is first seen as unnamed captor (turn-009) and later named (turn-149). All pre-naming descriptions refer to the same person."
+    }
+  ],
+
+  "entity_staleness_targets": [
+    {"id": "char-player", "expected_last_updated_min": 300, "reason": "PC is active through turn-344"},
+    {"id": "char-elder-figure-by-fire", "expected_last_updated_min": 300, "reason": "Elder active through turn-340 winter council"},
+    {"id": "char-kael", "expected_last_updated_min": 300, "reason": "Kael active through turn-343"},
+    {"id": "char-lena", "expected_last_updated_min": 250, "reason": "Lena active through turn-301"},
+    {"id": "char-anya", "expected_last_updated_min": 250, "reason": "Anya active through turn-343"}
+  ],
+
+  "expected_locations_beyond_turn_100": [
+    {"name": "Eastern boundary / mountains", "expected_first_seen_range": [189, 201], "notes": "Arcane fragment discovery site"},
+    {"name": "Pulsating river stones", "expected_first_seen_range": [268, 270], "notes": "Disruption field experiment site"}
+  ],
+
+  "expected_factions_beyond_early_game": [
+    {"name": "The Quiet Weave", "expected_first_seen_range": [291, 293], "notes": "Formally named settlement/philosophy"},
+    {"name": "Southern Tribes / Ironwood Clan", "expected_first_seen_range": [313, 316], "notes": "Chief Thorne's people"}
+  ]
+}

--- a/tests/test_extraction_ground_truth.py
+++ b/tests/test_extraction_ground_truth.py
@@ -1,0 +1,120 @@
+"""Tests for the extraction ground truth fixture and validation framework (#159)."""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "fixtures",
+    "extraction-ground-truth-full-session.json",
+)
+
+
+@pytest.fixture
+def ground_truth():
+    with open(FIXTURE_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Fixture structure tests
+# ---------------------------------------------------------------------------
+
+
+class TestFixtureStructure:
+    def test_fixture_loads_and_parses(self, ground_truth):
+        assert isinstance(ground_truth, dict)
+        assert "description" in ground_truth
+        assert "source_session" in ground_truth
+
+    def test_fixture_has_expected_characters(self, ground_truth):
+        chars = ground_truth.get("expected_independent_characters", [])
+        assert len(chars) >= 10, "Expected at least 10 independent characters"
+        for char in chars:
+            assert "name" in char
+            assert "id_patterns" in char
+            assert isinstance(char["id_patterns"], list)
+            assert len(char["id_patterns"]) > 0
+
+    def test_fixture_has_pc_aliases(self, ground_truth):
+        aliases = ground_truth.get("expected_pc_aliases", [])
+        assert isinstance(aliases, list)
+        assert len(aliases) >= 1
+
+    def test_fixture_has_must_not_merge(self, ground_truth):
+        rules = ground_truth.get("must_not_merge", [])
+        assert len(rules) >= 1
+        for rule in rules:
+            assert "pair" in rule
+            assert len(rule["pair"]) == 2
+            assert "reason" in rule
+
+    def test_fixture_has_coreference_groups(self, ground_truth):
+        groups = ground_truth.get("coreference_groups", [])
+        assert len(groups) >= 1
+        for group in groups:
+            assert "canonical_name" in group
+            assert "expected_id" in group
+            assert "variants_to_merge" in group
+
+    def test_fixture_turn_ranges_valid(self, ground_truth):
+        turn_range = ground_truth.get("turn_range", [])
+        assert len(turn_range) == 2
+        assert turn_range[0] < turn_range[1]
+
+        for char in ground_truth.get("expected_independent_characters", []):
+            r = char.get("expected_first_seen_range", [])
+            assert len(r) == 2, f"{char['name']}: missing first_seen_range"
+            assert r[0] <= r[1], f"{char['name']}: invalid range {r}"
+            assert r[0] >= turn_range[0], f"{char['name']}: range before session"
+            assert r[1] <= turn_range[1], f"{char['name']}: range after session"
+
+    def test_fixture_no_duplicate_names(self, ground_truth):
+        chars = ground_truth.get("expected_independent_characters", [])
+        names = [c["name"] for c in chars]
+        assert len(names) == len(set(names)), (
+            f"Duplicate character names: "
+            f"{[n for n in names if names.count(n) > 1]}"
+        )
+
+    def test_fixture_has_staleness_targets(self, ground_truth):
+        targets = ground_truth.get("entity_staleness_targets", [])
+        assert len(targets) >= 1
+        for t in targets:
+            assert "id" in t
+            assert "expected_last_updated_min" in t
+            assert isinstance(t["expected_last_updated_min"], int)
+
+    def test_fixture_has_location_and_faction_expectations(self, ground_truth):
+        locations = ground_truth.get("expected_locations_beyond_turn_100", [])
+        factions = ground_truth.get("expected_factions_beyond_early_game", [])
+        assert len(locations) >= 1
+        assert len(factions) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Validation script import tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidationScriptImportable:
+    def test_validation_script_importable(self):
+        import validate_extraction
+        assert hasattr(validate_extraction, "validate")
+        assert hasattr(validate_extraction, "main")
+        assert callable(validate_extraction.validate)
+
+    def test_check_functions_exist(self):
+        import validate_extraction
+        assert hasattr(validate_extraction, "check_independent_characters")
+        assert hasattr(validate_extraction, "check_pc_aliases")
+        assert hasattr(validate_extraction, "check_must_not_merge")
+        assert hasattr(validate_extraction, "check_coreference_groups")
+        assert hasattr(validate_extraction, "check_staleness")
+        assert hasattr(validate_extraction, "check_locations")
+        assert hasattr(validate_extraction, "check_factions")

--- a/tests/test_extraction_ground_truth.py
+++ b/tests/test_extraction_ground_truth.py
@@ -118,3 +118,177 @@ class TestValidationScriptImportable:
         assert hasattr(validate_extraction, "check_staleness")
         assert hasattr(validate_extraction, "check_locations")
         assert hasattr(validate_extraction, "check_factions")
+
+
+# ---------------------------------------------------------------------------
+# Functional end-to-end tests with synthetic catalog
+# ---------------------------------------------------------------------------
+
+def _write_json(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+@pytest.fixture
+def mini_ground_truth(tmp_path):
+    """Minimal ground truth covering key check paths."""
+    gt = {
+        "description": "mini fixture",
+        "source_session": "test",
+        "turn_range": [1, 50],
+        "expected_pc_aliases": ["Hero Name"],
+        "expected_independent_characters": [
+            {
+                "name": "Alice",
+                "role": "ally",
+                "id_patterns": ["char-alice"],
+                "must_not_be_pc_alias": True,
+                "expected_first_seen_range": [1, 5],
+                "expected_last_updated_min": 40,
+                "notes": "test char",
+            },
+            {
+                "name": "MissingBob",
+                "role": "missing",
+                "id_patterns": ["char-bob"],
+                "must_not_be_pc_alias": True,
+                "expected_first_seen_range": [10, 12],
+                "expected_last_updated_min": 30,
+                "notes": "should be missing",
+            },
+        ],
+        "must_not_merge": [
+            {"pair": ["Alice", "char-player"], "reason": "Alice is an NPC"},
+        ],
+        "coreference_groups": [
+            {
+                "canonical_name": "Alice",
+                "expected_id": "char-alice",
+                "variants_to_merge": ["tall figure"],
+                "notes": "test group",
+            },
+        ],
+        "entity_staleness_targets": [
+            {"id": "char-alice", "expected_last_updated_min": 40, "reason": "active"},
+            {"id": "char-gone", "expected_last_updated_min": 30, "reason": "deleted"},
+        ],
+        "expected_locations_beyond_turn_100": [],
+        "expected_factions_beyond_early_game": [],
+    }
+    gt_path = tmp_path / "gt.json"
+    _write_json(gt_path, gt)
+    return gt_path
+
+
+@pytest.fixture
+def synthetic_catalog(tmp_path):
+    """Synthetic catalog directory with controlled entities."""
+    cat_dir = tmp_path / "catalogs"
+    chars = cat_dir / "characters"
+    chars.mkdir(parents=True)
+
+    # PC with one correct and one false alias
+    _write_json(chars / "char-player.json", {
+        "id": "char-player",
+        "name": "Player Character",
+        "type": "character",
+        "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-045",
+        "stable_attributes": {
+            "aliases": {"value": ["Hero Name", "Alice"], "source_turn": "turn-005"},
+        },
+    })
+
+    # Alice exists but is stale
+    _write_json(chars / "char-alice.json", {
+        "id": "char-alice",
+        "name": "Alice",
+        "type": "character",
+        "first_seen_turn": "turn-003",
+        "last_updated_turn": "turn-015",
+        "stable_attributes": {},
+    })
+
+    # A coreference fragment that should have been merged
+    _write_json(chars / "char-tall-figure.json", {
+        "id": "char-tall-figure",
+        "name": "tall figure",
+        "type": "character",
+        "first_seen_turn": "turn-003",
+        "last_updated_turn": "turn-004",
+        "stable_attributes": {},
+    })
+
+    return cat_dir
+
+
+class TestFunctionalValidation:
+    def test_independent_char_found_but_stale(self, mini_ground_truth, synthetic_catalog):
+        import validate_extraction
+        gt = json.loads(mini_ground_truth.read_text(encoding="utf-8"))
+        pc_aliases = validate_extraction._pc_aliases(synthetic_catalog)
+        results = validate_extraction.check_independent_characters(
+            gt, synthetic_catalog, pc_aliases,
+        )
+        alice = [r for r in results if r.label == "Alice"][0]
+        # Alice exists but last_updated_turn=15 vs expected 40 → gap=25 → WARN
+        assert alice.status == validate_extraction.Result.WARN
+
+    def test_independent_char_missing(self, mini_ground_truth, synthetic_catalog):
+        import validate_extraction
+        gt = json.loads(mini_ground_truth.read_text(encoding="utf-8"))
+        pc_aliases = validate_extraction._pc_aliases(synthetic_catalog)
+        results = validate_extraction.check_independent_characters(
+            gt, synthetic_catalog, pc_aliases,
+        )
+        bob = [r for r in results if r.label == "MissingBob"][0]
+        assert bob.status == validate_extraction.Result.FAIL
+
+    def test_pc_alias_correct_and_false_positive(self, mini_ground_truth, synthetic_catalog):
+        import validate_extraction
+        gt = json.loads(mini_ground_truth.read_text(encoding="utf-8"))
+        pc_aliases = validate_extraction._pc_aliases(synthetic_catalog)
+        results = validate_extraction.check_pc_aliases(gt, pc_aliases)
+        statuses = {r.label: r.status for r in results}
+        # "hero name" should be PASS, "alice" should be FAIL (false positive)
+        assert statuses["hero name"] == validate_extraction.Result.PASS
+        assert statuses["alice"] == validate_extraction.Result.FAIL
+
+    def test_must_not_merge_detects_pc_alias(self, mini_ground_truth, synthetic_catalog):
+        import validate_extraction
+        gt = json.loads(mini_ground_truth.read_text(encoding="utf-8"))
+        pc_aliases = validate_extraction._pc_aliases(synthetic_catalog)
+        results = validate_extraction.check_must_not_merge(
+            gt, synthetic_catalog, pc_aliases,
+        )
+        assert len(results) == 1
+        assert results[0].status == validate_extraction.Result.FAIL
+        assert "MERGED" in results[0].detail
+
+    def test_coreference_fragmentation_detected(self, mini_ground_truth, synthetic_catalog):
+        import validate_extraction
+        gt = json.loads(mini_ground_truth.read_text(encoding="utf-8"))
+        results = validate_extraction.check_coreference_groups(gt, synthetic_catalog)
+        assert len(results) == 1
+        assert results[0].status == validate_extraction.Result.WARN
+        assert "FRAGMENT" in results[0].detail
+
+    def test_staleness_missing_entity(self, mini_ground_truth, synthetic_catalog):
+        import validate_extraction
+        gt = json.loads(mini_ground_truth.read_text(encoding="utf-8"))
+        results = validate_extraction.check_staleness(gt, synthetic_catalog)
+        gone = [r for r in results if r.label == "char-gone"][0]
+        assert gone.status == validate_extraction.Result.FAIL
+
+    def test_validate_returns_nonzero(self, mini_ground_truth, synthetic_catalog):
+        import validate_extraction
+        exit_code = validate_extraction.validate(synthetic_catalog, mini_ground_truth)
+        assert exit_code == 1, "Expected failures in synthetic catalog"
+
+    def test_normalize_aliases_string(self):
+        import validate_extraction
+        assert validate_extraction._normalize_aliases("foo, bar") == ["foo", "bar"]
+        assert validate_extraction._normalize_aliases("single") == ["single"]
+        assert validate_extraction._normalize_aliases(None) == []
+        assert validate_extraction._normalize_aliases(["A", "B"]) == ["a", "b"]

--- a/tools/validate_extraction.py
+++ b/tools/validate_extraction.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""Post-extraction validation against curated ground truth.
+
+Compares extraction output (entity catalogs) against a ground truth fixture
+to catch entity-level problems: false alias merges, missing characters,
+coreference fragmentation, and entity staleness.
+
+Usage:
+    python tools/validate_extraction.py --catalog-dir framework-local/catalogs
+    python tools/validate_extraction.py --catalog-dir framework-local/catalogs \
+        --ground-truth tests/fixtures/extraction-ground-truth-full-session.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _turn_number(turn_str: str) -> int | None:
+    """Extract numeric turn from strings like 'turn-245'."""
+    m = re.search(r"(\d+)", str(turn_str))
+    return int(m.group(1)) if m else None
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _load_character(catalog_dir: Path, char_id: str) -> dict[str, Any] | None:
+    """Load a character JSON file by ID from the characters/ subdirectory."""
+    char_path = catalog_dir / "characters" / f"{char_id}.json"
+    if char_path.exists():
+        return _load_json(char_path)
+    return None
+
+
+def _pc_aliases(catalog_dir: Path) -> list[str]:
+    """Return the list of PC aliases from char-player.json."""
+    pc = _load_character(catalog_dir, "char-player")
+    if not pc:
+        return []
+    aliases_attr = pc.get("stable_attributes", {}).get("aliases", {})
+    return [a.lower() for a in aliases_attr.get("value", [])]
+
+
+def _all_character_ids(catalog_dir: Path) -> list[str]:
+    """Return all character IDs found in the characters/ subdirectory."""
+    chars_dir = catalog_dir / "characters"
+    if not chars_dir.is_dir():
+        return []
+    ids = []
+    for f in chars_dir.iterdir():
+        if (
+            f.suffix == ".json"
+            and not f.name.endswith(".synthesis.json")
+            and not f.name.endswith(".arcs.json")
+            and f.name != "index.json"
+        ):
+            ids.append(f.stem)
+    return sorted(ids)
+
+
+# ---------------------------------------------------------------------------
+# Result tracking
+# ---------------------------------------------------------------------------
+
+class Result:
+    PASS = "PASS"
+    WARN = "WARN"
+    FAIL = "FAIL"
+
+    def __init__(self, status: str, label: str, detail: str = ""):
+        self.status = status
+        self.label = label
+        self.detail = detail
+
+    def __str__(self) -> str:
+        parts = [f"{self.status:4s}  {self.label:24s}"]
+        if self.detail:
+            parts.append(self.detail)
+        return "  ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Check implementations
+# ---------------------------------------------------------------------------
+
+def check_independent_characters(
+    ground_truth: dict, catalog_dir: Path, pc_alias_list: list[str],
+) -> list[Result]:
+    """Check A: each expected independent character exists as its own entity."""
+    results: list[Result] = []
+    all_ids = _all_character_ids(catalog_dir)
+
+    for entry in ground_truth.get("expected_independent_characters", []):
+        name = entry["name"]
+        patterns = entry.get("id_patterns", [])
+        found_id = None
+
+        for pat in patterns:
+            if pat in all_ids:
+                found_id = pat
+                break
+
+        if not found_id:
+            # Check if merged as PC alias
+            if name.lower() in pc_alias_list:
+                results.append(Result(
+                    Result.FAIL, name, "NOT FOUND — merged as PC alias",
+                ))
+            else:
+                results.append(Result(Result.FAIL, name, "NOT FOUND"))
+            continue
+
+        # Check staleness
+        char_data = _load_character(catalog_dir, found_id)
+        last_turn = _turn_number(
+            char_data.get("last_updated_turn", "") if char_data else "",
+        )
+        turn_display = f"turn-{last_turn}" if last_turn else "unknown"
+
+        expected_min = entry.get("expected_last_updated_min")
+        if expected_min and last_turn and last_turn < expected_min:
+            gap = expected_min - last_turn
+            severity = Result.FAIL if gap > 50 else Result.WARN
+            results.append(Result(
+                severity,
+                name,
+                f"{found_id:30s} ({turn_display}) — stale by {gap} turns "
+                f"(expected ≥{expected_min})",
+            ))
+        else:
+            results.append(Result(
+                Result.PASS, name, f"{found_id:30s} ({turn_display})",
+            ))
+
+    return results
+
+
+def check_pc_aliases(
+    ground_truth: dict, pc_alias_list: list[str],
+) -> list[Result]:
+    """Check B: PC aliases match expected set."""
+    results: list[Result] = []
+    expected = {a.lower() for a in ground_truth.get("expected_pc_aliases", [])}
+
+    # Check expected aliases are present
+    for alias in expected:
+        if alias in pc_alias_list:
+            results.append(Result(Result.PASS, alias, "present"))
+        else:
+            results.append(Result(Result.FAIL, alias, "MISSING from PC aliases"))
+
+    # Check for false positives
+    for alias in pc_alias_list:
+        if alias not in expected:
+            results.append(Result(
+                Result.FAIL, alias, "false positive (in aliases but shouldn't be)",
+            ))
+
+    return results
+
+
+def check_must_not_merge(
+    ground_truth: dict, catalog_dir: Path, pc_alias_list: list[str],
+) -> list[Result]:
+    """Check C: entities that must not be merged."""
+    results: list[Result] = []
+
+    for rule in ground_truth.get("must_not_merge", []):
+        pair = rule["pair"]
+        reason = rule.get("reason", "")
+        entity_a = pair[0]
+        entity_b = pair[1]
+
+        merged = False
+        # If entity_b is char-player, check if entity_a is in PC aliases
+        if entity_b == "char-player":
+            if entity_a.lower() in pc_alias_list:
+                merged = True
+        # Also check reverse
+        elif entity_a == "char-player":
+            if entity_b.lower() in pc_alias_list:
+                merged = True
+        else:
+            # Check if one entity references the other as an alias
+            # by loading both and seeing if one has the other's name
+            for check_id_name, check_alias_name in [
+                (entity_a, entity_b), (entity_b, entity_a),
+            ]:
+                # Try loading as character ID
+                char = _load_character(catalog_dir, check_id_name)
+                if char:
+                    aliases = char.get("stable_attributes", {}).get(
+                        "aliases", {},
+                    ).get("value", [])
+                    if check_alias_name.lower() in [
+                        a.lower() for a in aliases
+                    ]:
+                        merged = True
+
+        label = f"{entity_a} ↔ {entity_b}"
+        if merged:
+            results.append(Result(Result.FAIL, label, f"MERGED — {reason}"))
+        else:
+            results.append(Result(Result.PASS, label, "separate"))
+
+    return results
+
+
+def check_coreference_groups(
+    ground_truth: dict, catalog_dir: Path,
+) -> list[Result]:
+    """Check D: coreference groups are properly merged."""
+    results: list[Result] = []
+    all_ids = _all_character_ids(catalog_dir)
+
+    for group in ground_truth.get("coreference_groups", []):
+        canonical = group["canonical_name"]
+        expected_id = group["expected_id"]
+        variants = group.get("variants_to_merge", [])
+
+        # Check canonical exists
+        if expected_id not in all_ids:
+            results.append(Result(
+                Result.FAIL, canonical, f"{expected_id} NOT FOUND",
+            ))
+            continue
+
+        # Check for fragmented variants
+        fragments = []
+        for variant in variants:
+            # Convert variant name to possible ID
+            variant_id = "char-" + variant.lower().replace(" ", "-")
+            if variant_id in all_ids:
+                fragments.append(variant_id)
+
+        if fragments:
+            frag_list = ", ".join([expected_id] + fragments)
+            results.append(Result(
+                Result.WARN,
+                canonical,
+                f"{len(fragments) + 1} FRAGMENTS: {frag_list}",
+            ))
+        else:
+            results.append(Result(Result.PASS, canonical, f"{expected_id} — unified"))
+
+    return results
+
+
+def check_staleness(
+    ground_truth: dict, catalog_dir: Path,
+) -> list[Result]:
+    """Check E: entity staleness against targets."""
+    results: list[Result] = []
+
+    for target in ground_truth.get("entity_staleness_targets", []):
+        entity_id = target["id"]
+        expected_min = target["expected_last_updated_min"]
+        reason = target.get("reason", "")
+
+        char_data = _load_character(catalog_dir, entity_id)
+        if not char_data:
+            results.append(Result(
+                Result.FAIL, entity_id, f"NOT FOUND — {reason}",
+            ))
+            continue
+
+        last_turn = _turn_number(char_data.get("last_updated_turn", ""))
+        if last_turn is None:
+            results.append(Result(
+                Result.FAIL, entity_id, f"no last_updated_turn — {reason}",
+            ))
+            continue
+
+        gap = expected_min - last_turn
+        if gap > 50:
+            results.append(Result(
+                Result.FAIL, entity_id,
+                f"turn-{last_turn} (expected ≥{expected_min}, gap={gap})",
+            ))
+        elif gap > 20:
+            results.append(Result(
+                Result.WARN, entity_id,
+                f"turn-{last_turn} (expected ≥{expected_min}, gap={gap})",
+            ))
+        else:
+            results.append(Result(
+                Result.PASS, entity_id, f"turn-{last_turn}",
+            ))
+
+    return results
+
+
+def check_locations(
+    ground_truth: dict, catalog_dir: Path,
+) -> list[Result]:
+    """Check F: expected late-game locations exist."""
+    results: list[Result] = []
+    loc_dir = catalog_dir / "locations"
+    loc_files = []
+    if loc_dir.is_dir():
+        loc_files = [f.stem for f in loc_dir.iterdir() if f.suffix == ".json"]
+
+    for entry in ground_truth.get("expected_locations_beyond_turn_100", []):
+        name = entry["name"]
+        notes = entry.get("notes", "")
+        # Simple substring match against location file names
+        found = any(
+            _name_matches_loc(name, loc_id) for loc_id in loc_files
+        )
+        if found:
+            results.append(Result(Result.PASS, name, notes))
+        else:
+            results.append(Result(Result.FAIL, name, f"NOT FOUND — {notes}"))
+
+    return results
+
+
+def _name_matches_loc(name: str, loc_id: str) -> bool:
+    """Check if a location name roughly matches a location file ID."""
+    name_words = set(name.lower().replace("/", " ").split())
+    id_words = set(loc_id.replace("loc-", "").replace("-", " ").split())
+    # Match if any significant word overlap
+    return len(name_words & id_words) >= 1
+
+
+def check_factions(
+    ground_truth: dict, catalog_dir: Path,
+) -> list[Result]:
+    """Check G: expected late-game factions exist."""
+    results: list[Result] = []
+    fac_dir = catalog_dir / "factions"
+    fac_files = []
+    if fac_dir.is_dir():
+        fac_files = [f.stem for f in fac_dir.iterdir() if f.suffix == ".json"]
+
+    for entry in ground_truth.get("expected_factions_beyond_early_game", []):
+        name = entry["name"]
+        notes = entry.get("notes", "")
+        found = any(
+            _name_matches_faction(name, fac_id) for fac_id in fac_files
+        )
+        if found:
+            results.append(Result(Result.PASS, name, notes))
+        else:
+            results.append(Result(Result.FAIL, name, f"NOT FOUND — {notes}"))
+
+    return results
+
+
+def _name_matches_faction(name: str, fac_id: str) -> bool:
+    """Check if a faction name roughly matches a faction file ID."""
+    name_words = set(name.lower().replace("/", " ").split())
+    id_words = set(fac_id.replace("faction-", "").replace("-", " ").split())
+    return len(name_words & id_words) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+def print_report(
+    sections: list[tuple[str, int | None, list[Result]]],
+    catalog_dir: Path,
+    ground_truth_path: Path,
+) -> int:
+    """Print the validation scorecard. Returns 0 if no FAILs, 1 otherwise."""
+    total_pass = 0
+    total_warn = 0
+    total_fail = 0
+
+    print("=== Extraction Validation Report ===")
+    print(f"Date: {date.today().isoformat()}")
+    print(f"Catalog: {catalog_dir}")
+    print(f"Ground Truth: {ground_truth_path}")
+    print()
+
+    for title, expected_count, results in sections:
+        count_str = f" ({expected_count} expected)" if expected_count else ""
+        print(f"## {title}{count_str}")
+
+        for r in results:
+            print(f"  {r}")
+            if r.status == Result.PASS:
+                total_pass += 1
+            elif r.status == Result.WARN:
+                total_warn += 1
+            else:
+                total_fail += 1
+
+        print()
+
+    print("## Summary")
+    print(f"  PASS: {total_pass}  WARN: {total_warn}  FAIL: {total_fail}")
+
+    return 0 if total_fail == 0 else 1
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def validate(catalog_dir: Path, ground_truth_path: Path) -> int:
+    """Run all validation checks and print report. Returns exit code."""
+    gt = _load_json(ground_truth_path)
+    pc_aliases = _pc_aliases(catalog_dir)
+
+    expected_char_count = len(gt.get("expected_independent_characters", []))
+
+    sections = [
+        (
+            "Independent Characters",
+            expected_char_count,
+            check_independent_characters(gt, catalog_dir, pc_aliases),
+        ),
+        (
+            "PC Aliases",
+            None,
+            check_pc_aliases(gt, pc_aliases),
+        ),
+        (
+            "Must-Not-Merge",
+            None,
+            check_must_not_merge(gt, catalog_dir, pc_aliases),
+        ),
+        (
+            "Coreference Groups",
+            None,
+            check_coreference_groups(gt, catalog_dir),
+        ),
+        (
+            "Staleness",
+            None,
+            check_staleness(gt, catalog_dir),
+        ),
+        (
+            "Locations (late-game)",
+            None,
+            check_locations(gt, catalog_dir),
+        ),
+        (
+            "Factions (late-game)",
+            None,
+            check_factions(gt, catalog_dir),
+        ),
+    ]
+
+    return print_report(sections, catalog_dir, ground_truth_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate extraction catalogs against ground truth.",
+    )
+    parser.add_argument(
+        "--catalog-dir",
+        default="framework-local/catalogs",
+        help="Path to the catalog directory (default: framework-local/catalogs)",
+    )
+    parser.add_argument(
+        "--ground-truth",
+        default="tests/fixtures/extraction-ground-truth-full-session.json",
+        help="Path to the ground truth fixture",
+    )
+    args = parser.parse_args()
+
+    catalog_dir = Path(args.catalog_dir)
+    ground_truth_path = Path(args.ground_truth)
+
+    if not catalog_dir.is_dir():
+        print(f"Error: catalog directory not found: {catalog_dir}", file=sys.stderr)
+        sys.exit(2)
+    if not ground_truth_path.is_file():
+        print(
+            f"Error: ground truth file not found: {ground_truth_path}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    exit_code = validate(catalog_dir, ground_truth_path)
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate_extraction.py
+++ b/tools/validate_extraction.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import sys
 from datetime import date
@@ -45,13 +44,28 @@ def _load_character(catalog_dir: Path, char_id: str) -> dict[str, Any] | None:
     return None
 
 
+def _normalize_aliases(raw: Any) -> list[str]:
+    """Normalize aliases value to a lowercase list.
+
+    Handles: list of strings, single string, comma-separated string,
+    or missing/None value.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [s.strip().lower() for s in raw.split(",") if s.strip()]
+    if isinstance(raw, list):
+        return [str(a).lower() for a in raw]
+    return []
+
+
 def _pc_aliases(catalog_dir: Path) -> list[str]:
     """Return the list of PC aliases from char-player.json."""
     pc = _load_character(catalog_dir, "char-player")
     if not pc:
         return []
     aliases_attr = pc.get("stable_attributes", {}).get("aliases", {})
-    return [a.lower() for a in aliases_attr.get("value", [])]
+    return _normalize_aliases(aliases_attr.get("value"))
 
 
 def _all_character_ids(catalog_dir: Path) -> list[str]:
@@ -131,14 +145,21 @@ def check_independent_characters(
         turn_display = f"turn-{last_turn}" if last_turn else "unknown"
 
         expected_min = entry.get("expected_last_updated_min")
-        if expected_min and last_turn and last_turn < expected_min:
+        if expected_min and last_turn is None:
+            results.append(Result(
+                Result.FAIL,
+                name,
+                f"{found_id:30s} ({turn_display}) — last_updated_turn missing "
+                f"(expected >={expected_min})",
+            ))
+        elif expected_min and last_turn and last_turn < expected_min:
             gap = expected_min - last_turn
             severity = Result.FAIL if gap > 50 else Result.WARN
             results.append(Result(
                 severity,
                 name,
                 f"{found_id:30s} ({turn_display}) — stale by {gap} turns "
-                f"(expected ≥{expected_min})",
+                f"(expected >={expected_min})",
             ))
         else:
             results.append(Result(
@@ -172,6 +193,49 @@ def check_pc_aliases(
     return results
 
 
+def _resolve_name_to_ids(
+    name: str, catalog_dir: Path, ground_truth: dict,
+) -> list[str]:
+    """Resolve a human name to catalog entity IDs.
+
+    Checks id_patterns from ground truth first, then scans all character files
+    for matching name or alias.
+    """
+    # Direct ID (starts with char-)
+    if name.startswith("char-"):
+        return [name]
+
+    # Check ground truth id_patterns
+    for entry in ground_truth.get("expected_independent_characters", []):
+        if entry["name"].lower() == name.lower():
+            return entry.get("id_patterns", [])
+
+    # Scan catalog files for name/alias match
+    matched: list[str] = []
+    chars_dir = catalog_dir / "characters"
+    if not chars_dir.is_dir():
+        return matched
+    for f in chars_dir.iterdir():
+        if (
+            f.suffix != ".json"
+            or f.name.endswith(".synthesis.json")
+            or f.name.endswith(".arcs.json")
+            or f.name == "index.json"
+        ):
+            continue
+        char = _load_json(f)
+        char_name = char.get("name", "").lower()
+        if char_name == name.lower():
+            matched.append(f.stem)
+            continue
+        aliases = _normalize_aliases(
+            char.get("stable_attributes", {}).get("aliases", {}).get("value"),
+        )
+        if name.lower() in aliases:
+            matched.append(f.stem)
+    return matched
+
+
 def check_must_not_merge(
     ground_truth: dict, catalog_dir: Path, pc_alias_list: list[str],
 ) -> list[Result]:
@@ -189,28 +253,48 @@ def check_must_not_merge(
         if entity_b == "char-player":
             if entity_a.lower() in pc_alias_list:
                 merged = True
-        # Also check reverse
         elif entity_a == "char-player":
             if entity_b.lower() in pc_alias_list:
                 merged = True
         else:
-            # Check if one entity references the other as an alias
-            # by loading both and seeing if one has the other's name
-            for check_id_name, check_alias_name in [
-                (entity_a, entity_b), (entity_b, entity_a),
-            ]:
-                # Try loading as character ID
-                char = _load_character(catalog_dir, check_id_name)
-                if char:
-                    aliases = char.get("stable_attributes", {}).get(
-                        "aliases", {},
-                    ).get("value", [])
-                    if check_alias_name.lower() in [
-                        a.lower() for a in aliases
-                    ]:
-                        merged = True
+            # Resolve both names to IDs and cross-check aliases
+            ids_a = _resolve_name_to_ids(entity_a, catalog_dir, ground_truth)
+            ids_b = _resolve_name_to_ids(entity_b, catalog_dir, ground_truth)
 
-        label = f"{entity_a} ↔ {entity_b}"
+            for id_a in ids_a:
+                char_a = _load_character(catalog_dir, id_a)
+                if not char_a:
+                    continue
+                aliases_a = _normalize_aliases(
+                    char_a.get("stable_attributes", {}).get(
+                        "aliases", {},
+                    ).get("value"),
+                )
+                # Check if entity_b's name or any of its IDs appear as alias
+                if entity_b.lower() in aliases_a:
+                    merged = True
+                for id_b in ids_b:
+                    if id_b in aliases_a or id_b == id_a:
+                        # Same ID means they were merged
+                        pass
+
+            for id_b in ids_b:
+                char_b = _load_character(catalog_dir, id_b)
+                if not char_b:
+                    continue
+                aliases_b = _normalize_aliases(
+                    char_b.get("stable_attributes", {}).get(
+                        "aliases", {},
+                    ).get("value"),
+                )
+                if entity_a.lower() in aliases_b:
+                    merged = True
+
+            # Also check if both names resolve to the same entity ID
+            if ids_a and ids_b and set(ids_a) & set(ids_b):
+                merged = True
+
+        label = f"{entity_a} <-> {entity_b}"
         if merged:
             results.append(Result(Result.FAIL, label, f"MERGED — {reason}"))
         else:
@@ -288,12 +372,12 @@ def check_staleness(
         if gap > 50:
             results.append(Result(
                 Result.FAIL, entity_id,
-                f"turn-{last_turn} (expected ≥{expected_min}, gap={gap})",
+                f"turn-{last_turn} (expected >={expected_min}, gap={gap})",
             ))
         elif gap > 20:
             results.append(Result(
                 Result.WARN, entity_id,
-                f"turn-{last_turn} (expected ≥{expected_min}, gap={gap})",
+                f"turn-{last_turn} (expected >={expected_min}, gap={gap})",
             ))
         else:
             results.append(Result(


### PR DESCRIPTION
## Summary

Adds a post-extraction validation framework that catches entity-level problems (false alias merges, missing characters, staleness, coreference fragmentation) by comparing extraction output against a curated ground truth.

## Issue #159 — Extraction validation framework

### What's new:
1. **Full-session ground truth fixture** (`tests/fixtures/extraction-ground-truth-full-session.json`) — 16 expected independent characters, PC alias rules, must-not-merge pairs, coreference groups, staleness targets, location/faction coverage for turns 1-345
2. **Validation script** (`tools/validate_extraction.py`) — runs 7 check categories (independent characters, PC aliases, must-not-merge, coreference groups, staleness, locations, factions), produces scorecard with PASS/WARN/FAIL, returns exit code
3. **Integration tests** (`tests/test_extraction_ground_truth.py`) — 11 tests for fixture structure validation and script importability (712 total tests, 0 failures)

### Why this matters:
Run 9 had 4 false alias merges, 5 missing characters, Kael fragmented across 6 IDs, and 279-turn staleness for The Elder — all invisible to existing evaluation. Running `validate_extraction.py` against Run 9 catalogs correctly reports: **PASS: 9, WARN: 3, FAIL: 24**.

### Usage:
```
python tools/validate_extraction.py --catalog-dir framework-local/catalogs
```

### Documentation updates:
- `docs/usage.md` — added "Post-Extraction Validation" section
- `docs/architecture.md` — added `validate_extraction.py` to tool scripts table
- `docs/roadmap.md` — added extraction validation to post-extraction quality passes

Closes #159
