### PR TITLE
fix: strip null values from stable_attributes before validation

### DIFF
--- a/tests/test_coerce_entity.py
+++ b/tests/test_coerce_entity.py
@@ -938,3 +938,22 @@ def test_coerce_new_suffix_discards_schema_key_variants_when_base_exists():
     assert "name_new" not in result
     assert result["id"] == "char-player"
     assert result["name"] == "PC"
+
+
+def test_coerce_stable_attributes_null_value_removed():
+    """stable_attributes entries with null value are stripped (#178)."""
+    entity = {
+        "id": "char-player", "name": "PC", "type": "character",
+        "identity": "The player.",
+        "first_seen_turn": "turn-001", "last_updated_turn": "turn-050",
+        "stable_attributes": {
+            "race": {"value": "human", "inference": False, "confidence": 1.0},
+            "class": {"value": None, "inference": False, "confidence": 1.0},
+            "alignment": {"value": "neutral", "inference": True, "confidence": 0.7},
+        },
+    }
+    result = _coerce_entity_fields(entity)
+    sa = result["stable_attributes"]
+    assert "race" in sa
+    assert "alignment" in sa
+    assert "class" not in sa  # null value stripped

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -409,6 +409,16 @@ def _coerce_entity_fields(entity_data) -> dict | None:
             entity_data.pop(dk)
             print(f"  COERCE: discarded non-schema key '{dk}'", file=sys.stderr)
 
+    # Strip stable_attributes entries where the LLM returned null for value (#178).
+    # The schema requires value to be string or string[] — null is not valid.
+    sa = entity_data.get("stable_attributes")
+    if isinstance(sa, dict):
+        null_keys = [k for k, v in sa.items()
+                     if isinstance(v, dict) and v.get("value") is None]
+        for k in null_keys:
+            del sa[k]
+            print(f"  COERCE: stable_attributes.{k}.value was null — removed", file=sys.stderr)
+
     # Ensure volatile_state has last_updated_turn if we populated it
     vs = entity_data.get("volatile_state")
     if isinstance(vs, dict) and "last_updated_turn" not in vs and has_valid_turn:


### PR DESCRIPTION
## Summary

Strip `null` values from `stable_attributes` entries before schema validation, preventing false validation failures when the LLM returns `null` for attribute values.

## Issue #178 — LLM null values in stable_attributes cause schema validation failure

During Run 10a PC recovery, 9 turns (~7%) failed schema validation with:
```
WARNING: Entity failed schema validation: None is not valid under any of the given schemas
```

The LLM sometimes returns `null` for `stable_attributes.*.value`, but the entity schema only accepts `string` or `string[]`. The partial merge fallback rescues some fields, but **relationship updates from those turns are lost entirely**.

### Changes

- **`tools/semantic_extraction.py`**: Added null-value stripping in `_coerce_entity_fields()` — entries where `stable_attributes.*.value` is `None` are removed before validation
- **`tests/test_coerce_entity.py`**: Added `test_coerce_stable_attributes_null_value_removed` (764 tests pass)

Closes #178
