### PR TITLE
feat: coreference hints file for deterministic entity merging

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,6 +113,7 @@ An automated pipeline that uses an LLM to extract structured data from transcrip
 - **PC alias merge** (`_merge_pc_aliases`): Post-extraction pass that identifies character entities which are actually aliases of the player character (e.g., the PC's proper name appearing as a separate entity). Candidates must appear ≥2 times in PC event text within a ≤3 turn span. Two guards prevent false positives: (1) **co-occurrence guard** — skips merge if the candidate and char-player both appear in the same event's `related_entities`, indicating distinct characters; (2) **relationship guard** — skips merge if either entity has a relationship targeting the other.
 - Biography sections use LLM-generated descriptive titles (not generic "Phase" labels), cached in `.synthesis.json` sidecars
 - Wiki pages include cross-page entity links: the first mention of each known entity in biography prose, relationship tables, event timelines, and member/connection lists is a clickable markdown link to that entity's wiki page. Link resolution uses relative paths across entity types.
+- **Coreference hints** (`apply_coreference_hints`): Optional manual merge rules in `sessions/*/coreference-hints.json`. Each entry maps a canonical entity ID to variant names and ID patterns. After the automatic dedup pass, the pipeline loads any hints file from the session directory and deterministically merges variant entities into their canonical counterpart — absorbing relationships, events, and stable attributes, deleting variant files, and rewriting all dangling references. Validated against `schemas/coreference-hints.schema.json`.
 
 ### Timeline Layer (Framework)
 
@@ -142,6 +143,7 @@ All data structures are defined in `schemas/`. See each schema file for field de
 | `prompt-candidate.schema.json` | A candidate next-player-prompt |
 | `dm-profile.schema.json` | Inferred DM behavior profile |
 | `timeline.schema.json` | A temporal marker (season transition, time skip, biological marker, etc.) |
+| `coreference-hints.schema.json` | Manual coreference hints for entity fragmentation resolution |
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -269,6 +269,42 @@ Recommended segment sizes:
 
 Segment size 0 (the default) preserves legacy single-pass behavior.
 
+### Coreference Hints
+
+When the automatic dedup pass doesn't catch all duplicates (e.g., a character
+referred to by descriptions like "broad figure" before being named), you can
+provide a manual hints file to force deterministic merging.
+
+Create `sessions/<session>/coreference-hints.json`:
+
+```json
+{
+  "character_groups": [
+    {
+      "canonical_name": "Kael",
+      "canonical_id": "char-kael",
+      "variant_names": ["broad figure", "young hunter", "brave warrior"],
+      "variant_id_patterns": ["char-broad-figure", "char-young-hunter", "char-brave-warrior"],
+      "notes": "Kael appears unnamed before turn-149"
+    }
+  ]
+}
+```
+
+Fields:
+- `canonical_name` / `canonical_id` — the entity that survives the merge
+- `variant_names` — entity names to match (case-insensitive)
+- `variant_id_patterns` — entity IDs to match exactly
+- `notes` — optional documentation
+
+The hints file is validated against `schemas/coreference-hints.schema.json`.
+If no hints file exists, the pipeline skips this step gracefully.
+
+During batch extraction, coreference hints run after the automatic dedup pass.
+Variant entities are merged into the canonical entity: relationships, events,
+and stable attributes are absorbed, variant files are deleted from disk, and
+all dangling references are rewritten.
+
 ### Incremental Mode (Ingest)
 
 Pass `--extract` to `ingest_turn.py` to run semantic extraction on a single new turn:

--- a/schemas/coreference-hints.schema.json
+++ b/schemas/coreference-hints.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Coreference Hints",
+  "description": "Manual coreference hints for entity fragmentation resolution",
+  "type": "object",
+  "properties": {
+    "character_groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "canonical_name": { "type": "string" },
+          "canonical_id": { "type": "string" },
+          "variant_names": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "variant_id_patterns": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "notes": { "type": "string" }
+        },
+        "required": ["canonical_name", "canonical_id", "variant_names"]
+      }
+    }
+  },
+  "required": ["character_groups"]
+}

--- a/schemas/coreference-hints.schema.json
+++ b/schemas/coreference-hints.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "coreference-hints.schema.json",
   "title": "Coreference Hints",
   "description": "Manual coreference hints for entity fragmentation resolution",
   "type": "object",
@@ -9,21 +10,26 @@
       "items": {
         "type": "object",
         "properties": {
-          "canonical_name": { "type": "string" },
-          "canonical_id": { "type": "string" },
+          "canonical_name": { "type": "string", "minLength": 1 },
+          "canonical_id": {
+            "type": "string",
+            "pattern": "^(char|loc|faction|item|creature|concept)-[a-z0-9]+(-[a-z0-9]+)*$"
+          },
           "variant_names": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": { "type": "string", "minLength": 1 }
           },
           "variant_id_patterns": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": { "type": "string", "minLength": 1 }
           },
           "notes": { "type": "string" }
         },
-        "required": ["canonical_name", "canonical_id", "variant_names"]
+        "required": ["canonical_name", "canonical_id", "variant_names"],
+        "additionalProperties": false
       }
     }
   },
-  "required": ["character_groups"]
+  "required": ["character_groups"],
+  "additionalProperties": false
 }

--- a/tests/test_coreference_hints.py
+++ b/tests/test_coreference_hints.py
@@ -3,7 +3,6 @@ import json
 import os
 import sys
 import tempfile
-from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
@@ -256,6 +255,25 @@ class TestCoreferenceGracefulSkip:
 
         assert merged == []
         assert len(catalogs["characters.json"]) == 2
+
+    def test_skip_when_malformed_json(self, capsys):
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-kael", "Kael", "turn-149"),
+            ]
+        }
+        events = []
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hints_path = os.path.join(tmpdir, "coreference-hints.json")
+            with open(hints_path, "w") as f:
+                f.write("{invalid json content!!!")
+            merged = apply_coreference_hints(catalogs, events, tmpdir, hints_path)
+
+        assert merged == []
+        assert len(catalogs["characters.json"]) == 1
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
 
 
 class TestCoreferenceMatchByName:

--- a/tests/test_coreference_hints.py
+++ b/tests/test_coreference_hints.py
@@ -1,0 +1,406 @@
+"""Tests for apply_coreference_hints() — deterministic entity merging via hints file (#162)."""
+import json
+import os
+import sys
+import tempfile
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from semantic_extraction import apply_coreference_hints
+
+
+def _make_entity(id_, name, turn="turn-001", identity=None, relationships=None,
+                 stable_attributes=None):
+    entity = {
+        "id": id_,
+        "name": name,
+        "type": "character",
+        "identity": identity or f"{name} is a character.",
+        "first_seen_turn": turn,
+        "last_updated_turn": turn,
+        "relationships": relationships or [],
+        "stable_attributes": stable_attributes or {},
+    }
+    return entity
+
+
+def _make_event(event_id, turn_id, related_entities, description="Something happened"):
+    return {
+        "event_id": event_id,
+        "turn_id": turn_id,
+        "type": "interaction",
+        "description": description,
+        "related_entities": related_entities,
+    }
+
+
+def _write_hints(tmpdir, groups):
+    path = os.path.join(tmpdir, "coreference-hints.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"character_groups": groups}, f)
+    return path
+
+
+class TestApplyCoreferenceMerge:
+    """Test merging multiple variant entities into a canonical entity."""
+
+    def test_merge_three_variants_into_canonical(self):
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-kael", "Kael", "turn-149"),
+                _make_entity("char-broad-figure", "broad figure", "turn-009"),
+                _make_entity("char-young-hunter", "young hunter", "turn-020"),
+                _make_entity("char-brave-warrior", "brave warrior", "turn-050"),
+            ]
+        }
+        events = [
+            _make_event("evt-1", "turn-009", ["char-broad-figure"]),
+            _make_event("evt-2", "turn-020", ["char-young-hunter", "char-elder"]),
+            _make_event("evt-3", "turn-050", ["char-brave-warrior"]),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hints_path = _write_hints(tmpdir, [{
+                "canonical_name": "Kael",
+                "canonical_id": "char-kael",
+                "variant_names": ["broad figure", "young hunter", "brave warrior"],
+                "variant_id_patterns": ["char-broad-figure", "char-young-hunter", "char-brave-warrior"],
+            }])
+
+            merged = apply_coreference_hints(catalogs, events, tmpdir, hints_path)
+
+        assert len(merged) == 3
+        assert "char-broad-figure" in merged
+        assert "char-young-hunter" in merged
+        assert "char-brave-warrior" in merged
+
+        # Only canonical remains
+        assert len(catalogs["characters.json"]) == 1
+        assert catalogs["characters.json"][0]["id"] == "char-kael"
+
+    def test_events_reassociated_after_merge(self):
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-kael", "Kael", "turn-149"),
+                _make_entity("char-broad-figure", "broad figure", "turn-009"),
+            ]
+        }
+        events = [
+            _make_event("evt-1", "turn-009", ["char-broad-figure", "char-elder"]),
+            _make_event("evt-2", "turn-010", ["char-broad-figure"]),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hints_path = _write_hints(tmpdir, [{
+                "canonical_name": "Kael",
+                "canonical_id": "char-kael",
+                "variant_names": ["broad figure"],
+                "variant_id_patterns": ["char-broad-figure"],
+            }])
+            apply_coreference_hints(catalogs, events, tmpdir, hints_path)
+
+        # Events should now reference canonical ID
+        assert events[0]["related_entities"] == ["char-kael", "char-elder"]
+        assert events[1]["related_entities"] == ["char-kael"]
+
+    def test_relationship_references_rewritten(self):
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-kael", "Kael", "turn-149", relationships=[
+                    {"target_id": "char-elder", "source_id": "char-kael", "type": "ally_of"},
+                ]),
+                _make_entity("char-broad-figure", "broad figure", "turn-009"),
+                _make_entity("char-elder", "Elder", "turn-001", relationships=[
+                    {"target_id": "char-broad-figure", "source_id": "char-elder", "type": "captor_of"},
+                ]),
+            ]
+        }
+        events = []
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hints_path = _write_hints(tmpdir, [{
+                "canonical_name": "Kael",
+                "canonical_id": "char-kael",
+                "variant_names": ["broad figure"],
+                "variant_id_patterns": ["char-broad-figure"],
+            }])
+            apply_coreference_hints(catalogs, events, tmpdir, hints_path)
+
+        # Elder's relationship should now point to char-kael
+        elder = [e for e in catalogs["characters.json"] if e["id"] == "char-elder"][0]
+        assert elder["relationships"][0]["target_id"] == "char-kael"
+
+    def test_variant_files_deleted_from_disk(self):
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-kael", "Kael", "turn-149"),
+                _make_entity("char-broad-figure", "broad figure", "turn-009"),
+            ]
+        }
+        events = []
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            catalog_dir = tmpdir
+            char_dir = os.path.join(catalog_dir, "characters")
+            os.makedirs(char_dir, exist_ok=True)
+            # Create variant entity file on disk
+            variant_file = os.path.join(char_dir, "char-broad-figure.json")
+            with open(variant_file, "w") as f:
+                json.dump(_make_entity("char-broad-figure", "broad figure"), f)
+
+            hints_path = _write_hints(tmpdir, [{
+                "canonical_name": "Kael",
+                "canonical_id": "char-kael",
+                "variant_names": ["broad figure"],
+                "variant_id_patterns": ["char-broad-figure"],
+            }])
+            apply_coreference_hints(catalogs, events, catalog_dir, hints_path)
+
+            assert not os.path.exists(variant_file)
+
+    def test_variant_names_added_as_aliases(self):
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-kael", "Kael", "turn-149"),
+                _make_entity("char-broad-figure", "broad figure", "turn-009"),
+            ]
+        }
+        events = []
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hints_path = _write_hints(tmpdir, [{
+                "canonical_name": "Kael",
+                "canonical_id": "char-kael",
+                "variant_names": ["broad figure", "young hunter"],
+                "variant_id_patterns": ["char-broad-figure"],
+            }])
+            apply_coreference_hints(catalogs, events, tmpdir, hints_path)
+
+        kael = catalogs["characters.json"][0]
+        aliases = kael["stable_attributes"]["aliases"]["value"]
+        assert "broad figure" in aliases
+        assert "young hunter" in aliases
+        # canonical name should not be in aliases
+        assert "Kael" not in aliases
+
+
+class TestCoreferenceGracefulSkip:
+    """Test that missing or empty hints are handled gracefully."""
+
+    def test_skip_when_no_hints_file(self):
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-kael", "Kael", "turn-149"),
+            ]
+        }
+        events = []
+
+        merged = apply_coreference_hints(catalogs, events, "/nonexistent", "/nonexistent/hints.json")
+        assert merged == []
+        assert len(catalogs["characters.json"]) == 1
+
+    def test_skip_when_empty_groups(self):
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-kael", "Kael", "turn-149"),
+            ]
+        }
+        events = []
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hints_path = _write_hints(tmpdir, [])
+            merged = apply_coreference_hints(catalogs, events, tmpdir, hints_path)
+
+        assert merged == []
+        assert len(catalogs["characters.json"]) == 1
+
+    def test_skip_when_canonical_not_found(self, capsys):
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-other", "Other", "turn-001"),
+            ]
+        }
+        events = []
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hints_path = _write_hints(tmpdir, [{
+                "canonical_name": "Kael",
+                "canonical_id": "char-kael",
+                "variant_names": ["broad figure"],
+            }])
+            merged = apply_coreference_hints(catalogs, events, tmpdir, hints_path)
+
+        assert merged == []
+        assert len(catalogs["characters.json"]) == 1
+        captured = capsys.readouterr()
+        assert "not found" in captured.out
+
+    def test_no_match_leaves_catalogs_unchanged(self):
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-kael", "Kael", "turn-149"),
+                _make_entity("char-elder", "Elder", "turn-001"),
+            ]
+        }
+        events = []
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hints_path = _write_hints(tmpdir, [{
+                "canonical_name": "Kael",
+                "canonical_id": "char-kael",
+                "variant_names": ["nonexistent name"],
+                "variant_id_patterns": ["char-nonexistent"],
+            }])
+            merged = apply_coreference_hints(catalogs, events, tmpdir, hints_path)
+
+        assert merged == []
+        assert len(catalogs["characters.json"]) == 2
+
+
+class TestCoreferenceMatchByName:
+    """Test that variants can be matched by name alone (no ID pattern needed)."""
+
+    def test_match_by_name_only(self):
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-kael", "Kael", "turn-149"),
+                _make_entity("char-unknown-123", "young hunter", "turn-020"),
+            ]
+        }
+        events = [
+            _make_event("evt-1", "turn-020", ["char-unknown-123"]),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hints_path = _write_hints(tmpdir, [{
+                "canonical_name": "Kael",
+                "canonical_id": "char-kael",
+                "variant_names": ["young hunter"],
+            }])
+            merged = apply_coreference_hints(catalogs, events, tmpdir, hints_path)
+
+        assert "char-unknown-123" in merged
+        assert len(catalogs["characters.json"]) == 1
+        assert events[0]["related_entities"] == ["char-kael"]
+
+    def test_match_by_id_pattern_only(self):
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-kael", "Kael", "turn-149"),
+                _make_entity("char-broad-figure", "A tall broad figure", "turn-009"),
+            ]
+        }
+        events = []
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hints_path = _write_hints(tmpdir, [{
+                "canonical_name": "Kael",
+                "canonical_id": "char-kael",
+                "variant_names": [],
+                "variant_id_patterns": ["char-broad-figure"],
+            }])
+            merged = apply_coreference_hints(catalogs, events, tmpdir, hints_path)
+
+        assert "char-broad-figure" in merged
+        assert len(catalogs["characters.json"]) == 1
+
+
+class TestCoreferenceDryRun:
+    """Test that dry_run prevents file deletion but still modifies in-memory catalogs."""
+
+    def test_dry_run_does_not_delete_files(self):
+        catalogs = {
+            "characters.json": [
+                _make_entity("char-kael", "Kael", "turn-149"),
+                _make_entity("char-broad-figure", "broad figure", "turn-009"),
+            ]
+        }
+        events = []
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            catalog_dir = tmpdir
+            char_dir = os.path.join(catalog_dir, "characters")
+            os.makedirs(char_dir, exist_ok=True)
+            variant_file = os.path.join(char_dir, "char-broad-figure.json")
+            with open(variant_file, "w") as f:
+                json.dump(_make_entity("char-broad-figure", "broad figure"), f)
+
+            hints_path = _write_hints(tmpdir, [{
+                "canonical_name": "Kael",
+                "canonical_id": "char-kael",
+                "variant_names": ["broad figure"],
+                "variant_id_patterns": ["char-broad-figure"],
+            }])
+            merged = apply_coreference_hints(catalogs, events, catalog_dir, hints_path, dry_run=True)
+
+            assert len(merged) == 1
+            # File should still exist because dry_run=True
+            assert os.path.exists(variant_file)
+
+
+class TestCoreferenceHintsValidation:
+    """Test loading and validating hints files."""
+
+    def test_valid_hints_file_loads(self):
+        catalogs = {"characters.json": [_make_entity("char-kael", "Kael")]}
+        events = []
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hints_path = _write_hints(tmpdir, [{
+                "canonical_name": "Kael",
+                "canonical_id": "char-kael",
+                "variant_names": ["broad figure"],
+                "variant_id_patterns": ["char-broad-figure"],
+                "notes": "Test note",
+            }])
+            # Should not raise
+            merged = apply_coreference_hints(catalogs, events, tmpdir, hints_path)
+            assert isinstance(merged, list)
+
+    def test_hints_schema_valid(self):
+        """Validate the hints file against its schema."""
+        schema_path = os.path.join(
+            os.path.dirname(__file__), "..", "schemas", "coreference-hints.schema.json"
+        )
+        hints_data = {
+            "character_groups": [{
+                "canonical_name": "Kael",
+                "canonical_id": "char-kael",
+                "variant_names": ["broad figure"],
+                "variant_id_patterns": ["char-broad-figure"],
+                "notes": "test",
+            }]
+        }
+
+        try:
+            import jsonschema
+            with open(schema_path, "r", encoding="utf-8") as f:
+                schema = json.load(f)
+            jsonschema.validate(hints_data, schema)
+        except ImportError:
+            pass  # jsonschema not required for basic tests
+
+    def test_session_hints_file_valid(self):
+        """Validate the session-import hints file against its schema."""
+        hints_path = os.path.join(
+            os.path.dirname(__file__), "..", "sessions", "session-import",
+            "coreference-hints.json",
+        )
+        schema_path = os.path.join(
+            os.path.dirname(__file__), "..", "schemas", "coreference-hints.schema.json"
+        )
+
+        if not os.path.exists(hints_path):
+            return  # Skip if session file doesn't exist
+
+        with open(hints_path, "r", encoding="utf-8") as f:
+            hints_data = json.load(f)
+
+        try:
+            import jsonschema
+            with open(schema_path, "r", encoding="utf-8") as f:
+                schema = json.load(f)
+            jsonschema.validate(hints_data, schema)
+        except ImportError:
+            pass  # jsonschema not required

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -2044,8 +2044,12 @@ def apply_coreference_hints(
     if not os.path.isfile(hints_path):
         return []
 
-    with open(hints_path, "r", encoding="utf-8") as f:
-        hints = json.load(f)
+    try:
+        with open(hints_path, "r", encoding="utf-8") as f:
+            hints = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"  WARNING: failed to load coreference hints '{hints_path}': {exc}", file=sys.stderr)
+        return []
 
     groups = hints.get("character_groups", [])
     if not groups:
@@ -2100,7 +2104,7 @@ def apply_coreference_hints(
         for variant in variants_to_remove:
             entities.remove(variant)
 
-        # Delete variant files from disk (V2 layout)
+        # Delete variant files from disk (V2 layout) — per-group only
         if catalog_dir and not dry_run:
             # Determine subdirectory from entity type prefix
             prefix = canonical_id.split("-", 1)[0] if "-" in canonical_id else ""
@@ -2114,10 +2118,12 @@ def apply_coreference_hints(
             }
             subdir = type_dirs.get(prefix, "")
             if subdir:
-                for eid in merged_ids:
-                    entity_file = os.path.join(catalog_dir, subdir, f"{eid}.json")
-                    if os.path.isfile(entity_file):
-                        os.remove(entity_file)
+                for variant in variants_to_remove:
+                    eid = variant.get("id", "")
+                    if eid:
+                        entity_file = os.path.join(catalog_dir, subdir, f"{eid}.json")
+                        if os.path.isfile(entity_file):
+                            os.remove(entity_file)
 
         # Add variant names as aliases on the canonical entry
         sa = canonical_entry.setdefault("stable_attributes", {})
@@ -2127,9 +2133,15 @@ def apply_coreference_hints(
         alias_list = aliases.get("value", [])
         if isinstance(alias_list, str):
             alias_list = [a.strip() for a in alias_list.split(",") if a.strip()]
+        existing_aliases_lower = {a.strip().lower() for a in alias_list if isinstance(a, str) and a.strip()}
+        canonical_lower = canonical_name.strip().lower()
         for vname in group.get("variant_names", []):
-            if vname not in alias_list and vname.lower() != canonical_name.lower():
-                alias_list.append(vname)
+            stripped = vname.strip() if isinstance(vname, str) else ""
+            if not stripped:
+                continue
+            if stripped.lower() not in existing_aliases_lower and stripped.lower() != canonical_lower:
+                alias_list.append(stripped)
+                existing_aliases_lower.add(stripped.lower())
         aliases["value"] = alias_list
         sa["aliases"] = aliases
 

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -2021,6 +2021,129 @@ def _merge_pc_aliases(
 
 
 # ---------------------------------------------------------------------------
+# Coreference hints — deterministic merging (#162)
+# ---------------------------------------------------------------------------
+
+def apply_coreference_hints(
+    catalogs: dict,
+    events_list: list,
+    catalog_dir: str,
+    hints_path: str,
+    dry_run: bool = False,
+) -> list[str]:
+    """Apply manual coreference hints to merge known entity variants.
+
+    Loads a coreference-hints.json file and merges variant entities into their
+    canonical counterpart.  This is a deterministic merge for cases where the
+    same character is referred to by multiple names/IDs across the transcript.
+
+    Returns list of entity IDs that were merged away.
+    """
+    from catalog_merger import dedup_merge_entity
+
+    if not os.path.isfile(hints_path):
+        return []
+
+    with open(hints_path, "r", encoding="utf-8") as f:
+        hints = json.load(f)
+
+    groups = hints.get("character_groups", [])
+    if not groups:
+        return []
+
+    merged_ids: list[str] = []
+    merge_map: dict[str, str] = {}
+
+    for group in groups:
+        canonical_id = group.get("canonical_id", "")
+        canonical_name = group.get("canonical_name", "")
+        variant_id_patterns = set(group.get("variant_id_patterns", []))
+        variant_names = {n.strip().lower() for n in group.get("variant_names", [])}
+
+        if not canonical_id:
+            continue
+
+        # Find canonical entity
+        canonical_result = find_entity_by_id(catalogs, canonical_id)
+        if not canonical_result:
+            print(f"  Coreference hints: canonical entity '{canonical_id}' not found, skipping group '{canonical_name}'")
+            continue
+        canonical_catalog, canonical_entry = canonical_result
+
+        # Find and merge all variants
+        entities = catalogs.get(canonical_catalog, [])
+        variants_to_remove = []
+
+        for entity in entities:
+            eid = entity.get("id", "")
+            if eid == canonical_id or not eid:
+                continue
+
+            ename = entity.get("name", "").strip().lower()
+            matched = eid in variant_id_patterns or ename in variant_names
+            if not matched:
+                continue
+
+            # Merge variant into canonical, but prevent dedup_merge_entity
+            # from overwriting the canonical name with the variant's name.
+            saved_name = canonical_entry.get("name")
+            variant_copy = dict(entity)
+            variant_copy.pop("name", None)
+            dedup_merge_entity(canonical_entry, variant_copy)
+            canonical_entry["name"] = saved_name
+            variants_to_remove.append(entity)
+            merge_map[eid] = canonical_id
+            merged_ids.append(eid)
+            print(f"  Coreference hints: merged '{eid}' ({entity.get('name', '')}) into '{canonical_id}'")
+
+        # Remove merged variants from catalog list
+        for variant in variants_to_remove:
+            entities.remove(variant)
+
+        # Delete variant files from disk (V2 layout)
+        if catalog_dir and not dry_run:
+            # Determine subdirectory from entity type prefix
+            prefix = canonical_id.split("-", 1)[0] if "-" in canonical_id else ""
+            type_dirs = {
+                "char": "characters",
+                "loc": "locations",
+                "faction": "factions",
+                "item": "items",
+                "creature": "creatures",
+                "concept": "concepts",
+            }
+            subdir = type_dirs.get(prefix, "")
+            if subdir:
+                for eid in merged_ids:
+                    entity_file = os.path.join(catalog_dir, subdir, f"{eid}.json")
+                    if os.path.isfile(entity_file):
+                        os.remove(entity_file)
+
+        # Add variant names as aliases on the canonical entry
+        sa = canonical_entry.setdefault("stable_attributes", {})
+        aliases = sa.get("aliases", {"value": []})
+        if not isinstance(aliases, dict):
+            aliases = {"value": []}
+        alias_list = aliases.get("value", [])
+        if isinstance(alias_list, str):
+            alias_list = [a.strip() for a in alias_list.split(",") if a.strip()]
+        for vname in group.get("variant_names", []):
+            if vname not in alias_list and vname.lower() != canonical_name.lower():
+                alias_list.append(vname)
+        aliases["value"] = alias_list
+        sa["aliases"] = aliases
+
+    # Rewrite dangling references to merged variant IDs
+    if merge_map:
+        _rewrite_stale_ids(catalogs, events_list, merge_map)
+
+    if merged_ids:
+        print(f"  Coreference hints: merged {len(merged_ids)} variant(s) total")
+
+    return merged_ids
+
+
+# ---------------------------------------------------------------------------
 # Segmented extraction helpers (#141)
 # ---------------------------------------------------------------------------
 
@@ -2518,6 +2641,14 @@ def extract_semantic_batch(
         _rewrite_stale_ids(catalogs, events_list, merge_map)
         entities_after = sum(len(v) for v in catalogs.values())
         print(f"  Post-batch dedup merged {dupes_merged} duplicate(s); {entities_after} entities remain")
+
+    # Apply coreference hints (manual merge rules, #162)
+    hints_path = os.path.join(session_dir, "coreference-hints.json")
+    if os.path.isfile(hints_path):
+        coref_merged = apply_coreference_hints(catalogs, events_list, catalog_dir, hints_path, dry_run)
+        if coref_merged:
+            entities_after = sum(len(v) for v in catalogs.values())
+            print(f"  Coreference hints applied; {entities_after} entities remain")
 
     # --- Phase 4: Post-batch orphan sweep (#106) ---
     orphan_stubs = _post_batch_orphan_sweep(catalogs, events_list)

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -49,6 +49,7 @@ SCHEMA_MAP = {
     "season-summaries.json": "schemas/season-summary.schema.json",
     "metadata.json": "schemas/metadata.schema.json",
     "turn-context.json": "schemas/turn-context.schema.json",
+    "coreference-hints.json": "schemas/coreference-hints.schema.json",
 }
 
 # Entity catalog directory names that contain per-entity JSON files


### PR DESCRIPTION
## Summary

Adds coreference hints file support for deterministic merging of known entity fragments. When the automatic dedup pass can't catch all duplicates (e.g., a character referred to by descriptions like "broad figure" before being named), a session-level hints file provides manual merge rules.

## Issue #162 — Kael entity fragmentation (partial fix)

- **New schema**: `schemas/coreference-hints.schema.json` — defines the hints file format with character groups containing canonical ID, variant names, and variant ID patterns
- **New function**: `apply_coreference_hints()` in `tools/semantic_extraction.py` — loads hints, merges variant entities into canonical, absorbs relationships/events/stable_attributes, deletes variant files from disk, and rewrites all dangling references
- **Pipeline integration**: Runs after the automatic dedup pass in `extract_semantic_batch()`, before orphan sweep
- **Canonical name preservation**: Prevents `dedup_merge_entity()` from overwriting the canonical entity's name with the variant's name during merge
- **Validation**: Added `coreference-hints.json` to `tools/validate.py` schema map
- **Tests**: 15 new tests covering merge of multiple variants, event reassociation, relationship rewriting, file deletion, alias addition, dry-run mode, graceful skip on missing/empty hints, name-only matching, and ID-pattern-only matching
- **Docs**: Updated `docs/architecture.md` (extraction pipeline description + schema table) and `docs/usage.md` (new Coreference Hints section with format and usage)

### Usage

Create `sessions/<session>/coreference-hints.json` with groups of variant names/IDs to merge:

```json
{
  "character_groups": [
    {
      "canonical_name": "Kael",
      "canonical_id": "char-kael",
      "variant_names": ["broad figure", "young hunter"],
      "variant_id_patterns": ["char-broad-figure", "char-young-hunter"]
    }
  ]
}
```

The pipeline picks it up automatically during batch extraction. If no hints file exists, the step is skipped gracefully.

Partially addresses #162
