### PR TITLE
fix: add event type coercion to prevent silent event drops

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,6 +104,7 @@ An automated pipeline that uses an LLM to extract structured data from transcrip
 - `config/llm.json` configures the LLM provider, model, and endpoint
 - All extracted entities are validated against `schemas/entity.schema.json` before merging
 - Entities below a confidence threshold are logged but not cataloged
+- **Event type coercion** (#198): Before schema validation, `_coerce_event_fields()` remaps invalid event `type` values to the nearest valid enum value using `_EVENT_TYPE_REMAP`. For example, `"acquisition"` → `"discovery"`, `"conflict"` → `"encounter"`. Unknown types fall back to `"other"`. This prevents valid events from being silently dropped when the LLM produces a type not in the schema enum.
 - Batch mode checkpoints progress every 50 turns for resume after interruption
 - **Segmented extraction** (`--segment-size N`): For long sessions (300+ turns), extraction runs in segments of N turns, each starting with a fresh catalog. This prevents context window saturation in the entity discovery prompt, which includes the full known-entities table. After all segments complete, a reconciliation pass merges entities by ID and name, stitches event timelines, and joins relationships across segment boundaries. Segment size should be tuned to the model's effective context capacity (recommended: 100-150 for 14B models with 32K context).
 - Birth events trigger automatic entity creation for named children, with child IDs added to event `related_entities`

--- a/tests/test_coerce_entity.py
+++ b/tests/test_coerce_entity.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
 from semantic_extraction import (
     _coerce_entity_fields,
+    _coerce_event_fields,
     _filter_concept_prefix_from_items,
     _format_prior_entity_context,
     _collect_existing_relationships,
@@ -957,3 +958,36 @@ def test_coerce_stable_attributes_null_value_removed():
     assert "race" in sa
     assert "alignment" in sa
     assert "class" not in sa  # null value stripped
+
+
+# ---------------------------------------------------------------------------
+# _coerce_event_fields tests (#198)
+# ---------------------------------------------------------------------------
+
+def test_coerce_event_type_known_remap():
+    """Known invalid type 'acquisition' is remapped to 'discovery'."""
+    event = {"type": "acquisition", "description": "Obtained a sword"}
+    result = _coerce_event_fields(event)
+    assert result["type"] == "discovery"
+
+
+def test_coerce_event_type_unknown_falls_back_to_other():
+    """Completely unknown type falls back to 'other'."""
+    event = {"type": "completely_unknown_type", "description": "Something happened"}
+    result = _coerce_event_fields(event)
+    assert result["type"] == "other"
+
+
+def test_coerce_event_type_valid_unchanged():
+    """Valid event type is left unchanged."""
+    event = {"type": "encounter", "description": "Met a stranger"}
+    result = _coerce_event_fields(event)
+    assert result["type"] == "encounter"
+
+
+def test_coerce_event_type_missing_unchanged():
+    """Event with no 'type' key is returned unchanged."""
+    event = {"description": "Something with no type"}
+    result = _coerce_event_fields(event)
+    assert "type" not in result
+

--- a/tests/test_coerce_entity.py
+++ b/tests/test_coerce_entity.py
@@ -991,3 +991,25 @@ def test_coerce_event_type_missing_unchanged():
     result = _coerce_event_fields(event)
     assert "type" not in result
 
+
+def test_coerce_event_type_non_string_falls_back_to_other():
+    """Non-string or unhashable event types are coerced to 'other'."""
+    for bad_type in (["encounter"], {"kind": "encounter"}, 123):
+        event = {"type": bad_type, "description": "Something happened"}
+        result = _coerce_event_fields(event)
+        assert result["type"] == "other"
+
+
+def test_coerce_event_returns_none_for_non_dict():
+    """Non-dict event items return None."""
+    assert _coerce_event_fields(["not", "a", "dict"]) is None
+    assert _coerce_event_fields("just a string") is None
+    assert _coerce_event_fields(42) is None
+
+
+def test_coerce_event_type_strip_lower_normalization():
+    """Whitespace and casing in type values are normalized."""
+    event = {"type": " Encounter ", "description": "Met someone"}
+    result = _coerce_event_fields(event)
+    assert result["type"] == "encounter"
+

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -501,20 +501,44 @@ _EVENT_TYPE_REMAP: dict[str, str] = {
 }
 
 
-def _coerce_event_fields(event: dict) -> dict:
+def _coerce_event_fields(event: dict) -> dict | None:
     """Coerce invalid event field values to schema-valid equivalents.
 
     Currently handles: type remapping for invalid enum values.
     If type cannot be remapped to a valid value, falls back to 'other'.
+    Returns None for non-dict events (caller should skip them).
     """
-    event_type = event.get("type")
-    if event_type is not None and event_type not in _VALID_EVENT_TYPES:
-        remapped = _EVENT_TYPE_REMAP.get(event_type, "other")
+    if not isinstance(event, dict):
         print(
-            f"  COERCE: event type '{event_type}' → '{remapped}'",
+            f"  COERCE: non-dict event {event!r} → skipped",
             file=sys.stderr,
         )
-        event["type"] = remapped
+        return None
+
+    event_type = event.get("type")
+    if event_type is None:
+        return event
+
+    if not isinstance(event_type, str):
+        print(
+            f"  COERCE: non-string event type {event_type!r} → 'other'",
+            file=sys.stderr,
+        )
+        event["type"] = "other"
+        return event
+
+    normalized_type = event_type.strip().lower()
+    if normalized_type in _VALID_EVENT_TYPES:
+        if normalized_type != event_type:
+            event["type"] = normalized_type
+        return event
+
+    remapped = _EVENT_TYPE_REMAP.get(normalized_type, "other")
+    print(
+        f"  COERCE: event type '{event_type}' → '{remapped}'",
+        file=sys.stderr,
+    )
+    event["type"] = remapped
     return event
 
 
@@ -1488,7 +1512,7 @@ def extract_and_merge(
                     normalize_entity_id(eid, known_ids) for eid in related
                 ]
 
-        valid_events = [e for e in (_coerce_event_fields(ev) for ev in new_events) if _validate_event(e)]
+        valid_events = [e for e in (_coerce_event_fields(ev) for ev in new_events) if e is not None and _validate_event(e)]
 
         # --- Phase 2: Create stub entities for orphan IDs (#106) ---
         if valid_events:

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -471,6 +471,53 @@ def _validate_entity(entity_data: dict) -> bool:
         return False
 
 
+# Valid event types from event.schema.json / event-extractor template
+_VALID_EVENT_TYPES = {
+    "birth", "death", "arrival", "departure", "construction", "decision",
+    "encounter", "recruitment", "discovery", "anomaly", "capture", "trap",
+    "ritual", "healing", "communication", "examination", "release",
+    "offering", "other",
+}
+
+# Map of invalid type values → nearest valid type
+_EVENT_TYPE_REMAP: dict[str, str] = {
+    "acquisition": "discovery",
+    "trade": "offering",
+    "purchase": "offering",
+    "sale": "offering",
+    "injury": "other",
+    "conflict": "encounter",
+    "combat": "encounter",
+    "negotiation": "decision",
+    "exploration": "discovery",
+    "investigation": "examination",
+    "rest": "other",
+    "travel": "arrival",
+    "reward": "other",
+    "quest": "other",
+    "interaction": "encounter",
+    "observation": "examination",
+    "transformation": "other",
+}
+
+
+def _coerce_event_fields(event: dict) -> dict:
+    """Coerce invalid event field values to schema-valid equivalents.
+
+    Currently handles: type remapping for invalid enum values.
+    If type cannot be remapped to a valid value, falls back to 'other'.
+    """
+    event_type = event.get("type")
+    if event_type is not None and event_type not in _VALID_EVENT_TYPES:
+        remapped = _EVENT_TYPE_REMAP.get(event_type, "other")
+        print(
+            f"  COERCE: event type '{event_type}' → '{remapped}'",
+            file=sys.stderr,
+        )
+        event["type"] = remapped
+    return event
+
+
 def _validate_event(event_data: dict) -> bool:
     """Validate an event dict against event.schema.json. Returns True if valid."""
     schema = _load_schema("event.schema.json")
@@ -1441,7 +1488,7 @@ def extract_and_merge(
                     normalize_entity_id(eid, known_ids) for eid in related
                 ]
 
-        valid_events = [e for e in new_events if _validate_event(e)]
+        valid_events = [e for e in (_coerce_event_fields(ev) for ev in new_events) if _validate_event(e)]
 
         # --- Phase 2: Create stub entities for orphan IDs (#106) ---
         if valid_events:


### PR DESCRIPTION
## Summary

Events with invalid `type` values (e.g., `"acquisition"`) were silently dropped after schema validation failure. This adds a `_coerce_event_fields()` function that remaps known invalid types to the nearest valid enum value, falling back to `"other"` for unknown types.

## Changes

- `tools/semantic_extraction.py`: new `_coerce_event_fields()` function with `_EVENT_TYPE_REMAP` dict
- `tools/semantic_extraction.py`: apply coercion before schema validation in event extraction call site
- `tests/test_coerce_entity.py`: 4 regression tests for `_coerce_event_fields()`
- `docs/architecture.md`: document the new event type coercion step

Observed fix: 2 events typed `"acquisition"` in turn-264 were previously dropped; they will now be coerced to `"discovery"` and retained.

Closes #198
