### PR TITLE
fix: reconcile PC prompt with available prior context (#201)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -185,6 +185,26 @@ models.
 
 **PC extraction cooldown:** If PC extraction fails for 20 consecutive turns (`_PC_SKIP_THRESHOLD`), it enters a cooldown cycle: skipping 50 turns, then retrying for 5 turns, repeating until a success resets the counter (#133, #168). An end-of-run summary reports how many turns were skipped.
 
+### PC Entity Extraction - Context Constraints
+
+Player-character extraction uses a trimmed prior-context payload to stay within
+effective context limits on long campaigns. The allowlist is defined in
+`tools/semantic_extraction.py` as `_PC_KEY_STABLE_ATTRS` and currently includes:
+
+- `species`
+- `race`
+- `class`
+- `aliases`
+
+This list is intentionally small. Many PC-facing fields (for example: level,
+background, equipment, condition, quest, and status) are excluded from prior
+context because they are volatile and increase token pressure in late-turn
+extraction.
+
+If you need to preserve and extract additional PC attributes more reliably,
+use segmented extraction (`--segment-size`) to reduce late-turn context bloat,
+then revisit the allowlist size.
+
 Or use CLI overrides for one-off runs:
 
 ```bash

--- a/templates/extraction/entity-detail.md
+++ b/templates/extraction/entity-detail.md
@@ -2,6 +2,8 @@ You are an entity detail extractor for an RPG session transcript analysis tool.
 
 Given a turn of transcript text and the current catalog entry for a specific entity (or an empty entry for a new entity), extract or update the entity based on what this turn reveals. You will receive the entity's prior state as context (if it exists).
 
+PC attribute allowlist note: The allowed `char-player` stable attributes below must match `_PC_KEY_STABLE_ATTRS` in `tools/semantic_extraction.py`. If keys are changed there, update this prompt list in the same change.
+
 Return a single JSON object conforming to this V2 structure:
 - "id": string — the entity's ID (use the provided ID for existing entities, or the proposed_id for new ones)
 - "name": string — display name (update if the text reveals a proper name for a previously unnamed entity)
@@ -44,7 +46,8 @@ Rules:
 - Keep identity and status factual and concise.
 - stable_attributes keys should describe persistent properties (role, appearance, race, class, allegiance), not transient narrative actions. If an entity performs an action in this turn, that action is an event — do not record it as a stable_attribute.
 - For the player character (id "char-player", referred to as "you" in DM narration): only extract STABLE traits and state changes, not transient narrative actions.
-  Allowed stable_attribute keys for char-player: "race", "class", "abilities", "appearance", "hp_change", "condition", "equipment", "quest", "allegiance", "status", "aliases".
+  Allowed stable_attribute keys for char-player: "species", "race", "class", "aliases".
+  Only use keys present in prior context for this turn. If a key is not shown in prior context, do not invent it.
   Do NOT create stable_attribute keys for temporary actions (e.g., "carries_wood", "talks_to_elder", "watches_sunset") — those belong in events, not entity attributes.
   Preserve existing stable attributes across turns. Only add or update attributes that represent lasting character state.
 

--- a/templates/extraction/entity-detail.md
+++ b/templates/extraction/entity-detail.md
@@ -47,7 +47,7 @@ Rules:
 - stable_attributes keys should describe persistent properties (role, appearance, race, class, allegiance), not transient narrative actions. If an entity performs an action in this turn, that action is an event — do not record it as a stable_attribute.
 - For the player character (id "char-player", referred to as "you" in DM narration): only extract STABLE traits and state changes, not transient narrative actions.
   Allowed stable_attribute keys for char-player: "species", "race", "class", "aliases".
-  Only use keys present in prior context for this turn. If a key is not shown in prior context, do not invent it.
+  Only use those allowlisted keys for char-player. Preserve allowlisted keys already present in prior context, and add an allowlisted key if the current turn explicitly reveals it. Do not invent values for allowlisted keys when they are not supported by the current turn text or existing entry.
   Do NOT create stable_attribute keys for temporary actions (e.g., "carries_wood", "talks_to_elder", "watches_sunset") — those belong in events, not entity attributes.
   Preserve existing stable attributes across turns. Only add or update attributes that represent lasting character state.
 

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -724,7 +724,7 @@ def format_discovery_prompt(turn: dict, known_entities: str) -> str:
     )
 
 
-# Stable attribute keys always included in trimmed PC prior context.
+# Stable attribute keys considered when trimming PC prior context.
 #
 # Why these are included:
 # - species/race/class: high-signal identity anchors that improve continuity.
@@ -733,8 +733,8 @@ def format_discovery_prompt(turn: dict, known_entities: str) -> str:
 # Why many keys are excluded here (for example: level, background, deity,
 # equipment, hp_change, condition, quest, allegiance, status): they are either
 # volatile, frequently rewritten by the model, or expensive in token budget.
-# The detail prompt must only promise keys present in this set to avoid
-# fabricated "carried-forward" attributes.
+# The detail prompt must only promise keys from this set to avoid fabricated
+# "carried-forward" attributes.
 _PC_KEY_STABLE_ATTRS = {"species", "race", "class", "aliases"}
 
 # Maximum number of volatile_state snapshots to include for PC

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -724,7 +724,17 @@ def format_discovery_prompt(turn: dict, known_entities: str) -> str:
     )
 
 
-# Stable attribute keys always included in trimmed PC context
+# Stable attribute keys always included in trimmed PC prior context.
+#
+# Why these are included:
+# - species/race/class: high-signal identity anchors that improve continuity.
+# - aliases: needed so newly revealed names can merge back into char-player.
+#
+# Why many keys are excluded here (for example: level, background, deity,
+# equipment, hp_change, condition, quest, allegiance, status): they are either
+# volatile, frequently rewritten by the model, or expensive in token budget.
+# The detail prompt must only promise keys present in this set to avoid
+# fabricated "carried-forward" attributes.
 _PC_KEY_STABLE_ATTRS = {"species", "race", "class", "aliases"}
 
 # Maximum number of volatile_state snapshots to include for PC
@@ -863,7 +873,7 @@ def _format_prior_entity_context(
 
     For ``char-player``, trims the context to keep prompt size manageable:
     - Always includes identity and current_status
-    - Only key stable_attributes (species, class, aliases)
+    - Only key stable_attributes (species, race, class, aliases)
     - Last 3 volatile_state snapshots only
     - Relationship histories replaced with arc summaries when available (#120)
     - Old volatile state entries digested into count + themes (#121)


### PR DESCRIPTION
## Summary
Align entity-detail prompt constraints with actual char-player prior-context keys to prevent fabricated carry-forward attributes.

The prompt previously listed more PC stable attributes than the prior context actually provides via `_PC_KEY_STABLE_ATTRS`, which encouraged hallucinated fields in extraction output.

Related: #196 (coercion), #199 (logging)

## Changes
- Trimmed char-player allowed stable attributes in `templates/extraction/entity-detail.md` to match `_PC_KEY_STABLE_ATTRS`
- Added explicit non-invention instruction when key is not present in prior context
- Added rationale comments around `_PC_KEY_STABLE_ATTRS` in `tools/semantic_extraction.py`
- Corrected prior-context docstring list to include `race`
- Added usage docs section: "PC Entity Extraction - Context Constraints"

## Testing
- `pytest tests/ -k "entity_detail or pc_extract"`
  - Result: 2 passed
- Verified prompt attributes are a subset of `_PC_KEY_STABLE_ATTRS`

Closes #201
