### PR TITLE
fix: re-import transcript with correct player label to separate DM/player text

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -167,7 +167,7 @@ Useful flags:
 - `--format {auto,markdown,labeled,alternating}` override auto-detect
 - `--dm-label` / `--player-label` for non-default speaker labels
 
-**Important:** The `--player-label` must exactly match the speaker label used in your source transcript. For example, if the transcript uses `Fenouille Moonwind:` as the player label, pass `--player-label "Fenouille Moonwind"`. If the label doesn't match, the parser won't recognize player turns and their text will be appended to the preceding DM turn, contaminating extraction input.
+**Important:** The `--player-label` must match the speaker label text used in your source transcript (case-insensitive; pass the label text without the trailing colon). For example, if the transcript uses `Fenouille Moonwind:` as the player label, pass `--player-label "Fenouille Moonwind"`. If the label text doesn't match, the parser won't recognize player turns and their text will be appended to the preceding DM turn, contaminating extraction input.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -167,6 +167,8 @@ Useful flags:
 - `--format {auto,markdown,labeled,alternating}` override auto-detect
 - `--dm-label` / `--player-label` for non-default speaker labels
 
+**Important:** The `--player-label` must exactly match the speaker label used in your source transcript. For example, if the transcript uses `Fenouille Moonwind:` as the player label, pass `--player-label "Fenouille Moonwind"`. If the label doesn't match, the parser won't recognize player turns and their text will be appended to the preceding DM turn, contaminating extraction input.
+
 ---
 
 ## Updating State


### PR DESCRIPTION
## Summary

Re-imports the session transcript with the correct player label (`Fenouille Moonwind` instead of default `Player`), fixing the bug where all DM turn files included the player's response text appended at the end.

## Issue #160 — Transcript parsing includes player text in DM turns

- **Root cause:** `bootstrap_session.py --player-label` defaulted to `Player`, but the source transcript uses `Fenouille Moonwind:` as the player label
- Without matching the label, the parser couldn't recognize player turns — their text was appended to the preceding DM turn block
- Re-imported locally with `--player-label "Fenouille Moonwind" --overwrite --allow-raw-overwrite`
- Result: 172 DM + 172 player turn files (344 total), 0 contaminated DM turns
- Session data files are gitignored (local content), so the code change here is a documentation update to `docs/usage.md` warning about this pitfall
- Deleted 86 stale DM turn files left over from the old import's numbering scheme

### Documentation

- Added a note to `docs/usage.md` explaining that `--player-label` must exactly match the speaker label used in the source transcript

Closes #160
