### PR TITLE
fix: document and default --segment-size for large sessions

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -86,7 +86,7 @@ Remaining work:
 - Batch processing mode for unattended overnight extraction (**partially implemented** via detached helper scripts: `tools/start_extraction_detached.ps1`, `tools/watch_extraction_detached.ps1`, `tools/stop_extraction_detached.ps1`)
 - Provider setup documentation in `docs/usage.md`
 - Quality validation of `qwen2.5:7b` as a faster alternative to 14B
-- **Segmented extraction** (#141): Long sessions (300+ turns) are extracted in configurable segments to stay within model context limits. Each segment starts with a clean entity catalog; a reconciliation pass merges the results. Naturally parallelizable across GPU instances.
+- **Segmented extraction** (#141, #197): Long sessions are extracted in configurable segments to stay within model context limits. Each segment starts with a clean entity catalog; a reconciliation pass merges the results. The bootstrap default now auto-enables `--segment-size 100` when session size exceeds 150 turns (pass `--segment-size 0` to disable).
 
 Design implications for earlier phases:
 - Keep context loading modular (catalog-first) so smaller local models can handle targeted tasks

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -406,6 +406,8 @@ Stop-Process -Id (Get-Content run-logs/extract-<timestamp>.pid)
 For sessions with more than 150 turns on models with <=32K context windows,
 use segmented extraction to prevent quality degradation in late turns:
 
+Explicit segmented extraction command:
+
 ```bash
 python tools/bootstrap_session.py \
   --session sessions/session-001 \
@@ -421,13 +423,12 @@ As of issue #197, when `--segment-size` is omitted the bootstrap tool
 automatically applies `--segment-size 100` for sessions larger than 150 turns.
 Pass `--segment-size 0` explicitly to disable segmentation.
 
-Recommended command for large sessions (>150 turns):
+Equivalent command relying on the auto-default (>150 turns):
 
 ```bash
 python tools/bootstrap_session.py \
   --session sessions/session-001 \
-  --file sessions/_import/session-001-full-transcript.txt \
-  --segment-size 100
+  --file sessions/_import/session-001-full-transcript.txt
 ```
 
 Recommended segment sizes:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -403,8 +403,8 @@ Stop-Process -Id (Get-Content run-logs/extract-<timestamp>.pid)
 
 ### Segmented Extraction
 
-For sessions with 200+ turns on models with ≤32K context windows, use
-segmented extraction to prevent quality degradation in late turns:
+For sessions with more than 150 turns on models with <=32K context windows,
+use segmented extraction to prevent quality degradation in late turns:
 
 ```bash
 python tools/bootstrap_session.py \
@@ -417,12 +417,25 @@ Each segment processes turns with a fresh entity catalog. After all segments
 complete, entities are automatically reconciled across segment boundaries by
 ID and name matching.
 
+As of issue #197, when `--segment-size` is omitted the bootstrap tool
+automatically applies `--segment-size 100` for sessions larger than 150 turns.
+Pass `--segment-size 0` explicitly to disable segmentation.
+
+Recommended command for large sessions (>150 turns):
+
+```bash
+python tools/bootstrap_session.py \
+  --session sessions/session-001 \
+  --file sessions/_import/session-001-full-transcript.txt \
+  --segment-size 100
+```
+
 Recommended segment sizes:
 - 7B models (8K context): 50 turns
 - 14B models (32K context): 100-150 turns
 - 70B+ models (128K context): 300+ turns (may not need segmentation)
 
-Segment size 0 (the default) runs a single-pass extraction without segmentation.
+Segment size 0 runs a single-pass extraction without segmentation.
 
 ### Coreference Hints
 

--- a/tests/test_bootstrap_segment_size_default.py
+++ b/tests/test_bootstrap_segment_size_default.py
@@ -1,0 +1,35 @@
+"""Tests for bootstrap_session segment-size auto-default behavior (#197)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from bootstrap_session import _resolve_segment_size
+
+
+def test_auto_default_enabled_for_large_sessions_when_unset():
+    """Unset --segment-size should auto-default to 100 for >150 turns."""
+    size, auto_enabled = _resolve_segment_size(None, 151)
+    assert size == 100
+    assert auto_enabled is True
+
+
+def test_auto_default_not_enabled_at_threshold():
+    """Threshold is exclusive: 150 turns should keep segmentation disabled."""
+    size, auto_enabled = _resolve_segment_size(None, 150)
+    assert size == 0
+    assert auto_enabled is False
+
+
+def test_explicit_zero_disables_segmentation():
+    """Explicit --segment-size 0 should remain disabled and skip auto-defaulting."""
+    size, auto_enabled = _resolve_segment_size(0, 400)
+    assert size == 0
+    assert auto_enabled is False
+
+
+def test_explicit_segment_size_is_preserved():
+    """Explicit non-zero segment size should always be respected."""
+    size, auto_enabled = _resolve_segment_size(120, 500)
+    assert size == 120
+    assert auto_enabled is False

--- a/tools/bootstrap_session.py
+++ b/tools/bootstrap_session.py
@@ -483,11 +483,25 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--segment-size",
         type=int,
-        default=0,
+        default=None,
         help="Extract in segments of N turns with fresh catalogs, then reconcile. "
-             "0 = no segmentation (legacy behavior). Recommended: 100-150 for 14B models.",
+             "If omitted, sessions with >150 turns auto-default to 100. "
+             "Pass 0 to disable segmentation.",
     )
     return parser
+
+
+_AUTO_SEGMENT_THRESHOLD = 150
+_AUTO_SEGMENT_SIZE = 100
+
+
+def _resolve_segment_size(requested_segment_size: int | None, turn_count: int) -> tuple[int, bool]:
+    """Resolve effective segment size and whether auto-defaulting was applied."""
+    if requested_segment_size is not None:
+        return requested_segment_size, False
+    if turn_count > _AUTO_SEGMENT_THRESHOLD:
+        return _AUTO_SEGMENT_SIZE, True
+    return 0, False
 
 
 def main() -> None:
@@ -619,6 +633,18 @@ def main() -> None:
         for t in turns
     ]
 
+    effective_segment_size, auto_segment_enabled = _resolve_segment_size(
+        args.segment_size,
+        len(turn_dicts),
+    )
+    if auto_segment_enabled:
+        print(
+            f"  INFO: Auto-enabled --segment-size {_AUTO_SEGMENT_SIZE} "
+            f"(session has {len(turn_dicts)} turns, threshold is {_AUTO_SEGMENT_THRESHOLD}). "
+            "Pass --segment-size 0 explicitly to disable.",
+            file=sys.stderr,
+        )
+
     # Extract structured data from all turns (#21, #27, #28)
     try:
         from extract_structured_data import (
@@ -669,7 +695,7 @@ def main() -> None:
         extract_semantic_batch(
             turn_dicts, session_dir, framework_dir=args.framework, dry_run=args.dry_run,
             overrides=llm_overrides or None,
-            segment_size=args.segment_size,
+            segment_size=effective_segment_size,
         )
 
         # Stub backfill pass (#128, #131 — now runs by default)


### PR DESCRIPTION
## Summary

The `--segment-size` flag was already implemented but defaulted to 0 (disabled), causing context accumulation and late-turn PC extraction degradation on sessions > 150 turns. This change auto-defaults to 100 when the session size exceeds the threshold, and documents the behavior.

## Changes

- `tools/bootstrap_session.py`: auto-default `segment_size` to 100 when session > 150 turns when the flag is omitted
- `docs/usage.md`: document `--segment-size 100` as recommended for large sessions and explain auto-default behavior
- `docs/roadmap.md`: note the improved segmented extraction default
- `tests/test_bootstrap_segment_size_default.py`: add coverage for auto-default and explicit override behavior

Closes #197
