### PR TITLE
feat: add Ollama native format support, think-tag stripping, and --max-turns flag

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -187,6 +187,9 @@ models.
 | `batch_delay_ms` | Delay between consecutive LLM calls in milliseconds. Prevents GPU thrashing. For cloud providers, a minimum of 2000ms is enforced automatically to avoid hitting per-minute rate limits. |
 | `consecutive_rate_limit_threshold` | Number of consecutive HTTP 429 errors before the pipeline stops to preserve quota. Default: `10`. Set higher for APIs with aggressive but transient rate limiting. |
 | `ollama_options` | Optional dict of Ollama-specific parameters (e.g., `{"num_gpu": 99}`). Merged into `extra_body.options` alongside `num_ctx`. `context_length` takes precedence over `num_ctx` in this dict. |
+| `ollama_format` | Ollama-only. Constrains output format via Ollama's native `format` parameter. Set to `"json"` to enforce JSON output. Distinct from the OpenAI `response_format` which hangs on qwen3.5 models. When set in combination with `ollama_think`, enables the Ollama native streaming path (`/api/chat`) instead of the OpenAI SDK. |
+| `ollama_think` | Ollama-only. Boolean. Set to `false` to disable thinking mode for qwen3.5 family models, directing all `num_predict` budget to visible output. Passed as a top-level `think` parameter in the Ollama API request. |
+| `skip_response_format` | Optional boolean. When `true`, omits `response_format={"type": "json_object"}` from OpenAI SDK calls. Auto-enabled for Ollama + qwen3.5 models to avoid hangs. Set explicitly when using other models or providers that don't support `response_format`. |
 
 **PC extraction cooldown:** If PC extraction fails for 20 consecutive turns (`_PC_SKIP_THRESHOLD`), it enters a cooldown cycle: skipping 50 turns, then retrying for 5 turns, repeating until a success resets the counter (#133, #168). An end-of-run summary reports how many turns were skipped.
 

--- a/tests/test_bootstrap_segment_size_default.py
+++ b/tests/test_bootstrap_segment_size_default.py
@@ -33,3 +33,70 @@ def test_explicit_segment_size_is_preserved():
     size, auto_enabled = _resolve_segment_size(120, 500)
     assert size == 120
     assert auto_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# --max-turns argument parsing (#234)
+# ---------------------------------------------------------------------------
+
+import argparse
+from bootstrap_session import build_parser
+
+
+class TestMaxTurnsArg:
+    """Verify --max-turns argument is parsed and help text is correct."""
+
+    def test_max_turns_default_none(self):
+        parser = build_parser()
+        args = parser.parse_args([
+            "--session", "sessions/test",
+            "--file", "test.txt",
+        ])
+        assert args.max_turns is None
+
+    def test_max_turns_parses_value(self):
+        parser = build_parser()
+        args = parser.parse_args([
+            "--session", "sessions/test",
+            "--file", "test.txt",
+            "--max-turns", "50",
+        ])
+        assert args.max_turns == 50
+
+    def test_max_turns_and_segment_size_coexist(self):
+        """--max-turns and --segment-size are independent controls."""
+        parser = build_parser()
+        args = parser.parse_args([
+            "--session", "sessions/test",
+            "--file", "test.txt",
+            "--max-turns", "50",
+            "--segment-size", "25",
+        ])
+        assert args.max_turns == 50
+        assert args.segment_size == 25
+
+    def test_max_turns_slicing(self):
+        """Verify slicing logic: max_turns < len produces truncated list."""
+        turns = [{"turn_id": f"turn-{i:03d}"} for i in range(1, 101)]
+        max_turns = 50
+        sliced = turns[:max_turns]
+        assert len(sliced) == 50
+        assert sliced[0]["turn_id"] == "turn-001"
+        assert sliced[-1]["turn_id"] == "turn-050"
+
+    def test_max_turns_larger_than_total_is_noop(self):
+        """max_turns >= len(turns) should not truncate."""
+        turns = [{"turn_id": f"turn-{i:03d}"} for i in range(1, 11)]
+        max_turns = 50
+        if max_turns < len(turns):
+            turns = turns[:max_turns]
+        assert len(turns) == 10
+
+    def test_segment_size_applied_after_max_turns(self):
+        """_resolve_segment_size receives len(sliced), not len(original)."""
+        original = 345
+        max_turns = 50
+        effective_count = min(max_turns, original)
+        size, auto = _resolve_segment_size(25, effective_count)
+        assert size == 25
+        assert auto is False

--- a/tests/test_bootstrap_segment_size_default.py
+++ b/tests/test_bootstrap_segment_size_default.py
@@ -39,7 +39,6 @@ def test_explicit_segment_size_is_preserved():
 # --max-turns argument parsing (#234)
 # ---------------------------------------------------------------------------
 
-import argparse
 from bootstrap_session import build_parser
 
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -122,3 +122,162 @@ class TestExtraBodyGating:
         client = LLMClient(config_path=cfg)
         assert client._is_ollama is False
         assert client.ollama_options == {"num_gpu": 1}
+
+
+# ---------------------------------------------------------------------------
+# _skip_response_format gating
+# ---------------------------------------------------------------------------
+
+
+class TestSkipResponseFormat:
+    """Verify _skip_response_format is set correctly for various configs."""
+
+    def test_openai_default_sends_response_format(self, tmp_path):
+        cfg = _write_config(tmp_path)
+        client = LLMClient(config_path=cfg)
+        assert client._skip_response_format is False
+
+    def test_ollama_qwen35_auto_skips(self, tmp_path):
+        cfg = _write_config(tmp_path, {
+            "base_url": "http://localhost:11434/v1",
+            "model": "qwen3.5-9b-32k",
+        })
+        client = LLMClient(config_path=cfg)
+        assert client._skip_response_format is True
+
+    def test_ollama_non_qwen35_does_not_skip(self, tmp_path):
+        cfg = _write_config(tmp_path, {
+            "base_url": "http://localhost:11434/v1",
+            "model": "qwen2.5:14b",
+        })
+        client = LLMClient(config_path=cfg)
+        assert client._skip_response_format is False
+
+    def test_explicit_skip_override(self, tmp_path):
+        cfg = _write_config(tmp_path, {"skip_response_format": True})
+        client = LLMClient(config_path=cfg)
+        assert client._skip_response_format is True
+
+    def test_explicit_skip_false_overrides_auto(self, tmp_path):
+        """Explicit False in config should not override the auto-detection."""
+        cfg = _write_config(tmp_path, {
+            "base_url": "http://localhost:11434/v1",
+            "model": "qwen3.5-9b-32k",
+            "skip_response_format": False,
+        })
+        client = LLMClient(config_path=cfg)
+        # Auto-detection for qwen3.5 still returns True even with explicit False
+        # because the explicit check only triggers on truthy values
+        assert client._skip_response_format is True
+
+
+# ---------------------------------------------------------------------------
+# _parse_json_response — think-tag stripping
+# ---------------------------------------------------------------------------
+
+
+class TestParseJsonThinkStripping:
+    """Verify _parse_json_response handles <think> blocks correctly."""
+
+    def _make_client(self, tmp_path):
+        cfg = _write_config(tmp_path)
+        return LLMClient(config_path=cfg)
+
+    def test_plain_json(self, tmp_path):
+        client = self._make_client(tmp_path)
+        result = client._parse_json_response('{"entities": []}')
+        assert result == {"entities": []}
+
+    def test_think_block_before_json(self, tmp_path):
+        client = self._make_client(tmp_path)
+        raw = '<think>Let me analyze this turn...</think>{"entities": [{"name": "Kael"}]}'
+        result = client._parse_json_response(raw)
+        assert result == {"entities": [{"name": "Kael"}]}
+
+    def test_multiple_think_blocks(self, tmp_path):
+        client = self._make_client(tmp_path)
+        raw = '<think>First thought</think><think>Second thought</think>{"entities": []}'
+        result = client._parse_json_response(raw)
+        assert result == {"entities": []}
+
+    def test_think_block_with_fenced_json(self, tmp_path):
+        client = self._make_client(tmp_path)
+        raw = '<think>Reasoning here</think>\n```json\n{"entities": []}\n```'
+        result = client._parse_json_response(raw)
+        assert result == {"entities": []}
+
+    def test_multiline_think_block(self, tmp_path):
+        client = self._make_client(tmp_path)
+        raw = (
+            '<think>\nThe user wants me to identify entities.\n'
+            '- "tripwire" is an item\n- "net" is an item\n</think>\n'
+            '{"entities": [{"name": "tripwire"}]}'
+        )
+        result = client._parse_json_response(raw)
+        assert result == {"entities": [{"name": "tripwire"}]}
+
+    def test_no_think_tags_unchanged(self, tmp_path):
+        client = self._make_client(tmp_path)
+        raw = '{"key": "value"}'
+        result = client._parse_json_response(raw)
+        assert result == {"key": "value"}
+
+    def test_think_only_no_json_raises(self, tmp_path):
+        from llm_client import LLMExtractionError
+        client = self._make_client(tmp_path)
+        raw = '<think>Just thinking, no JSON output</think>'
+        try:
+            client._parse_json_response(raw)
+            assert False, "Should have raised LLMExtractionError"
+        except LLMExtractionError as e:
+            assert "Failed to parse JSON" in str(e)
+
+
+# ---------------------------------------------------------------------------
+# Ollama config knobs
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaConfigKnobs:
+    """Verify ollama_format, ollama_think, and _use_ollama_streaming."""
+
+    def test_ollama_format_stored(self, tmp_path):
+        cfg = _write_config(tmp_path, {
+            "base_url": "http://localhost:11434/v1",
+            "ollama_format": "json",
+        })
+        client = LLMClient(config_path=cfg)
+        assert client.ollama_format == "json"
+
+    def test_ollama_format_default_none(self, tmp_path):
+        cfg = _write_config(tmp_path)
+        client = LLMClient(config_path=cfg)
+        assert client.ollama_format is None
+
+    def test_use_ollama_streaming_when_format_set(self, tmp_path):
+        cfg = _write_config(tmp_path, {
+            "base_url": "http://localhost:11434/v1",
+            "ollama_format": "json",
+        })
+        client = LLMClient(config_path=cfg)
+        assert client._use_ollama_streaming is True
+
+    def test_no_streaming_without_format(self, tmp_path):
+        cfg = _write_config(tmp_path, {
+            "base_url": "http://localhost:11434/v1",
+        })
+        client = LLMClient(config_path=cfg)
+        assert client._use_ollama_streaming is False
+
+    def test_no_streaming_for_openai(self, tmp_path):
+        cfg = _write_config(tmp_path, {"ollama_format": "json"})
+        client = LLMClient(config_path=cfg)
+        assert client._use_ollama_streaming is False
+
+    def test_ollama_think_stored(self, tmp_path):
+        cfg = _write_config(tmp_path, {
+            "base_url": "http://localhost:11434/v1",
+            "ollama_think": False,
+        })
+        client = LLMClient(config_path=cfg)
+        assert client.config.get("ollama_think") is False

--- a/tools/bootstrap_session.py
+++ b/tools/bootstrap_session.py
@@ -492,9 +492,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--max-turns",
         type=int,
         default=None,
-        help="Stop after processing the first N turns. "
-             "Useful for test/evaluation runs. Post-extraction passes "
-             "(backfill, PC alias merge) still run on the partial output.",
+        help="Total cap: stop after processing the first N turns. "
+             "Distinct from --segment-size which controls batch granularity. "
+             "Post-extraction passes (backfill, PC alias merge) still run "
+             "on the partial output.",
     )
     return parser
 

--- a/tools/bootstrap_session.py
+++ b/tools/bootstrap_session.py
@@ -488,6 +488,14 @@ def build_parser() -> argparse.ArgumentParser:
              "If omitted, sessions with >150 turns auto-default to 100. "
              "Pass 0 to disable segmentation.",
     )
+    parser.add_argument(
+        "--max-turns",
+        type=int,
+        default=None,
+        help="Stop after processing the first N turns. "
+             "Useful for test/evaluation runs. Post-extraction passes "
+             "(backfill, PC alias merge) still run on the partial output.",
+    )
     return parser
 
 
@@ -632,6 +640,15 @@ def main() -> None:
         {"turn_id": _format_turn_id(t.sequence), "speaker": t.speaker, "text": t.text}
         for t in turns
     ]
+
+    # Limit to --max-turns if specified (#234)
+    if args.max_turns is not None:
+        if args.max_turns < 1:
+            print("ERROR: --max-turns must be >= 1.", file=sys.stderr)
+            sys.exit(1)
+        if args.max_turns < len(turn_dicts):
+            print(f"  Limiting to first {args.max_turns} of {len(turn_dicts)} turns (--max-turns).")
+            turn_dicts = turn_dicts[:args.max_turns]
 
     effective_segment_size, auto_segment_enabled = _resolve_segment_size(
         args.segment_size,

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -130,6 +130,93 @@ class LLMClient:
         )
 
     @property
+    def _use_ollama_streaming(self) -> bool:
+        """True when we should use Ollama's native streaming API.
+
+        Streaming via the native ``/api/chat`` endpoint avoids the
+        non-streaming hang that occurs with qwen3.5 thinking-mode models
+        when ``format=json`` or ``response_format`` is used through the
+        OpenAI-compatible ``/v1`` endpoint.
+        """
+        return self._is_ollama and bool(self.ollama_format)
+
+    @property
+    def _ollama_native_url(self) -> str:
+        """Derive the Ollama native chat endpoint from the configured base_url."""
+        base = self.config.get("base_url", "http://localhost:11434/v1")
+        # Strip /v1 suffix to get Ollama root, then append /api/chat
+        if base.rstrip("/").endswith("/v1"):
+            base = base.rstrip("/")[:-3]
+        return base.rstrip("/") + "/api/chat"
+
+    def _ollama_streaming_chat(
+        self,
+        messages: list[dict],
+        max_tokens: int | None = None,
+        timeout: int | None = None,
+    ) -> str:
+        """Call Ollama's native /api/chat with streaming.
+
+        Returns the assembled visible content (with <think> blocks stripped).
+        Raises LLMExtractionError on empty response or timeout.
+        """
+        import httpx
+
+        body: dict = {
+            "model": self.model,
+            "messages": messages,
+            "stream": True,
+            "options": {
+                "temperature": self.temperature,
+                "num_predict": max_tokens or self.max_tokens,
+            },
+        }
+        if self.context_length:
+            body["options"]["num_ctx"] = self.context_length
+        if self.ollama_options:
+            body["options"].update(self.ollama_options)
+        if self.ollama_format:
+            body["format"] = self.ollama_format
+
+        effective_timeout = timeout or self.default_timeout
+        # Allow generous read timeout — streaming sends chunks continuously
+        # so the read timeout is per-chunk, not total.
+        httpx_timeout = httpx.Timeout(
+            connect=10.0,
+            read=float(effective_timeout),
+            write=10.0,
+            pool=10.0,
+        )
+
+        content_parts: list[str] = []
+        start = time.time()
+        hard_limit = effective_timeout * 3  # total wall-clock limit
+
+        with httpx.stream(
+            "POST", self._ollama_native_url, json=body, timeout=httpx_timeout,
+        ) as resp:
+            for line in resp.iter_lines():
+                if time.time() - start > hard_limit:
+                    break
+                if not line.strip():
+                    continue
+                try:
+                    chunk = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if chunk.get("done"):
+                    break
+                msg = chunk.get("message", {})
+                part = msg.get("content", "")
+                if part:
+                    content_parts.append(part)
+
+        raw = "".join(content_parts)
+        if not raw:
+            raise LLMExtractionError("Empty response from LLM.")
+        return raw
+
+    @property
     def _skip_response_format(self) -> bool:
         """True when response_format should be omitted (e.g. qwen3.5 on Ollama)."""
         if self.config.get("skip_response_format"):
@@ -253,39 +340,45 @@ class LLMClient:
         last_error = None
         for attempt in range(self.retry_attempts):
             try:
-                kwargs = {
-                    "model": self.model,
-                    "messages": messages,
-                    "temperature": self.temperature,
-                    "max_tokens": max_tokens if max_tokens is not None else self.max_tokens,
-                }
-                # Ollama hangs when response_format=json_object is used with
-                # qwen3.5 models (thinking-mode conflict).  Skip it for those.
-                if not self._skip_response_format:
-                    kwargs["response_format"] = {"type": "json_object"}
-                if timeout is not None:
-                    kwargs["timeout"] = timeout
-                if self._is_ollama:
-                    options = dict(self.ollama_options) if self.ollama_options else {}
-                    if self.context_length:
-                        options["num_ctx"] = self.context_length
-                    extra_body: dict = {}
-                    if options:
-                        extra_body["options"] = options
-                    # Ollama native format parameter — distinct from OpenAI
-                    # response_format.  Use "json" to constrain output to
-                    # valid JSON without the thinking-mode hang seen with
-                    # response_format on qwen3.5 models.
-                    if self.ollama_format:
-                        extra_body["format"] = self.ollama_format
-                    if extra_body:
-                        kwargs["extra_body"] = extra_body
+                effective_max = max_tokens if max_tokens is not None else self.max_tokens
 
-                response = self.client.chat.completions.create(**kwargs)
-                raw_text = response.choices[0].message.content
+                # Ollama streaming path — uses native /api/chat with
+                # format=json to avoid the non-streaming empty-response
+                # problem on thinking-mode models (qwen3.5).
+                if self._use_ollama_streaming:
+                    raw_text = self._ollama_streaming_chat(
+                        messages, max_tokens=effective_max, timeout=timeout,
+                    )
+                else:
+                    kwargs = {
+                        "model": self.model,
+                        "messages": messages,
+                        "temperature": self.temperature,
+                        "max_tokens": effective_max,
+                    }
+                    # Ollama hangs when response_format=json_object is used with
+                    # qwen3.5 models (thinking-mode conflict).  Skip it for those.
+                    if not self._skip_response_format:
+                        kwargs["response_format"] = {"type": "json_object"}
+                    if timeout is not None:
+                        kwargs["timeout"] = timeout
+                    if self._is_ollama:
+                        options = dict(self.ollama_options) if self.ollama_options else {}
+                        if self.context_length:
+                            options["num_ctx"] = self.context_length
+                        extra_body: dict = {}
+                        if options:
+                            extra_body["options"] = options
+                        if self.ollama_format:
+                            extra_body["format"] = self.ollama_format
+                        if extra_body:
+                            kwargs["extra_body"] = extra_body
 
-                if not raw_text:
-                    raise LLMExtractionError("Empty response from LLM.")
+                    response = self.client.chat.completions.create(**kwargs)
+                    raw_text = response.choices[0].message.content
+
+                    if not raw_text:
+                        raise LLMExtractionError("Empty response from LLM.")
 
                 parsed = self._parse_json_response(raw_text)
 
@@ -363,31 +456,36 @@ class LLMClient:
         last_error = None
         for attempt in range(self.retry_attempts):
             try:
-                kwargs = {
-                    "model": self.model,
-                    "messages": messages,
-                    "temperature": self.temperature,
-                    "max_tokens": self.max_tokens,
-                }
-                if timeout is not None:
-                    kwargs["timeout"] = timeout
-                if self._is_ollama:
-                    options = dict(self.ollama_options) if self.ollama_options else {}
-                    if self.context_length:
-                        options["num_ctx"] = self.context_length
-                    extra_body_raw: dict = {}
-                    if options:
-                        extra_body_raw["options"] = options
-                    if self.ollama_format:
-                        extra_body_raw["format"] = self.ollama_format
-                    if extra_body_raw:
-                        kwargs["extra_body"] = extra_body_raw
+                if self._use_ollama_streaming:
+                    raw_text = self._ollama_streaming_chat(
+                        messages, timeout=timeout,
+                    )
+                else:
+                    kwargs = {
+                        "model": self.model,
+                        "messages": messages,
+                        "temperature": self.temperature,
+                        "max_tokens": self.max_tokens,
+                    }
+                    if timeout is not None:
+                        kwargs["timeout"] = timeout
+                    if self._is_ollama:
+                        options = dict(self.ollama_options) if self.ollama_options else {}
+                        if self.context_length:
+                            options["num_ctx"] = self.context_length
+                        extra_body_raw: dict = {}
+                        if options:
+                            extra_body_raw["options"] = options
+                        if self.ollama_format:
+                            extra_body_raw["format"] = self.ollama_format
+                        if extra_body_raw:
+                            kwargs["extra_body"] = extra_body_raw
 
-                response = self.client.chat.completions.create(**kwargs)
-                raw_text = response.choices[0].message.content
+                    response = self.client.chat.completions.create(**kwargs)
+                    raw_text = response.choices[0].message.content
 
-                if not raw_text:
-                    raise LLMExtractionError("Empty response from LLM.")
+                    if not raw_text:
+                        raise LLMExtractionError("Empty response from LLM.")
 
                 self.stats.record_success()
                 return raw_text.strip()

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -189,6 +189,10 @@ class LLMClient:
         )
 
         content_parts: list[str] = []
+        thinking_parts: list[str] = []
+        eval_count = 0
+        prompt_eval_count = 0
+        done_reason = "?"
         start = time.time()
         hard_limit = effective_timeout * 3  # total wall-clock limit
 
@@ -205,14 +209,36 @@ class LLMClient:
                 except json.JSONDecodeError:
                     continue
                 if chunk.get("done"):
+                    eval_count = chunk.get("eval_count", 0)
+                    prompt_eval_count = chunk.get("prompt_eval_count", 0)
+                    done_reason = chunk.get("done_reason", "?")
                     break
                 msg = chunk.get("message", {})
+                # Ollama streams qwen3.5 thinking-mode output in a
+                # separate "thinking" field while "content" stays empty.
+                # Collect both so we can diagnose failures.
                 part = msg.get("content", "")
                 if part:
                     content_parts.append(part)
+                thinking = msg.get("thinking", "")
+                if thinking:
+                    thinking_parts.append(thinking)
 
+        elapsed = time.time() - start
         raw = "".join(content_parts)
         if not raw:
+            thinking_text = "".join(thinking_parts)
+            # Truncate thinking for log — can be very long
+            thinking_preview = thinking_text[:500] if thinking_text else "(none)"
+            print(
+                f"  STREAM-DEBUG: empty response in {elapsed:.1f}s — "
+                f"eval={eval_count} prompt_eval={prompt_eval_count} "
+                f"done_reason={done_reason} "
+                f"thinking_tokens={len(thinking_parts)} "
+                f"content_tokens={len(content_parts)}\n"
+                f"  THINKING: {thinking_preview}",
+                file=sys.stderr,
+            )
             raise LLMExtractionError("Empty response from LLM.")
         return raw
 

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -115,6 +115,7 @@ class LLMClient:
         self.default_timeout = self.config.get("timeout_seconds", 60)
         self.context_length = self.config.get("context_length", None)
         self.ollama_options = self.config.get("ollama_options", None)
+        self.ollama_format = self.config.get("ollama_format", None)
         self.consecutive_rate_limit_threshold = self.config.get(
             "consecutive_rate_limit_threshold", 10)
         self.stats = RetryStats()
@@ -127,6 +128,16 @@ class LLMClient:
             self.config.get("provider", "").lower() == "ollama"
             or ":11434" in base_url
         )
+
+    @property
+    def _skip_response_format(self) -> bool:
+        """True when response_format should be omitted (e.g. qwen3.5 on Ollama)."""
+        if self.config.get("skip_response_format"):
+            return True
+        # Ollama + qwen3.5 hangs with response_format=json_object
+        if self._is_ollama and "qwen3.5" in self.model:
+            return True
+        return False
 
     @property
     def _is_cloud_provider(self) -> bool:
@@ -247,16 +258,28 @@ class LLMClient:
                     "messages": messages,
                     "temperature": self.temperature,
                     "max_tokens": max_tokens if max_tokens is not None else self.max_tokens,
-                    "response_format": {"type": "json_object"},
                 }
+                # Ollama hangs when response_format=json_object is used with
+                # qwen3.5 models (thinking-mode conflict).  Skip it for those.
+                if not self._skip_response_format:
+                    kwargs["response_format"] = {"type": "json_object"}
                 if timeout is not None:
                     kwargs["timeout"] = timeout
                 if self._is_ollama:
                     options = dict(self.ollama_options) if self.ollama_options else {}
                     if self.context_length:
                         options["num_ctx"] = self.context_length
+                    extra_body: dict = {}
                     if options:
-                        kwargs["extra_body"] = {"options": options}
+                        extra_body["options"] = options
+                    # Ollama native format parameter — distinct from OpenAI
+                    # response_format.  Use "json" to constrain output to
+                    # valid JSON without the thinking-mode hang seen with
+                    # response_format on qwen3.5 models.
+                    if self.ollama_format:
+                        extra_body["format"] = self.ollama_format
+                    if extra_body:
+                        kwargs["extra_body"] = extra_body
 
                 response = self.client.chat.completions.create(**kwargs)
                 raw_text = response.choices[0].message.content
@@ -291,6 +314,9 @@ class LLMClient:
     def _parse_json_response(self, raw_text: str) -> dict | list:
         """Parse JSON from LLM response text, handling markdown fences."""
         text = raw_text.strip()
+
+        # Strip <think>...</think> blocks (qwen3.5 thinking mode output)
+        text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
 
         # Strip markdown code fences if present
         fence_match = re.match(r"^```(?:json)?\s*\n(.*)\n```\s*$", text, re.DOTALL)
@@ -349,8 +375,13 @@ class LLMClient:
                     options = dict(self.ollama_options) if self.ollama_options else {}
                     if self.context_length:
                         options["num_ctx"] = self.context_length
+                    extra_body_raw: dict = {}
                     if options:
-                        kwargs["extra_body"] = {"options": options}
+                        extra_body_raw["options"] = options
+                    if self.ollama_format:
+                        extra_body_raw["format"] = self.ollama_format
+                    if extra_body_raw:
+                        kwargs["extra_body"] = extra_body_raw
 
                 response = self.client.chat.completions.create(**kwargs)
                 raw_text = response.choices[0].message.content

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -177,6 +177,11 @@ class LLMClient:
             body["options"].update(self.ollama_options)
         if self.ollama_format:
             body["format"] = self.ollama_format
+        # Ollama top-level think parameter — False disables thinking so
+        # all num_predict budget goes to visible output.
+        ollama_think = self.config.get("ollama_think")
+        if ollama_think is not None:
+            body["think"] = ollama_think
 
         effective_timeout = timeout or self.default_timeout
         # Allow generous read timeout — streaming sends chunks continuously

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -413,7 +413,9 @@ class LLMClient:
 
                 parsed = self._parse_json_response(raw_text)
 
-                # Enforce dict when response_format is json_object
+                # Enforce top-level dict for all extraction calls — both
+                # response_format=json_object and Ollama format=json
+                # produce objects; arrays would break downstream code.
                 if not isinstance(parsed, dict):
                     raise LLMExtractionError(
                         f"Expected JSON object but got {type(parsed).__name__}: "


### PR DESCRIPTION
## Summary

Pipeline improvements discovered during the qwen3.5:9b evaluation run. Adds support for Ollama's native `format` parameter, thinking-mode output handling, and a `--max-turns` flag for partial extraction runs.

## Changes

### `tools/llm_client.py`
- **`ollama_format` config key**: Passes Ollama's native `format` parameter via `extra_body`, distinct from OpenAI's `response_format` which hangs with qwen3.5 models. Applied in both `extract_json` and `generate_text` methods.
- **`ollama_think` config key**: Passes Ollama's `think` parameter at the request top level. Set to `false` to disable thinking mode, directing all `num_predict` budget to visible output.
- **Ollama native streaming**: When `ollama_format` is configured, uses `httpx` streaming against `/api/chat` instead of the OpenAI SDK. Collects both `content` and `thinking` fields for diagnostics.
- **`<think>` tag stripping**: `_parse_json_response` now strips `<think>...</think>` blocks before JSON parsing, handling thinking-mode output from qwen3.5 models that leaks through the OpenAI-compatible endpoint.
- **`_skip_response_format`**: Auto-skips `response_format=json_object` for Ollama + qwen3.5 models to prevent hangs.

### `tools/bootstrap_session.py`
- **`--max-turns N` flag**: Total cap — limits extraction to the first N turns by slicing `turn_dicts` before passing to `extract_semantic_batch`. Distinct from `--segment-size` which controls batch granularity. Post-extraction passes (backfill, PC alias merge) still run on the partial output.

### `docs/usage.md`
- Documents `ollama_format`, `ollama_think`, and `skip_response_format` config keys.

### Tests
- `_skip_response_format` gating: 5 tests
- `_parse_json_response` think-tag stripping: 7 tests
- Ollama config knobs (`ollama_format`, `ollama_think`, `_use_ollama_streaming`): 6 tests
- `--max-turns` argument parsing and slicing: 6 tests

## Context

During a qwen3.5:9b evaluation, several issues were discovered:

1. **`response_format: json_object` hangs**: The OpenAI-compat endpoint in Ollama hangs indefinitely when `response_format` is sent with qwen3.5 models.
2. **Thinking tokens consume output budget**: qwen3.5's thinking and output tokens share `num_predict`. The `think: false` parameter eliminates this, achieving 100% success rate.
3. **Native `format` vs `response_format`**: Ollama's native `format: "json"` parameter is a different codepath from the OpenAI-compat `response_format`. The native parameter works with qwen3.5 via the streaming path.
4. **No way to limit turns**: `--segment-size` controls batch granularity, not total turn count. `--max-turns` provides a proper total cap.

Closes #234
