### PR TITLE
feat: add detached extraction operational tooling

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,6 +167,9 @@ All data structures are defined in `schemas/`. See each schema file for field de
 | `tools/temporal_extraction.py` | Pattern-based temporal signal extraction and day estimation |
 | `tools/catalog_merger.py` | Merge extracted entities into framework catalog files |
 | `tools/llm_client.py` | Provider-agnostic LLM client (OpenAI, Ollama, Google Gemini, etc.) |
+| `tools/start_extraction_detached.ps1` | Launch semantic extraction in a detached process with log/PID files |
+| `tools/watch_extraction_detached.ps1` | Show status and tail logs for detached extraction runs |
+| `tools/stop_extraction_detached.ps1` | Stop detached extraction runs by PID file |
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -83,7 +83,7 @@ Goals:
 Remaining work:
 - Fallback provider chain in `tools/llm_client.py` (local → cloud)
 - CLI `--provider` override for per-run provider selection
-- Batch processing mode for unattended overnight extraction
+- Batch processing mode for unattended overnight extraction (**partially implemented** via detached helper scripts: `tools/start_extraction_detached.ps1`, `tools/watch_extraction_detached.ps1`, `tools/stop_extraction_detached.ps1`)
 - Provider setup documentation in `docs/usage.md`
 - Quality validation of `qwen2.5:7b` as a faster alternative to 14B
 - **Segmented extraction** (#141): Long sessions (300+ turns) are extracted in configurable segments to stay within model context limits. Each segment starts with a clean entity catalog; a reconciliation pass merges the results. Naturally parallelizable across GPU instances.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -339,6 +339,67 @@ The pipeline processes each turn through four agents:
 
 Progress is checkpointed every 50 turns and can resume after interruption.
 
+### Detached Batch Execution (Recommended)
+
+For long extraction runs, launch extraction in a detached process so work in
+other VS Code chat sessions does not affect the running job.
+
+Use the helper script from the repository root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools/start_extraction_detached.ps1 `
+  -Session sessions/session-import `
+  -TranscriptFile sessions/_import/session-import-full-transcript.txt `
+  -SegmentSize 100
+```
+
+The script writes:
+- stdout log: `run-logs/extract-<timestamp>.log`
+- stderr log: `run-logs/extract-<timestamp>.err.log`
+- PID file: `run-logs/extract-<timestamp>.pid`
+- command helper: `run-logs/extract-<timestamp>.cmd.txt`
+
+Monitor/status a detached run (latest run by default):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools/watch_extraction_detached.ps1
+```
+
+Follow live stdout for a specific run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools/watch_extraction_detached.ps1 `
+  -PidFile run-logs/extract-<timestamp>.pid `
+  -Follow
+```
+
+Manual monitoring (without helper script):
+
+```powershell
+Get-Content run-logs/extract-<timestamp>.log -Tail 80
+Get-Content run-logs/extract-<timestamp>.err.log -Tail 80
+Get-Process -Id (Get-Content run-logs/extract-<timestamp>.pid)
+```
+
+Stop a detached run (latest run by default):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools/stop_extraction_detached.ps1
+```
+
+Stop a specific run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools/stop_extraction_detached.ps1 `
+  -PidFile run-logs/extract-<timestamp>.pid
+```
+
+Manual stop (without helper script):
+
+```powershell
+Stop-Process -Id (Get-Content run-logs/extract-<timestamp>.pid)
+```
+
 ### Segmented Extraction
 
 For sessions with 200+ turns on models with ≤32K context windows, use

--- a/tools/start_extraction_detached.ps1
+++ b/tools/start_extraction_detached.ps1
@@ -4,8 +4,7 @@ param(
     [int]$SegmentSize = 100,
     [string]$Model = "",
     [string]$LogsDir = "run-logs",
-    [switch]$Overwrite,
-    [switch]$NoExtract
+    [switch]$Overwrite
 )
 
 Set-StrictMode -Version Latest
@@ -39,10 +38,6 @@ if (-not (Test-Path -Path $TranscriptFile)) {
 
 $args += @("--file", $TranscriptFile)
 
-if (-not $NoExtract) {
-    $args += "--extract"
-}
-
 if ($SegmentSize -gt 0) {
     $args += @("--segment-size", $SegmentSize)
 }
@@ -59,7 +54,12 @@ $process = Start-Process -FilePath "python" -ArgumentList $args -RedirectStandar
 
 $process.Id | Set-Content -Path $pidPath
 
-$argString = $args -join " "
+function Format-QuotedArg {
+    param([string]$Value)
+    return "'" + $Value.Replace("'", "''") + "'"
+}
+
+$argString = ($args | ForEach-Object { Format-QuotedArg $_ }) -join " "
 @(
     "python $argString",
     "",

--- a/tools/start_extraction_detached.ps1
+++ b/tools/start_extraction_detached.ps1
@@ -1,0 +1,79 @@
+param(
+    [string]$Session = "sessions/session-import",
+    [string]$TranscriptFile = "",
+    [int]$SegmentSize = 100,
+    [string]$Model = "",
+    [string]$LogsDir = "run-logs",
+    [switch]$Overwrite,
+    [switch]$NoExtract
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    throw "python was not found on PATH."
+}
+
+if (-not (Test-Path -Path "tools/bootstrap_session.py")) {
+    throw "Run this script from the repository root (tools/bootstrap_session.py not found)."
+}
+
+New-Item -ItemType Directory -Path $LogsDir -Force | Out-Null
+
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logPath = Join-Path $LogsDir "extract-$timestamp.log"
+$errPath = Join-Path $LogsDir "extract-$timestamp.err.log"
+$pidPath = Join-Path $LogsDir "extract-$timestamp.pid"
+$cmdPath = Join-Path $LogsDir "extract-$timestamp.cmd.txt"
+
+$args = @("tools/bootstrap_session.py", "--session", $Session)
+
+if (-not $TranscriptFile) {
+    throw "-TranscriptFile is required (path to full transcript import file)."
+}
+
+if (-not (Test-Path -Path $TranscriptFile)) {
+    throw "Transcript file not found: $TranscriptFile"
+}
+
+$args += @("--file", $TranscriptFile)
+
+if (-not $NoExtract) {
+    $args += "--extract"
+}
+
+if ($SegmentSize -gt 0) {
+    $args += @("--segment-size", $SegmentSize)
+}
+
+if ($Model) {
+    $args += @("--model", $Model)
+}
+
+if ($Overwrite) {
+    $args += "--overwrite"
+}
+
+$process = Start-Process -FilePath "python" -ArgumentList $args -RedirectStandardOutput $logPath -RedirectStandardError $errPath -PassThru
+
+$process.Id | Set-Content -Path $pidPath
+
+$argString = $args -join " "
+@(
+    "python $argString",
+    "",
+    "Monitor/status:",
+    "  powershell -ExecutionPolicy Bypass -File tools/watch_extraction_detached.ps1 -PidFile '$pidPath'",
+    "  powershell -ExecutionPolicy Bypass -File tools/watch_extraction_detached.ps1 -PidFile '$pidPath' -Follow",
+    "",
+    "Stop process:",
+    "  powershell -ExecutionPolicy Bypass -File tools/stop_extraction_detached.ps1 -PidFile '$pidPath'"
+) | Set-Content -Path $cmdPath
+
+Write-Host "Detached extraction launched."
+Write-Host "  PID:      $($process.Id)"
+Write-Host "  Log:      $logPath"
+Write-Host "  Err log:  $errPath"
+Write-Host "  PID file: $pidPath"
+Write-Host "  Cmd file: $cmdPath"

--- a/tools/stop_extraction_detached.ps1
+++ b/tools/stop_extraction_detached.ps1
@@ -1,0 +1,45 @@
+param(
+    [string]$PidFile = "",
+    [string]$LogsDir = "run-logs",
+    [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not $PidFile) {
+    if (-not (Test-Path -Path $LogsDir)) {
+        throw "Logs directory not found: $LogsDir. Start a detached run first or pass -PidFile."
+    }
+    $PidFile = Get-ChildItem -Path $LogsDir -Filter "extract-*.pid" -File |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -First 1 |
+        ForEach-Object { $_.FullName }
+}
+
+if (-not $PidFile -or -not (Test-Path -Path $PidFile)) {
+    throw "No PID file found. Pass -PidFile or ensure run-logs contains extract-*.pid files."
+}
+
+$pidText = (Get-Content -Path $PidFile -Raw).Trim()
+if (-not $pidText) {
+    throw "PID file is empty: $PidFile"
+}
+
+$runPid = [int]$pidText
+$proc = Get-Process -Id $runPid -ErrorAction SilentlyContinue
+
+if (-not $proc) {
+    Write-Host "Process $runPid is already not running."
+    Write-Host "PID file: $PidFile"
+    exit 0
+}
+
+if ($Force) {
+    Stop-Process -Id $runPid -Force
+} else {
+    Stop-Process -Id $runPid
+}
+
+Write-Host "Stopped extraction process $runPid"
+Write-Host "PID file: $PidFile"

--- a/tools/watch_extraction_detached.ps1
+++ b/tools/watch_extraction_detached.ps1
@@ -1,0 +1,58 @@
+param(
+    [string]$PidFile = "",
+    [string]$LogsDir = "run-logs",
+    [int]$Tail = 80,
+    [switch]$Follow
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not $PidFile) {
+    if (-not (Test-Path -Path $LogsDir)) {
+        throw "Logs directory not found: $LogsDir. Start a detached run first or pass -PidFile."
+    }
+    $PidFile = Get-ChildItem -Path $LogsDir -Filter "extract-*.pid" -File |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -First 1 |
+        ForEach-Object { $_.FullName }
+}
+
+if (-not $PidFile -or -not (Test-Path -Path $PidFile)) {
+    throw "No PID file found. Pass -PidFile or ensure run-logs contains extract-*.pid files."
+}
+
+$pidText = (Get-Content -Path $PidFile -Raw).Trim()
+if (-not $pidText) {
+    throw "PID file is empty: $PidFile"
+}
+
+$runPid = [int]$pidText
+$stem = [System.IO.Path]::GetFileNameWithoutExtension($PidFile)
+$logPath = Join-Path (Split-Path -Parent $PidFile) ("$stem.log")
+$errPath = Join-Path (Split-Path -Parent $PidFile) ("$stem.err.log")
+
+$proc = Get-Process -Id $runPid -ErrorAction SilentlyContinue
+$state = if ($proc) { "running" } else { "not-running" }
+
+Write-Host "Extraction run status"
+Write-Host "  PID:      $runPid"
+Write-Host "  State:    $state"
+Write-Host "  PID file: $PidFile"
+Write-Host "  Log:      $logPath"
+Write-Host "  Err log:  $errPath"
+
+if (-not (Test-Path -Path $logPath)) {
+    Write-Host "`nstdout log not found yet: $logPath"
+} elseif ($Follow) {
+    Write-Host "`n--- stdout (tail $Tail, follow) ---"
+    Get-Content -Path $logPath -Tail $Tail -Wait
+} else {
+    Write-Host "`n--- stdout (tail $Tail) ---"
+    Get-Content -Path $logPath -Tail $Tail
+}
+
+if (Test-Path -Path $errPath) {
+    Write-Host "`n--- stderr (tail $Tail) ---"
+    Get-Content -Path $errPath -Tail $Tail
+}


### PR DESCRIPTION
## Summary

Add detached extraction operational tooling so long semantic extraction runs can continue independently of VS Code chat session state.

## What Changed

- Added `tools/start_extraction_detached.ps1`
  - Launches `bootstrap_session.py` in a detached process
  - Writes stdout/stderr logs, PID file, and helper command file
  - Validates `-TranscriptFile` is provided and exists
- Added `tools/watch_extraction_detached.ps1`
  - Shows run status from latest/specified PID file
  - Tails stdout/stderr logs
  - Supports `-Follow` for live stdout
- Added `tools/stop_extraction_detached.ps1`
  - Stops latest/specified detached run via PID file
  - Supports optional `-Force`
- Updated docs:
  - `docs/usage.md` with detached run launch/monitor/stop workflows
  - `docs/architecture.md` tool table entries for new scripts
  - `docs/roadmap.md` to mark unattended batch mode as partially implemented via detached helper scripts

## Validation

- Script lint/problem check: no diagnostics in new/updated files
- Smoke tested launcher behavior:
  - Fast-fail when `-TranscriptFile` is omitted
  - Generates run artifacts when invoked with valid inputs
- Verified watch/stop scripts handle missing or stale process states cleanly

## Notes

- `config/llm.json` had unrelated local changes and was intentionally excluded from this PR.
