### PR TITLE
feat: add Google Gemini Flash support for cloud-based extraction

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,7 +100,7 @@ An automated pipeline that uses an LLM to extract structured data from transcrip
 - Prompt templates in `templates/extraction/` define each agent's behavior
 - `tools/semantic_extraction.py` orchestrates the pipeline
 - `tools/catalog_merger.py` merges agent outputs into `framework/catalogs/`; includes per-pair relationship consolidation, `_dedup_relationships()` safety net (#183), and `cleanup_dangling_relationships()` to remove refs to non-existent entities (#184)
-- `tools/llm_client.py` provides a provider-agnostic LLM wrapper (OpenAI, Ollama, etc.)
+- `tools/llm_client.py` provides a provider-agnostic LLM wrapper (OpenAI, Ollama, Google Gemini, etc.)
 - `config/llm.json` configures the LLM provider, model, and endpoint
 - All extracted entities are validated against `schemas/entity.schema.json` before merging
 - Entities below a confidence threshold are logged but not cataloged
@@ -166,7 +166,7 @@ All data structures are defined in `schemas/`. See each schema file for field de
 | `tools/semantic_extraction.py` | LLM-based entity/relationship/event extraction pipeline |
 | `tools/temporal_extraction.py` | Pattern-based temporal signal extraction and day estimation |
 | `tools/catalog_merger.py` | Merge extracted entities into framework catalog files |
-| `tools/llm_client.py` | Provider-agnostic LLM client (OpenAI, Ollama, etc.) |
+| `tools/llm_client.py` | Provider-agnostic LLM client (OpenAI, Ollama, Google Gemini, etc.) |
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,7 +39,7 @@ Semantic extraction uses an LLM to identify entities, relationships, and events 
 
 - **Minimum**: 7B parameters — basic entity extraction works but expect some ID format errors and weak coreference resolution
 - **Recommended**: 14B+ parameters — reliable JSON output, good coreference, accurate entity classification
-- **Best**: GPT-4o or equivalent cloud model — highest accuracy but requires API key and costs per token
+- **Best**: GPT-4o, Gemini Flash, or equivalent cloud model — highest accuracy but requires API key and costs per token
 
 ### Tested Models
 
@@ -47,6 +47,7 @@ Semantic extraction uses an LLM to identify entities, relationships, and events 
 |---|---|---|---|---|
 | `qwen2.5:3b` | 3B | Q4_K_M | ~2.5 GB | Poor — 0% item recall, frequent hallucinations, ID format violations |
 | `qwen2.5:14b` | 14B | Q4_K_M | ~9 GB | Good — reliable entity classification, items extracted, acceptable coreference |
+| `gemini-2.5-flash` (Google) | Unknown | N/A | Cloud | Very good — fast, low cost (~$0.30/run), 1M token context, strong JSON mode |
 | `gpt-4o` (OpenAI) | Unknown | N/A | Cloud | Best — accurate structured JSON, strong coreference, minimal hallucination |
 
 ### VRAM Quick Reference
@@ -65,6 +66,45 @@ Semantic extraction uses an LLM to identify entities, relationships, and events 
 - Items rarely or never extracted
 - Location/character/faction type confusion
 - Hallucinated entities not present in the source text
+
+### Using Google Gemini
+
+Google Gemini models are accessible via an OpenAI-compatible endpoint. Set up
+an API key at [aistudio.google.com/apikey](https://aistudio.google.com/apikey),
+then configure `config/llm.json`:
+
+```json
+{
+  "provider": "openai",
+  "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
+  "model": "gemini-2.5-flash",
+  "api_key_env": "GEMINI_API_KEY",
+  "temperature": 0.0,
+  "max_tokens": 4096,
+  "pc_max_tokens": 8192,
+  "timeout_seconds": 60,
+  "retry_attempts": 3,
+  "batch_delay_ms": 100
+}
+```
+
+Set the environment variable before running extraction:
+
+```powershell
+# PowerShell — persist across sessions
+[Environment]::SetEnvironmentVariable("GEMINI_API_KEY", "your-key-here", "User")
+```
+
+```bash
+# Bash / sh
+export GEMINI_API_KEY="your-key-here"
+```
+
+> **Note:** Gemini uses the same OpenAI-compatible client path as GPT-4o.
+> No Ollama-specific options are needed. The `context_length` field is
+> ignored for cloud providers (Gemini manages context internally with up
+> to 1M tokens). Set `batch_delay_ms` to `100` or lower — cloud APIs
+> handle concurrent requests without GPU contention.
 
 ### Using a Local Model
 

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -4,6 +4,8 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
 # Ensure `import openai` succeeds even when the package is not installed.
@@ -12,7 +14,7 @@ if "openai" not in sys.modules:
     _mock_openai.OpenAI = MagicMock
     sys.modules["openai"] = _mock_openai
 
-from llm_client import LLMClient
+from llm_client import LLMClient, LLMExtractionError
 
 
 def _write_config(tmp_dir, overrides=None):
@@ -69,11 +71,9 @@ class TestGeminiProviderConfig:
         env = os.environ.copy()
         env.pop("GEMINI_API_KEY", None)
         with patch.dict(os.environ, env, clear=True):
-            try:
+            with pytest.raises(LLMExtractionError) as exc_info:
                 LLMClient(path)
-                assert False, "Should have raised"
-            except Exception as e:
-                assert "GEMINI_API_KEY" in str(e)
+            assert "GEMINI_API_KEY" in str(exc_info.value)
 
     def test_gemini_context_length_not_injected(self, tmp_path):
         """context_length should be stored but not cause Ollama extra_body."""

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -50,9 +50,12 @@ class TestGeminiProviderConfig:
         assert client.model == "gemini-2.5-flash"
 
     def test_gemini_base_url_preserved(self, tmp_path):
+        from urllib.parse import urlparse
+
         path = _write_config(str(tmp_path))
         client = LLMClient(path)
-        assert "generativelanguage.googleapis.com" in client.config["base_url"]
+        parsed = urlparse(client.config["base_url"])
+        assert parsed.hostname == "generativelanguage.googleapis.com"
 
     def test_gemini_api_key_env_loading(self, tmp_path):
         path = _write_config(str(tmp_path), {"api_key_env": "GEMINI_API_KEY"})

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -1,0 +1,149 @@
+"""Tests for Gemini Flash provider configuration and client behavior (#190)."""
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+# Ensure `import openai` succeeds even when the package is not installed.
+if "openai" not in sys.modules:
+    _mock_openai = MagicMock()
+    _mock_openai.OpenAI = MagicMock
+    sys.modules["openai"] = _mock_openai
+
+from llm_client import LLMClient
+
+
+def _write_config(tmp_dir, overrides=None):
+    """Write a minimal llm.json and return its path."""
+    cfg = {
+        "provider": "openai",
+        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
+        "model": "gemini-2.5-flash",
+        "api_key_env": "",
+        "temperature": 0.0,
+        "max_tokens": 4096,
+        "timeout_seconds": 10,
+        "retry_attempts": 1,
+        "batch_delay_ms": 0,
+    }
+    if overrides:
+        cfg.update(overrides)
+    path = os.path.join(tmp_dir, "llm.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(cfg, f)
+    return path
+
+
+class TestGeminiProviderConfig:
+    """Verify Gemini config loads correctly and is not treated as Ollama."""
+
+    def test_gemini_not_detected_as_ollama(self, tmp_path):
+        path = _write_config(str(tmp_path))
+        client = LLMClient(path)
+        assert not client._is_ollama
+
+    def test_gemini_model_name(self, tmp_path):
+        path = _write_config(str(tmp_path))
+        client = LLMClient(path)
+        assert client.model == "gemini-2.5-flash"
+
+    def test_gemini_base_url_preserved(self, tmp_path):
+        path = _write_config(str(tmp_path))
+        client = LLMClient(path)
+        assert "generativelanguage.googleapis.com" in client.config["base_url"]
+
+    def test_gemini_api_key_env_loading(self, tmp_path):
+        path = _write_config(str(tmp_path), {"api_key_env": "GEMINI_API_KEY"})
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "test-key-12345"}):
+            client = LLMClient(path)
+            assert client.model == "gemini-2.5-flash"
+
+    def test_gemini_api_key_missing_raises(self, tmp_path):
+        path = _write_config(str(tmp_path), {"api_key_env": "GEMINI_API_KEY"})
+        # Ensure the var is NOT set
+        env = os.environ.copy()
+        env.pop("GEMINI_API_KEY", None)
+        with patch.dict(os.environ, env, clear=True):
+            try:
+                LLMClient(path)
+                assert False, "Should have raised"
+            except Exception as e:
+                assert "GEMINI_API_KEY" in str(e)
+
+    def test_gemini_context_length_not_injected(self, tmp_path):
+        """context_length should be stored but not cause Ollama extra_body."""
+        path = _write_config(str(tmp_path), {"context_length": 1048576})
+        client = LLMClient(path)
+        assert client.context_length == 1048576
+        assert not client._is_ollama
+
+    def test_gemini_with_overrides(self, tmp_path):
+        path = _write_config(str(tmp_path))
+        client = LLMClient(path, overrides={"model": "gemini-2.5-flash-lite"})
+        assert client.model == "gemini-2.5-flash-lite"
+
+    def test_gemini_pc_max_tokens_default(self, tmp_path):
+        path = _write_config(str(tmp_path))
+        client = LLMClient(path)
+        assert client.pc_max_tokens == 4096  # Falls back to max_tokens
+
+    def test_gemini_pc_max_tokens_explicit(self, tmp_path):
+        path = _write_config(str(tmp_path), {"pc_max_tokens": 8192})
+        client = LLMClient(path)
+        assert client.pc_max_tokens == 8192
+
+
+class TestGeminiExtractJsonNoOllamaBody:
+    """Ensure extract_json does NOT inject Ollama extra_body for Gemini."""
+
+    def test_no_extra_body_for_gemini(self, tmp_path):
+        path = _write_config(str(tmp_path), {"context_length": 1048576})
+        client = LLMClient(path)
+
+        # Mock the underlying OpenAI client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = '{"entities": []}'
+        client.client.chat.completions.create = MagicMock(return_value=mock_response)
+
+        result = client.extract_json("system", "user")
+
+        call_kwargs = client.client.chat.completions.create.call_args[1]
+        assert "extra_body" not in call_kwargs
+        assert result == {"entities": []}
+
+    def test_response_format_json_object_sent(self, tmp_path):
+        path = _write_config(str(tmp_path))
+        client = LLMClient(path)
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = '{"test": true}'
+        client.client.chat.completions.create = MagicMock(return_value=mock_response)
+
+        client.extract_json("system", "user")
+
+        call_kwargs = client.client.chat.completions.create.call_args[1]
+        assert call_kwargs["response_format"] == {"type": "json_object"}
+        assert call_kwargs["model"] == "gemini-2.5-flash"
+
+
+class TestGeminiGenerateTextNoOllamaBody:
+    """Ensure generate_text does NOT inject Ollama extra_body for Gemini."""
+
+    def test_no_extra_body_for_gemini_text(self, tmp_path):
+        path = _write_config(str(tmp_path), {"context_length": 1048576})
+        client = LLMClient(path)
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Some text response"
+        client.client.chat.completions.create = MagicMock(return_value=mock_response)
+
+        result = client.generate_text("system", "user")
+
+        call_kwargs = client.client.chat.completions.create.call_args[1]
+        assert "extra_body" not in call_kwargs
+        assert result == "Some text response"


### PR DESCRIPTION
## Summary

Add Google Gemini Flash support as a cloud LLM provider for semantic extraction. Gemini 2.5 Flash is the lowest-cost cloud option (~$0.30 per 344-turn run) and works with zero changes to `llm_client.py` via its OpenAI-compatible endpoint.

## Changes

### Documentation
- **docs/usage.md**: Added `gemini-2.5-flash` to the tested models table, added a full "Using Google Gemini" configuration section with `config/llm.json` example, environment variable setup for PowerShell and Bash, and provider notes.
- **docs/architecture.md**: Updated provider references to include Google Gemini alongside OpenAI and Ollama.

### Tests
- **tests/test_gemini_provider.py**: 12 new tests covering:
  - Config loading with Gemini base URL and model name
  - Gemini is NOT detected as Ollama (`_is_ollama == False`)
  - API key environment variable loading and missing-key error
  - `context_length` stored but no Ollama `extra_body` injected
  - `extract_json` sends `response_format: {"type": "json_object"}` without `extra_body`
  - `generate_text` sends no `extra_body` for Gemini
  - Config overrides and `pc_max_tokens` behavior

### Validation
- Live smoke test confirmed `gemini-2.5-flash` handles JSON mode and free text via the OpenAI-compat endpoint at `generativelanguage.googleapis.com/v1beta/openai/`
- Full test suite: 842 passed (830 existing + 12 new)

## No code changes to `llm_client.py`

The existing OpenAI-compatible client path works as-is for Gemini. The `_is_ollama` gate correctly prevents Ollama-specific `extra_body` injection for non-Ollama providers.

Closes #190
