### PR TITLE
fix: harden detached extraction launch quoting

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,7 +168,7 @@ All data structures are defined in `schemas/`. See each schema file for field de
 | `tools/temporal_extraction.py` | Pattern-based temporal signal extraction and day estimation |
 | `tools/catalog_merger.py` | Merge extracted entities into framework catalog files |
 | `tools/llm_client.py` | Provider-agnostic LLM client (OpenAI, Ollama, Google Gemini, etc.) |
-| `tools/start_extraction_detached.ps1` | Launch semantic extraction in a detached process with log/PID files |
+| `tools/start_extraction_detached.ps1` | Launch semantic extraction in a detached process with log/PID files; supports `-Framework`/`-PlayerLabel` passthrough and safe argument quoting for values with spaces |
 | `tools/watch_extraction_detached.ps1` | Show status and tail logs for detached extraction runs |
 | `tools/stop_extraction_detached.ps1` | Stop detached extraction runs by PID file |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -83,7 +83,7 @@ Goals:
 Remaining work:
 - Fallback provider chain in `tools/llm_client.py` (local → cloud)
 - CLI `--provider` override for per-run provider selection
-- Batch processing mode for unattended overnight extraction (**partially implemented** via detached helper scripts: `tools/start_extraction_detached.ps1`, `tools/watch_extraction_detached.ps1`, `tools/stop_extraction_detached.ps1`)
+- Batch processing mode for unattended overnight extraction (**partially implemented** via detached helper scripts: `tools/start_extraction_detached.ps1`, `tools/watch_extraction_detached.ps1`, `tools/stop_extraction_detached.ps1`; launcher now safely quotes spaced arguments and supports framework/player-label passthrough)
 - Provider setup documentation in `docs/usage.md`
 - Quality validation of `qwen2.5:7b` as a faster alternative to 14B
 - **Segmented extraction** (#141, #197): Long sessions are extracted in configurable segments to stay within model context limits. Each segment starts with a clean entity catalog; a reconciliation pass merges the results. The bootstrap default now auto-enables `--segment-size 100` when session size exceeds 150 turns (pass `--segment-size 0` to disable).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -371,14 +371,23 @@ Use the helper script from the repository root:
 powershell -ExecutionPolicy Bypass -File tools/start_extraction_detached.ps1 `
   -Session sessions/session-import `
   -TranscriptFile sessions/_import/session-import-full-transcript.txt `
+  -Framework framework-local `
+  -PlayerLabel "Fenouille Moonwind" `
   -SegmentSize 100
 ```
+
+The helper safely quotes argument values passed to `Start-Process`, so values
+with spaces (for example `-PlayerLabel "Fenouille Moonwind"`) are passed as a
+single argument to `bootstrap_session.py`.
 
 The script writes:
 - stdout log: `run-logs/extract-<timestamp>.log`
 - stderr log: `run-logs/extract-<timestamp>.err.log`
 - PID file: `run-logs/extract-<timestamp>.pid`
 - command helper: `run-logs/extract-<timestamp>.cmd.txt`
+
+Optional detached-launch flags include `-Model`, `-Framework`,
+`-PlayerLabel`, and `-Overwrite`.
 
 Monitor/status a detached run (latest run by default):
 

--- a/tools/start_extraction_detached.ps1
+++ b/tools/start_extraction_detached.ps1
@@ -3,6 +3,8 @@ param(
     [string]$TranscriptFile = "",
     [int]$SegmentSize = 100,
     [string]$Model = "",
+    [string]$Framework = "",
+    [string]$PlayerLabel = "",
     [string]$LogsDir = "run-logs",
     [switch]$Overwrite
 )
@@ -46,20 +48,41 @@ if ($Model) {
     $args += @("--model", $Model)
 }
 
+if ($Framework) {
+    $args += @("--framework", $Framework)
+}
+
+if ($PlayerLabel) {
+    $args += @("--player-label", $PlayerLabel)
+}
+
 if ($Overwrite) {
     $args += "--overwrite"
 }
 
-$process = Start-Process -FilePath "python" -ArgumentList $args -RedirectStandardOutput $logPath -RedirectStandardError $errPath -PassThru
+function Format-WindowsProcessArgument {
+    param([string]$Value)
+
+    if ([string]::IsNullOrEmpty($Value)) {
+        return '""'
+    }
+
+    if ($Value -notmatch '[\s"]') {
+        return $Value
+    }
+
+    $escaped = $Value -replace '(\\*)"', '$1$1\\"'
+    $escaped = $escaped -replace '(\\+)$', '$1$1'
+    return '"' + $escaped + '"'
+}
+
+$argumentString = (($args | ForEach-Object { Format-WindowsProcessArgument ([string]$_) }) -join " ")
+
+$process = Start-Process -FilePath "python" -ArgumentList $argumentString -RedirectStandardOutput $logPath -RedirectStandardError $errPath -PassThru
 
 $process.Id | Set-Content -Path $pidPath
 
-function Format-QuotedArg {
-    param([string]$Value)
-    return "'" + $Value.Replace("'", "''") + "'"
-}
-
-$argString = ($args | ForEach-Object { Format-QuotedArg $_ }) -join " "
+$argString = ($args | ForEach-Object { Format-WindowsProcessArgument ([string]$_) }) -join " "
 @(
     "python $argString",
     "",

--- a/tools/start_extraction_detached.ps1
+++ b/tools/start_extraction_detached.ps1
@@ -82,9 +82,8 @@ $process = Start-Process -FilePath "python" -ArgumentList $argumentString -Redir
 
 $process.Id | Set-Content -Path $pidPath
 
-$argString = ($args | ForEach-Object { Format-WindowsProcessArgument ([string]$_) }) -join " "
 @(
-    "python $argString",
+    "python $argumentString",
     "",
     "Monitor/status:",
     "  powershell -ExecutionPolicy Bypass -File tools/watch_extraction_detached.ps1 -PidFile '$pidPath'",


### PR DESCRIPTION
## Summary
Fix detached extraction launch so argument values containing spaces are passed correctly to `bootstrap_session.py`, and expose missing passthrough flags needed for imported-session runs.

## Issue #209 — Detached launch splits spaced argument values
- Added robust Windows argument quoting in `tools/start_extraction_detached.ps1` before invoking `Start-Process`.
- Added `-Framework` and `-PlayerLabel` parameters and pass-through to bootstrap arguments.
- Updated detached launch docs in architecture/roadmap/usage to reflect the new behavior and options.

## Validation
- Launched detached extraction helper with `-PlayerLabel "Fenouille Moonwind"`.
- Confirmed process started without prior argparse split failure (`unrecognized arguments: Moonwind`).
- Stopped smoke-test process with `tools/stop_extraction_detached.ps1`.

Closes #209
