### PR TITLE
fix: improve PC extraction failure logging to capture raw response data

### DIFF
--- a/tests/test_pc_max_tokens.py
+++ b/tests/test_pc_max_tokens.py
@@ -308,6 +308,60 @@ class TestPCSkipIntegration:
         )
         assert se._pc_consecutive_failures == 0
 
+    def test_validation_failure_logs_raw_preview_and_debug_record(self, monkeypatch, tmp_path, capsys):
+        """Validation failures should log a preview and write a JSONL debug record."""
+        monkeypatch.setattr(se, "load_template", lambda name: f"{name} template")
+        monkeypatch.setattr(se, "_PC_DEBUG_LOG", str(tmp_path / "pc-extraction-debug.jsonl"))
+        monkeypatch.setattr(se, "_pc_partial_merge", lambda catalogs, entity_data, turn_id: False)
+        se._reset_pc_failure_tracking()
+
+        llm = MagicMock()
+        llm.default_timeout = 10
+        llm.pc_max_tokens = 4096
+        llm.delay = MagicMock()
+
+        def _extract_json(system_prompt, user_prompt, timeout=None, max_tokens=None,
+                          schema=None):
+            if "discover" in system_prompt.lower() or "discovery" in system_prompt.lower():
+                return {"entities": []}
+            if "detail" in system_prompt.lower():
+                return {"entity": {
+                    "id": "char-player",
+                    "name": "Player Character",
+                    "type": "character",
+                    "identity": {"summary": "nested value forces validation failure"},
+                    "first_seen_turn": "turn-001",
+                    "last_updated_turn": "turn-001",
+                }}
+            if "relationship" in system_prompt.lower():
+                return {"relationships": []}
+            if "event" in system_prompt.lower():
+                return {"events": []}
+            return {}
+
+        llm.extract_json = MagicMock(side_effect=_extract_json)
+
+        catalogs = _fresh_catalogs()
+        events = []
+        turn = {"turn_id": "turn-001", "speaker": "dm", "text": "The DM describes the PC."}
+
+        se.extract_and_merge(turn, catalogs, events, llm, min_confidence=0.6)
+
+        captured = capsys.readouterr()
+        assert "raw response preview (500 chars):" in captured.err
+        assert '"summary": "nested value forces validation failure"' in captured.err
+
+        debug_path = tmp_path / "pc-extraction-debug.jsonl"
+        assert debug_path.exists()
+        records = debug_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(records) == 1
+        record = json.loads(records[0])
+        assert record["turn_id"] == "turn-001"
+        assert record["failure_reason"] == "validation_failed"
+        assert "identity" in record["response_keys"]
+        assert 'nested value forces validation failure' in record["partial_entity_data_preview"]
+        assert record["merge_result"] is None
+
 
 class TestPCSkipLogNoise:
     """Verify log noise is reduced (#153): warnings only at threshold crossings."""

--- a/tests/test_pc_max_tokens.py
+++ b/tests/test_pc_max_tokens.py
@@ -360,7 +360,7 @@ class TestPCSkipIntegration:
         assert record["failure_reason"] == "validation_failed"
         assert "identity" in record["response_keys"]
         assert 'nested value forces validation failure' in record["partial_entity_data_preview"]
-        assert record["merge_result"] is None
+        assert record["merge_result"] is False
 
 
 class TestPCSkipLogNoise:

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -61,7 +61,10 @@ _PC_SKIP_COOLDOWN = 50       # Skip PC extraction for this many turns after thre
 _PC_RETRY_WINDOW = 5         # Retry for this many turns before entering cooldown again
 _PC_SKIP_THRESHOLD = 20      # Enter cooldown after this many consecutive failures (#149)
 _PC_DEBUG_LOG = os.path.join(
-    os.path.dirname(__file__), "..", "framework-local", "pc-extraction-debug.jsonl"
+    os.path.dirname(os.path.abspath(__file__)),
+    "..",
+    "framework-local",
+    "pc-extraction-debug.jsonl",
 )
 
 # Schema-compliant turn ID pattern (matches e.g. turn-001, turn-1234)
@@ -122,9 +125,10 @@ def _write_pc_debug_record(
         debug_path = os.path.abspath(_PC_DEBUG_LOG)
         os.makedirs(os.path.dirname(debug_path), exist_ok=True)
         with open(debug_path, "a", encoding="utf-8") as fh:
-            fh.write(_json.dumps(record) + "\n")
-    except OSError:
-        pass
+            fh.write(_json.dumps(record, default=str) + "\n")
+    except (OSError, TypeError, ValueError):
+        # Debug logging must never interrupt extraction.
+        return
 
 
 def _filter_pc_attributes(entity_data: dict) -> dict:
@@ -1369,12 +1373,18 @@ def extract_and_merge(
                 elif entity_data is not None:
                     # Validation failed — attempt partial merge fallback (#107)
                     # Log structure and partial values of the raw response to aid diagnosis (#125, #199)
-                    _data_keys = sorted(entity_data.keys()) if isinstance(entity_data, dict) else "non-dict"
-                    _data_preview = (
-                        json.dumps(entity_data, default=str)[:500]
-                        if isinstance(entity_data, dict)
-                        else str(entity_data)[:500]
-                    )
+                    if isinstance(entity_data, dict):
+                        try:
+                            _data_keys = sorted(entity_data.keys())
+                        except Exception:
+                            _data_keys = list(map(str, entity_data.keys()))
+                        try:
+                            _data_preview = json.dumps(entity_data, default=str)[:500]
+                        except Exception:
+                            _data_preview = repr(entity_data)[:500]
+                    else:
+                        _data_keys = "non-dict"
+                        _data_preview = str(entity_data)[:500]
                     print(
                         f"  PC detail extraction: validation failed at {turn_id}, "
                         f"response keys={_data_keys}, falling back to partial merge",
@@ -1384,9 +1394,15 @@ def extract_and_merge(
                         f"  PC detail extraction: raw response preview (500 chars): {_data_preview}",
                         file=sys.stderr,
                     )
-                    _write_pc_debug_record(turn_id, "validation_failed", _data_keys, _data_preview)
                     # Partial merge success counts as an update (#133)
                     pc_updated = _pc_partial_merge(catalogs, entity_data, turn_id)
+                    _write_pc_debug_record(
+                        turn_id,
+                        "validation_failed",
+                        _data_keys,
+                        _data_preview,
+                        merge_result=pc_updated,
+                    )
                 else:
                     # entity_data is None — extraction returned nothing (#133)
                     print(

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -60,6 +60,9 @@ _PC_FAILURE_WARN_THRESHOLD = 10
 _PC_SKIP_COOLDOWN = 50       # Skip PC extraction for this many turns after threshold failures
 _PC_RETRY_WINDOW = 5         # Retry for this many turns before entering cooldown again
 _PC_SKIP_THRESHOLD = 20      # Enter cooldown after this many consecutive failures (#149)
+_PC_DEBUG_LOG = os.path.join(
+    os.path.dirname(__file__), "..", "framework-local", "pc-extraction-debug.jsonl"
+)
 
 # Schema-compliant turn ID pattern (matches e.g. turn-001, turn-1234)
 _TURN_ID_RE = re.compile(r"^turn-[0-9]{3,}$")
@@ -96,6 +99,32 @@ def _should_skip_pc(consecutive_failures: int, turns_since_cooldown: int) -> boo
         return False
     cycle_position = turns_since_cooldown % (_PC_SKIP_COOLDOWN + _PC_RETRY_WINDOW)
     return cycle_position < _PC_SKIP_COOLDOWN
+
+
+def _write_pc_debug_record(
+    turn_id: str,
+    failure_reason: str,
+    response_keys: list | str,
+    partial_data_preview: str,
+    merge_result: bool | None = None,
+) -> None:
+    """Write a debug record for a PC extraction failure to a JSONL file (#199)."""
+    import json as _json
+
+    record = {
+        "turn_id": turn_id,
+        "failure_reason": failure_reason,
+        "response_keys": response_keys,
+        "partial_entity_data_preview": partial_data_preview,
+        "merge_result": merge_result,
+    }
+    try:
+        debug_path = os.path.abspath(_PC_DEBUG_LOG)
+        os.makedirs(os.path.dirname(debug_path), exist_ok=True)
+        with open(debug_path, "a", encoding="utf-8") as fh:
+            fh.write(_json.dumps(record) + "\n")
+    except OSError:
+        pass
 
 
 def _filter_pc_attributes(entity_data: dict) -> dict:
@@ -1339,13 +1368,23 @@ def extract_and_merge(
                     pc_updated = True
                 elif entity_data is not None:
                     # Validation failed — attempt partial merge fallback (#107)
-                    # Log structure of the raw response to aid diagnosis (#125)
+                    # Log structure and partial values of the raw response to aid diagnosis (#125, #199)
                     _data_keys = sorted(entity_data.keys()) if isinstance(entity_data, dict) else "non-dict"
+                    _data_preview = (
+                        json.dumps(entity_data, default=str)[:500]
+                        if isinstance(entity_data, dict)
+                        else str(entity_data)[:500]
+                    )
                     print(
                         f"  PC detail extraction: validation failed at {turn_id}, "
                         f"response keys={_data_keys}, falling back to partial merge",
                         file=sys.stderr,
                     )
+                    print(
+                        f"  PC detail extraction: raw response preview (500 chars): {_data_preview}",
+                        file=sys.stderr,
+                    )
+                    _write_pc_debug_record(turn_id, "validation_failed", _data_keys, _data_preview)
                     # Partial merge success counts as an update (#133)
                     pc_updated = _pc_partial_merge(catalogs, entity_data, turn_id)
                 else:
@@ -1355,6 +1394,7 @@ def extract_and_merge(
                         f"Consecutive failures: {_pc_consecutive_failures + 1}",
                         file=sys.stderr,
                     )
+                    _write_pc_debug_record(turn_id, "none_returned", [], "", merge_result=False)
             except LLMExtractionError as e:
                 print(f"  WARNING: PC detail extraction failed at {turn_id}: {e}", file=sys.stderr)
 


### PR DESCRIPTION
## Summary

When PC extraction validation fails, only field names were logged. This change adds a 500-char preview of the raw response values and writes a `framework-local/pc-extraction-debug.jsonl` debug file (one record per failure) to enable diagnosis of hard-drop cases.

## Changes

- `tools/semantic_extraction.py`: enhance validation-failure log to include truncated JSON preview
- `tools/semantic_extraction.py`: add `_write_pc_debug_record()` helper writing to JSONL file
- `tools/semantic_extraction.py`: also record None-return failures
- `tests/test_pc_max_tokens.py`: add regression coverage for preview logging and debug-record output

Closes #199
