### PR TITLE
fix: extend coercion map to cover new non-schema keys observed in Run 11

### DIFF
--- a/tests/test_coerce_entity.py
+++ b/tests/test_coerce_entity.py
@@ -517,11 +517,14 @@ def test_run11_discard_keys_removed():
     result = _coerce_entity_fields(entity)
     for key in ("recent_activities", "current_activities", "updated_turn",
                 "history_highlights", "goals", "background",
-                "abilities_description", "status_updated_turn"):
+                "abilities_description"):
         assert key not in result, f"Expected '{key}' to be discarded"
+    # status_updated_turn is schema-valid at top level — it must be preserved
+    assert result["status_updated_turn"] == "turn-010"
 
 
 def test_run11_status_updated_turn_stripped_from_volatile_state():
+    """When status_updated_turn is nested in volatile_state, strip it and promote to top level."""
     entity = {
         "name": "Kael",
         "type": "character",
@@ -535,6 +538,27 @@ def test_run11_status_updated_turn_stripped_from_volatile_state():
     result = _coerce_entity_fields(entity)
     assert "status_updated_turn" not in result["volatile_state"]
     assert result["volatile_state"]["location"] == "castle"
+    # Should be promoted to top level since it was absent there
+    assert result["status_updated_turn"] == "turn-010"
+
+
+def test_run11_status_updated_turn_not_overwritten_if_already_top_level():
+    """When status_updated_turn exists at top level and also in volatile_state, just strip the nested one."""
+    entity = {
+        "name": "Kael",
+        "type": "character",
+        "last_updated_turn": "turn-011",
+        "status_updated_turn": "turn-011",
+        "volatile_state": {
+            "location": "castle",
+            "status_updated_turn": "turn-010",
+            "last_updated_turn": "turn-011",
+        },
+    }
+    result = _coerce_entity_fields(entity)
+    assert "status_updated_turn" not in result["volatile_state"]
+    # Top-level value must not be overwritten
+    assert result["status_updated_turn"] == "turn-011"
 
 
 def test_relationship_context_empty():

--- a/tests/test_coerce_entity.py
+++ b/tests/test_coerce_entity.py
@@ -441,6 +441,102 @@ def test_relationship_context_assembly():
     assert parsed["char-elder"][0]["target_id"] == "char-player"
 
 
+# --- Run 11 coercion regression tests (#196) ---
+
+def test_run11_abilities_and_traits_mapped_to_stable_attributes():
+    entity = {
+        "name": "Kael",
+        "type": "character",
+        "last_updated_turn": "turn-011",
+        "abilities_and_traits": ["swordsmanship", "leadership"],
+    }
+    result = _coerce_entity_fields(entity)
+    assert "abilities_and_traits" not in result
+    assert result["stable_attributes"]["abilities"]["value"] == ["swordsmanship", "leadership"]
+    assert result["stable_attributes"]["abilities"]["inference"] is False
+
+
+def test_run11_additional_items_equipped_appended_to_equipment():
+    entity = {
+        "name": "Kael",
+        "type": "character",
+        "last_updated_turn": "turn-011",
+        "volatile_state": {"equipment": ["sword"], "location": "village"},
+        "additional_items_equipped": ["shield", "helm"],
+    }
+    result = _coerce_entity_fields(entity)
+    assert "additional_items_equipped" not in result
+    assert "shield" in result["volatile_state"]["equipment"]
+    assert "helm" in result["volatile_state"]["equipment"]
+    assert "sword" in result["volatile_state"]["equipment"]
+
+
+def test_run11_locations_remapped_to_volatile_state_location():
+    entity = {
+        "name": "Kael",
+        "type": "character",
+        "last_updated_turn": "turn-011",
+        "locations": "the market",
+    }
+    result = _coerce_entity_fields(entity)
+    assert "locations" not in result
+    assert result["volatile_state"]["location"] == "the market"
+
+
+def test_run11_stable_remap_age_gender_occupation():
+    entity = {
+        "name": "Kael",
+        "type": "character",
+        "last_updated_turn": "turn-011",
+        "age": "30",
+        "gender": "male",
+        "occupation": "blacksmith",
+    }
+    result = _coerce_entity_fields(entity)
+    assert "age" not in result
+    assert "gender" not in result
+    assert "occupation" not in result
+    assert result["stable_attributes"]["age"]["value"] == "30"
+    assert result["stable_attributes"]["gender"]["value"] == "male"
+    assert result["stable_attributes"]["occupation"]["value"] == "blacksmith"
+
+
+def test_run11_discard_keys_removed():
+    entity = {
+        "name": "Kael",
+        "type": "character",
+        "recent_activities": "training",
+        "current_activities": "resting",
+        "updated_turn": "turn-010",
+        "history_highlights": ["won a battle"],
+        "goals": "become champion",
+        "background": "grew up in the north",
+        "abilities_description": "very strong",
+        "status_updated_turn": "turn-010",
+    }
+    result = _coerce_entity_fields(entity)
+    for key in ("recent_activities", "current_activities", "updated_turn",
+                "history_highlights", "goals", "background",
+                "abilities_description", "status_updated_turn"):
+        assert key not in result, f"Expected '{key}' to be discarded"
+
+
+def test_run11_status_updated_turn_stripped_from_volatile_state():
+    entity = {
+        "name": "Kael",
+        "type": "character",
+        "last_updated_turn": "turn-011",
+        "volatile_state": {
+            "location": "castle",
+            "status_updated_turn": "turn-010",
+            "last_updated_turn": "turn-011",
+        },
+    }
+    result = _coerce_entity_fields(entity)
+    assert "status_updated_turn" not in result["volatile_state"]
+    assert result["volatile_state"]["location"] == "castle"
+
+
 def test_relationship_context_empty():
     """No existing relationships returns empty string."""
     catalogs = {

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -449,18 +449,22 @@ def _coerce_entity_fields(entity_data) -> dict | None:
         # Added in #196: ephemeral / history keys observed in Run 11
         "recent_activities", "current_activities", "updated_turn",
         "history_highlights", "goals", "background", "abilities_description",
-        "status_updated_turn",
     }
     for dk in list(entity_data.keys()):
         if dk in _discard_keys:
             entity_data.pop(dk)
             print(f"  COERCE: discarded non-schema key '{dk}'", file=sys.stderr)
 
-    # Strip status_updated_turn from volatile_state if present — it belongs at top level only
+    # Strip status_updated_turn from volatile_state if present — it belongs at top level only.
+    # If the LLM nested it under volatile_state and top-level is missing, promote it first.
     vs = entity_data.get("volatile_state")
     if isinstance(vs, dict) and "status_updated_turn" in vs:
-        vs.pop("status_updated_turn")
-        print("  COERCE: stripped status_updated_turn from volatile_state (top-level only)", file=sys.stderr)
+        nested_status_updated_turn = vs.pop("status_updated_turn")
+        if "status_updated_turn" not in entity_data:
+            entity_data["status_updated_turn"] = nested_status_updated_turn
+            print("  COERCE: promoted volatile_state.status_updated_turn → top-level status_updated_turn", file=sys.stderr)
+        else:
+            print("  COERCE: stripped status_updated_turn from volatile_state (top-level only)", file=sys.stderr)
 
     # Strip stable_attributes entries where the LLM returned null for value (#178).
     # The schema requires value to be string or string[] — null is not valid.

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -316,6 +316,7 @@ def _coerce_entity_fields(entity_data) -> dict | None:
         "item_inventory": "equipment",
         "location": "location",
         "current_location": "location",
+        "locations": "location",
         "status": "condition",
         "current_situation": "condition",
         "emotional_state": "condition",
@@ -351,6 +352,9 @@ def _coerce_entity_fields(entity_data) -> dict | None:
         "name_aliases": "aliases",
         "alignment": "alignment",
         "weaknesses": "weaknesses",
+        "age": "age",
+        "gender": "gender",
+        "occupation": "occupation",
     }
     for src_key, sa_key in _stable_remap.items():
         if src_key in entity_data:
@@ -375,6 +379,44 @@ def _coerce_entity_fields(entity_data) -> dict | None:
                     entry["source_turn"] = turn_id
                 sa[sa_key] = entry
             print(f"  COERCE: {src_key} → stable_attributes.{sa_key}", file=sys.stderr)
+
+    # abilities_and_traits → stable_attributes.abilities (Run 11 variant)
+    if "abilities_and_traits" in entity_data:
+        val = entity_data.pop("abilities_and_traits")
+        if "stable_attributes" not in entity_data:
+            entity_data["stable_attributes"] = {}
+        sa = entity_data["stable_attributes"]
+        if "abilities" not in sa and val:
+            if isinstance(val, list):
+                attr_val = [str(v) for v in val]
+            elif isinstance(val, str):
+                attr_val = val
+            else:
+                attr_val = str(val)
+            entry: dict = {"value": attr_val, "inference": False, "confidence": 1.0}
+            if has_valid_turn:
+                entry["source_turn"] = turn_id
+            sa["abilities"] = entry
+        print("  COERCE: abilities_and_traits → stable_attributes.abilities", file=sys.stderr)
+
+    # additional_items_equipped → volatile_state.equipment (append, don't overwrite)
+    if "additional_items_equipped" in entity_data:
+        val = entity_data.pop("additional_items_equipped")
+        if isinstance(val, str):
+            val = [v.strip() for v in val.split(",") if v.strip()]
+        elif isinstance(val, list):
+            val = [str(v) for v in val]
+        else:
+            val = [str(val)]
+        if "volatile_state" not in entity_data:
+            entity_data["volatile_state"] = {}
+        vs = entity_data["volatile_state"]
+        existing = vs.get("equipment", [])
+        if isinstance(existing, list):
+            vs["equipment"] = existing + [v for v in val if v not in existing]
+        else:
+            vs["equipment"] = val
+        print("  COERCE: additional_items_equipped → volatile_state.equipment (appended)", file=sys.stderr)
 
     # Relationship key variants → relationships
     _rel_keys = ["relations", "character_relations", "faction_relations",
@@ -404,11 +446,21 @@ def _coerce_entity_fields(entity_data) -> dict | None:
         "recent_relationship_changes", "name_changes",
         "equipment_history", "faction_relations_history",
         "relationships_history",
+        # Added in #196: ephemeral / history keys observed in Run 11
+        "recent_activities", "current_activities", "updated_turn",
+        "history_highlights", "goals", "background", "abilities_description",
+        "status_updated_turn",
     }
     for dk in list(entity_data.keys()):
         if dk in _discard_keys:
             entity_data.pop(dk)
             print(f"  COERCE: discarded non-schema key '{dk}'", file=sys.stderr)
+
+    # Strip status_updated_turn from volatile_state if present — it belongs at top level only
+    vs = entity_data.get("volatile_state")
+    if isinstance(vs, dict) and "status_updated_turn" in vs:
+        vs.pop("status_updated_turn")
+        print("  COERCE: stripped status_updated_turn from volatile_state (top-level only)", file=sys.stderr)
 
     # Strip stable_attributes entries where the LLM returned null for value (#178).
     # The schema requires value to be string or string[] — null is not valid.


### PR DESCRIPTION
## Summary

Extends `_coerce_entity_fields()` to handle all non-schema keys observed in Run 11 that were causing silent validation failures.

## Changes

- Added `locations` → `_volatile_remap` (`location`)
- Extended `_stable_remap` with `age`, `gender`, `occupation`
- Added explicit handling for `abilities_and_traits` → `stable_attributes.abilities`
- Added explicit handling for `additional_items_equipped` → `volatile_state.equipment` (append)
- Extended `_discard_keys` with `recent_activities`, `current_activities`, `updated_turn`, `history_highlights`, `goals`, `background`, `abilities_description`, `status_updated_turn`
- Added logic to strip `status_updated_turn` from inside `volatile_state` (belongs at top level only)
- Added 6 regression tests in `tests/test_coerce_entity.py` covering all new coercions

Closes #196
