### PR TITLE
fix: close relationship type and stable_attributes shape coercion gaps (#218, #219)

### DIFF
--- a/tests/test_coerce_entity.py
+++ b/tests/test_coerce_entity.py
@@ -1120,6 +1120,94 @@ def test_coerce_event_type_non_string_falls_back_to_other():
         assert result["type"] == "other"
 
 
+def test_relationship_type_coercion_known_phrase():
+    """'knowledge exchange' should map to 'mentorship' (#218)."""
+    entity = {
+        "id": "char-test", "name": "Test", "type": "character",
+        "identity": "Test", "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-001",
+        "relationships": [{"target_id": "char-other", "type": "knowledge exchange",
+                           "current_relationship": "shares knowledge"}]
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["relationships"][0]["type"] == "mentorship"
+
+
+def test_relationship_type_coercion_unknown_fallback():
+    """Unknown relationship types should fall back to 'other' (#218)."""
+    entity = {
+        "id": "char-test", "name": "Test", "type": "character",
+        "identity": "Test", "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-001",
+        "relationships": [{"target_id": "char-other", "type": "cosmic alignment",
+                           "current_relationship": "aligned"}]
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["relationships"][0]["type"] == "other"
+
+
+def test_relationship_type_valid_unchanged():
+    """Valid relationship types should not be modified (#218)."""
+    entity = {
+        "id": "char-test", "name": "Test", "type": "character",
+        "identity": "Test", "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-001",
+        "relationships": [{"target_id": "char-other", "type": "social",
+                           "current_relationship": "friend"}]
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["relationships"][0]["type"] == "social"
+
+
+def test_stable_attributes_list_wrapped():
+    """List value in stable_attributes should be wrapped to attribute object (#219)."""
+    entity = {
+        "id": "char-player", "name": "PC", "type": "character",
+        "identity": "Player", "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-001",
+        "stable_attributes": {
+            "aliases": ["Player Character"]  # raw list, not {value: [...]}
+        }
+    }
+    result = _coerce_entity_fields(entity)
+    attr = result["stable_attributes"]["aliases"]
+    assert isinstance(attr, dict)
+    assert attr["value"] == ["Player Character"]
+
+
+def test_stable_attributes_string_wrapped():
+    """String value in stable_attributes should be wrapped to attribute object (#219)."""
+    entity = {
+        "id": "char-test", "name": "Test", "type": "character",
+        "identity": "Test", "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-001",
+        "stable_attributes": {
+            "race": "Elf"  # raw string, not {value: "Elf", ...}
+        }
+    }
+    result = _coerce_entity_fields(entity)
+    attr = result["stable_attributes"]["race"]
+    assert isinstance(attr, dict)
+    assert attr["value"] == "Elf"
+
+
+def test_stable_attributes_existing_object_unchanged():
+    """Properly shaped stable_attributes values should not be re-wrapped (#219)."""
+    entity = {
+        "id": "char-test", "name": "Test", "type": "character",
+        "identity": "Test", "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-001",
+        "stable_attributes": {
+            "race": {"value": "Elf", "inference": False, "confidence": 1.0}
+        }
+    }
+    result = _coerce_entity_fields(entity)
+    attr = result["stable_attributes"]["race"]
+    assert attr["value"] == "Elf"
+    assert attr["inference"] is False
+    assert attr["confidence"] == 1.0
+
+
 def test_coerce_event_returns_none_for_non_dict():
     """Non-dict event items return None."""
     assert _coerce_event_fields(["not", "a", "dict"]) is None

--- a/tests/test_coerce_entity.py
+++ b/tests/test_coerce_entity.py
@@ -1159,6 +1159,33 @@ def test_relationship_type_valid_unchanged():
     assert result["relationships"][0]["type"] == "social"
 
 
+def test_relationship_type_coercion_trims_and_normalizes_case():
+    """Relationship types should be normalized for common LLM casing/whitespace variants."""
+    entity = {
+        "id": "char-test", "name": "Test", "type": "character",
+        "identity": "Test", "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-001",
+        "relationships": [{"target_id": "char-other", "type": " Social ",
+                           "current_relationship": "friend"}]
+    }
+    result = _coerce_entity_fields(entity)
+    assert result["relationships"][0]["type"] == "social"
+
+
+def test_relationship_type_non_string_falls_back_to_other():
+    """Non-string relationship types should safely fall back to 'other'."""
+    for bad_type in (["social"], {"kind": "social"}, 123, None):
+        entity = {
+            "id": "char-test", "name": "Test", "type": "character",
+            "identity": "Test", "first_seen_turn": "turn-001",
+            "last_updated_turn": "turn-001",
+            "relationships": [{"target_id": "char-other", "type": bad_type,
+                               "current_relationship": "friend"}]
+        }
+        result = _coerce_entity_fields(entity)
+        assert result["relationships"][0]["type"] == "other"
+
+
 def test_stable_attributes_list_wrapped():
     """List value in stable_attributes should be wrapped to attribute object (#219)."""
     entity = {
@@ -1189,6 +1216,37 @@ def test_stable_attributes_string_wrapped():
     attr = result["stable_attributes"]["race"]
     assert isinstance(attr, dict)
     assert attr["value"] == "Elf"
+
+
+def test_stable_attributes_list_elements_coerced_to_str():
+    """Non-string list elements in stable_attributes should be coerced to str (#219)."""
+    entity = {
+        "id": "char-test", "name": "Test", "type": "character",
+        "identity": "Test", "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-001",
+        "stable_attributes": {
+            "scores": [1, 2, 3]
+        }
+    }
+    result = _coerce_entity_fields(entity)
+    attr = result["stable_attributes"]["scores"]
+    assert isinstance(attr, dict)
+    assert attr["value"] == ["1", "2", "3"]
+
+
+def test_stable_attributes_wrapped_includes_source_turn():
+    """Wrapped stable_attributes should include source_turn when turn ID is valid (#219)."""
+    entity = {
+        "id": "char-test", "name": "Test", "type": "character",
+        "identity": "Test", "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-001",
+        "stable_attributes": {
+            "race": "Elf"
+        }
+    }
+    result = _coerce_entity_fields(entity)
+    attr = result["stable_attributes"]["race"]
+    assert attr["source_turn"] == "turn-001"
 
 
 def test_stable_attributes_existing_object_unchanged():

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -517,11 +517,19 @@ def _coerce_entity_fields(entity_data) -> dict | None:
                 continue  # handled above
             if not isinstance(v, dict):
                 # Wrap raw value (string, list, int, etc.) in attribute object
+                if isinstance(v, str):
+                    wrapped_value = v
+                elif isinstance(v, list):
+                    wrapped_value = [str(item) for item in v]
+                else:
+                    wrapped_value = str(v)
                 wrapped = {
-                    "value": v if isinstance(v, (str, list)) else str(v),
+                    "value": wrapped_value,
                     "inference": True,
                     "confidence": 0.5,
                 }
+                if has_valid_turn:
+                    wrapped["source_turn"] = turn_id
                 sa[k] = wrapped
                 print(f"  COERCE: stable_attributes.{k} was {type(v).__name__} — wrapped to attribute object", file=sys.stderr)
 
@@ -573,14 +581,23 @@ def _coerce_entity_fields(entity_data) -> dict | None:
     _VALID_REL_TYPES = {"kinship", "partnership", "mentorship", "political", "factional", "social", "adversarial", "romantic", "other"}
     for rel in entity_data.get("relationships", []):
         rt = rel.get("type", "")
-        if rt and rt.lower() not in _VALID_REL_TYPES:
-            mapped = _REL_TYPE_MAP.get(rt.lower())
-            if mapped:
-                rel["type"] = mapped
-                print(f"  COERCE: relationship type '{rt}' → '{mapped}'", file=sys.stderr)
+        if isinstance(rt, str):
+            normalized_rt = rt.strip().lower()
+            if normalized_rt in _VALID_REL_TYPES:
+                mapped = normalized_rt
+            elif normalized_rt:
+                mapped = _REL_TYPE_MAP.get(normalized_rt, "other")
             else:
-                rel["type"] = "other"
+                mapped = "other"
+        else:
+            mapped = "other"
+
+        if rel.get("type") != mapped:
+            rel["type"] = mapped
+            if mapped == "other":
                 print(f"  COERCE: relationship type '{rt}' → 'other' (unmapped)", file=sys.stderr)
+            else:
+                print(f"  COERCE: relationship type '{rt}' → '{mapped}'", file=sys.stderr)
 
     return entity_data
 

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -509,6 +509,22 @@ def _coerce_entity_fields(entity_data) -> dict | None:
             del sa[k]
             print(f"  COERCE: stable_attributes.{k}.value was null — removed", file=sys.stderr)
 
+    # Coerce non-object stable_attributes values to proper attribute objects (#219)
+    sa = entity_data.get("stable_attributes")
+    if isinstance(sa, dict):
+        for k, v in list(sa.items()):
+            if v is None:
+                continue  # handled above
+            if not isinstance(v, dict):
+                # Wrap raw value (string, list, int, etc.) in attribute object
+                wrapped = {
+                    "value": v if isinstance(v, (str, list)) else str(v),
+                    "inference": True,
+                    "confidence": 0.5,
+                }
+                sa[k] = wrapped
+                print(f"  COERCE: stable_attributes.{k} was {type(v).__name__} — wrapped to attribute object", file=sys.stderr)
+
     # Ensure volatile_state has last_updated_turn if we populated it
     vs = entity_data.get("volatile_state")
     if isinstance(vs, dict) and "last_updated_turn" not in vs and has_valid_turn:
@@ -527,6 +543,44 @@ def _coerce_entity_fields(entity_data) -> dict | None:
                 rel["first_seen_turn"] = source_turn
             if "last_updated_turn" not in rel:
                 rel["last_updated_turn"] = source_turn
+
+    # Coerce relationship type values to schema enum (#218)
+    _REL_TYPE_MAP = {
+        "knowledge exchange": "mentorship",
+        "knowledge sharing": "mentorship",
+        "teaching": "mentorship",
+        "learning": "mentorship",
+        "trade": "social",
+        "trading": "social",
+        "alliance": "political",
+        "rivalry": "adversarial",
+        "enemy": "adversarial",
+        "friend": "social",
+        "friendship": "social",
+        "family": "kinship",
+        "parent": "kinship",
+        "child": "kinship",
+        "sibling": "kinship",
+        "spouse": "romantic",
+        "lover": "romantic",
+        "companion": "social",
+        "follower": "factional",
+        "leader": "political",
+        "subordinate": "factional",
+        "protector": "social",
+        "caretaker": "social",
+    }
+    _VALID_REL_TYPES = {"kinship", "partnership", "mentorship", "political", "factional", "social", "adversarial", "romantic", "other"}
+    for rel in entity_data.get("relationships", []):
+        rt = rel.get("type", "")
+        if rt and rt.lower() not in _VALID_REL_TYPES:
+            mapped = _REL_TYPE_MAP.get(rt.lower())
+            if mapped:
+                rel["type"] = mapped
+                print(f"  COERCE: relationship type '{rt}' → '{mapped}'", file=sys.stderr)
+            else:
+                rel["type"] = "other"
+                print(f"  COERCE: relationship type '{rt}' → 'other' (unmapped)", file=sys.stderr)
 
     return entity_data
 


### PR DESCRIPTION
## Summary

Close two coercion gaps that allowed invalid data past schema validation.

## Issue #218 — Relationship type enum leak

Added relationship type coercion mapping natural-language phrases (e.g., `knowledge exchange`) to schema-valid enum values. Unknown types fall back to `other` instead of failing validation.

## Issue #219 — stable_attributes value shape leak

Added shape coercion for stable_attributes entries that arrive as raw strings/lists instead of the required `{value, inference, confidence}` objects. Values are automatically wrapped with conservative defaults.

## Testing

- Added tests for relationship type coercion (known phrase + unknown fallback + valid passthrough)
- Added tests for stable_attributes shape wrapping (list + string + existing object unchanged)
- All existing tests pass (888 → 894)

Closes #218
Closes #219
