### PR TITLE
fix: ground truth validator matches entities by name and aliases (#216)

### DIFF
--- a/tests/test_extraction_ground_truth.py
+++ b/tests/test_extraction_ground_truth.py
@@ -292,3 +292,247 @@ class TestFunctionalValidation:
         assert validate_extraction._normalize_aliases("single") == ["single"]
         assert validate_extraction._normalize_aliases(None) == []
         assert validate_extraction._normalize_aliases(["A", "B"]) == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Name/alias fallback matching tests (#216)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def name_fallback_ground_truth(tmp_path):
+    """Ground truth where id_patterns don't match the actual catalog IDs."""
+    gt = {
+        "description": "name fallback fixture",
+        "source_session": "test",
+        "turn_range": [1, 50],
+        "expected_pc_aliases": [],
+        "expected_independent_characters": [
+            {
+                "name": "Kael",
+                "role": "warrior",
+                "id_patterns": ["char-kael"],
+                "must_not_be_pc_alias": True,
+                "expected_first_seen_range": [1, 5],
+                "expected_last_updated_min": 40,
+                "notes": "test — stored under different ID",
+            },
+            {
+                "name": "Lyrawyn",
+                "role": "daughter",
+                "id_patterns": ["char-lyrawyn"],
+                "must_not_be_pc_alias": True,
+                "expected_first_seen_range": [10, 12],
+                "expected_last_updated_min": 30,
+                "notes": "test — found via alias",
+            },
+            {
+                "name": "TrulyMissing",
+                "role": "ghost",
+                "id_patterns": ["char-truly-missing"],
+                "must_not_be_pc_alias": True,
+                "expected_first_seen_range": [1, 5],
+                "expected_last_updated_min": 10,
+                "notes": "should not be found",
+            },
+            {
+                "name": "ExactMatch",
+                "role": "ally",
+                "id_patterns": ["char-exact"],
+                "must_not_be_pc_alias": True,
+                "expected_first_seen_range": [1, 5],
+                "expected_last_updated_min": 40,
+                "notes": "found by exact ID",
+            },
+        ],
+        "must_not_merge": [],
+        "coreference_groups": [
+            {
+                "canonical_name": "Kael",
+                "expected_id": "char-kael",
+                "variants_to_merge": ["young warrior"],
+                "notes": "test coreference with non-canonical ID",
+            },
+        ],
+        "entity_staleness_targets": [
+            {"id": "char-kael", "expected_last_updated_min": 40, "reason": "active"},
+        ],
+        "expected_locations_beyond_turn_100": [],
+        "expected_factions_beyond_early_game": [],
+    }
+    gt_path = tmp_path / "gt.json"
+    _write_json(gt_path, gt)
+    return gt_path
+
+
+@pytest.fixture
+def name_fallback_catalog(tmp_path):
+    """Catalog where entities have non-canonical IDs but correct names/aliases."""
+    cat_dir = tmp_path / "catalogs"
+    chars = cat_dir / "characters"
+    chars.mkdir(parents=True)
+
+    # Kael stored under char-companion instead of char-kael
+    _write_json(chars / "char-companion.json", {
+        "id": "char-companion",
+        "name": "Kael",
+        "type": "character",
+        "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-045",
+        "stable_attributes": {},
+    })
+
+    # Lyrawyn stored under char-new-life, findable via alias
+    _write_json(chars / "char-new-life.json", {
+        "id": "char-new-life",
+        "name": "New Life",
+        "type": "character",
+        "first_seen_turn": "turn-010",
+        "last_updated_turn": "turn-035",
+        "stable_attributes": {
+            "aliases": {"value": ["Lyrawyn", "daughter"], "source_turn": "turn-012"},
+        },
+    })
+
+    # ExactMatch found by exact id_patterns
+    _write_json(chars / "char-exact.json", {
+        "id": "char-exact",
+        "name": "ExactMatch",
+        "type": "character",
+        "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-045",
+        "stable_attributes": {},
+    })
+
+    return cat_dir
+
+
+class TestNameFallbackMatching:
+    """Tests for #216: name/alias fallback when ID patterns don't match."""
+
+    def test_name_match_finds_entity_under_different_id(
+        self, name_fallback_ground_truth, name_fallback_catalog,
+    ):
+        import validate_extraction
+        gt = json.loads(name_fallback_ground_truth.read_text(encoding="utf-8"))
+        pc_aliases = validate_extraction._pc_aliases(name_fallback_catalog)
+        results = validate_extraction.check_independent_characters(
+            gt, name_fallback_catalog, pc_aliases,
+        )
+        kael = [r for r in results if r.label == "Kael"][0]
+        assert kael.status != validate_extraction.Result.FAIL
+        assert "char-companion" in kael.detail
+        assert "matched by name" in kael.detail
+
+    def test_alias_match_finds_entity(
+        self, name_fallback_ground_truth, name_fallback_catalog,
+    ):
+        import validate_extraction
+        gt = json.loads(name_fallback_ground_truth.read_text(encoding="utf-8"))
+        pc_aliases = validate_extraction._pc_aliases(name_fallback_catalog)
+        results = validate_extraction.check_independent_characters(
+            gt, name_fallback_catalog, pc_aliases,
+        )
+        lyra = [r for r in results if r.label == "Lyrawyn"][0]
+        assert lyra.status != validate_extraction.Result.FAIL
+        assert "char-new-life" in lyra.detail
+        assert "matched by alias" in lyra.detail
+
+    def test_truly_missing_still_fails(
+        self, name_fallback_ground_truth, name_fallback_catalog,
+    ):
+        import validate_extraction
+        gt = json.loads(name_fallback_ground_truth.read_text(encoding="utf-8"))
+        pc_aliases = validate_extraction._pc_aliases(name_fallback_catalog)
+        results = validate_extraction.check_independent_characters(
+            gt, name_fallback_catalog, pc_aliases,
+        )
+        missing = [r for r in results if r.label == "TrulyMissing"][0]
+        assert missing.status == validate_extraction.Result.FAIL
+        assert "NOT FOUND" in missing.detail
+
+    def test_exact_id_match_still_works(
+        self, name_fallback_ground_truth, name_fallback_catalog,
+    ):
+        import validate_extraction
+        gt = json.loads(name_fallback_ground_truth.read_text(encoding="utf-8"))
+        pc_aliases = validate_extraction._pc_aliases(name_fallback_catalog)
+        results = validate_extraction.check_independent_characters(
+            gt, name_fallback_catalog, pc_aliases,
+        )
+        exact = [r for r in results if r.label == "ExactMatch"][0]
+        assert exact.status == validate_extraction.Result.PASS
+        assert "matched by" not in exact.detail
+
+    def test_case_insensitive_name_match(self, tmp_path):
+        import validate_extraction
+        cat_dir = tmp_path / "catalogs"
+        chars = cat_dir / "characters"
+        chars.mkdir(parents=True)
+        _write_json(chars / "char-elder-figure.json", {
+            "id": "char-elder-figure",
+            "name": "The elder",
+            "type": "character",
+            "first_seen_turn": "turn-008",
+            "last_updated_turn": "turn-045",
+            "stable_attributes": {},
+        })
+        gt = {
+            "expected_independent_characters": [
+                {
+                    "name": "The Elder",
+                    "id_patterns": ["char-elder"],
+                    "expected_last_updated_min": 40,
+                },
+            ],
+        }
+        results = validate_extraction.check_independent_characters(gt, cat_dir, [])
+        result = results[0]
+        assert result.status != validate_extraction.Result.FAIL
+        assert "char-elder-figure" in result.detail
+
+    def test_coreference_group_name_fallback(
+        self, name_fallback_ground_truth, name_fallback_catalog,
+    ):
+        import validate_extraction
+        gt = json.loads(name_fallback_ground_truth.read_text(encoding="utf-8"))
+        results = validate_extraction.check_coreference_groups(
+            gt, name_fallback_catalog,
+        )
+        kael_group = [r for r in results if r.label == "Kael"][0]
+        # Should not FAIL with NOT FOUND — should find via name
+        assert "NOT FOUND" not in kael_group.detail
+        assert "char-companion" in kael_group.detail
+
+    def test_staleness_name_fallback(
+        self, name_fallback_ground_truth, name_fallback_catalog,
+    ):
+        import validate_extraction
+        gt = json.loads(name_fallback_ground_truth.read_text(encoding="utf-8"))
+        results = validate_extraction.check_staleness(gt, name_fallback_catalog)
+        kael_stale = [r for r in results if r.label == "char-kael"][0]
+        # Should not FAIL with NOT FOUND — should find via name
+        assert "NOT FOUND" not in kael_stale.detail
+
+    def test_find_character_by_name_direct(self, name_fallback_catalog):
+        import validate_extraction
+        result = validate_extraction._find_character_by_name(
+            "Kael", name_fallback_catalog,
+        )
+        assert result is not None
+        assert result == ("char-companion", "name")
+
+    def test_find_character_by_alias_direct(self, name_fallback_catalog):
+        import validate_extraction
+        result = validate_extraction._find_character_by_name(
+            "Lyrawyn", name_fallback_catalog,
+        )
+        assert result is not None
+        assert result == ("char-new-life", "alias")
+
+    def test_find_character_not_found(self, name_fallback_catalog):
+        import validate_extraction
+        result = validate_extraction._find_character_by_name(
+            "Nobody", name_fallback_catalog,
+        )
+        assert result is None

--- a/tools/validate_extraction.py
+++ b/tools/validate_extraction.py
@@ -86,6 +86,54 @@ def _all_character_ids(catalog_dir: Path) -> list[str]:
     return sorted(ids)
 
 
+def _find_character_by_name(
+    name: str, catalog_dir: Path,
+) -> tuple[str, str] | None:
+    """Find a character by name or alias (case-insensitive).
+
+    Returns (char_id, match_type) where match_type is 'name' or 'alias',
+    or None if no match is found.
+    """
+    chars_dir = catalog_dir / "characters"
+    if not chars_dir.is_dir():
+        return None
+    target = name.lower()
+    # First pass: match by name
+    for f in sorted(chars_dir.iterdir()):
+        if (
+            f.suffix != ".json"
+            or f.name.endswith(".synthesis.json")
+            or f.name.endswith(".arcs.json")
+            or f.name == "index.json"
+        ):
+            continue
+        try:
+            char = _load_json(f)
+        except Exception:
+            continue
+        if char.get("name", "").lower() == target:
+            return (f.stem, "name")
+    # Second pass: match by alias
+    for f in sorted(chars_dir.iterdir()):
+        if (
+            f.suffix != ".json"
+            or f.name.endswith(".synthesis.json")
+            or f.name.endswith(".arcs.json")
+            or f.name == "index.json"
+        ):
+            continue
+        try:
+            char = _load_json(f)
+        except Exception:
+            continue
+        aliases = _normalize_aliases(
+            char.get("stable_attributes", {}).get("aliases", {}).get("value"),
+        )
+        if target in aliases:
+            return (f.stem, "alias")
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Result tracking
 # ---------------------------------------------------------------------------
@@ -123,6 +171,7 @@ def check_independent_characters(
         patterns = entry.get("id_patterns", [])
         is_optional = entry.get("optional", False)
         found_id = None
+        match_type = None
 
         for pat in patterns:
             # Support glob patterns (e.g. "char-shaman-turn-*")
@@ -137,15 +186,21 @@ def check_independent_characters(
                 break
 
         if not found_id:
-            # Check if merged as PC alias
-            if name.lower() in pc_alias_list:
-                results.append(Result(
-                    Result.FAIL, name, "NOT FOUND — merged as PC alias",
-                ))
+            # Fallback: scan catalog by name/alias
+            match = _find_character_by_name(name, catalog_dir)
+            if match:
+                found_id = match[0]
+                match_type = match[1]
             else:
-                severity = Result.WARN if is_optional else Result.FAIL
-                results.append(Result(severity, name, "NOT FOUND"))
-            continue
+                # Check if merged as PC alias
+                if name.lower() in pc_alias_list:
+                    results.append(Result(
+                        Result.FAIL, name, "NOT FOUND — merged as PC alias",
+                    ))
+                else:
+                    severity = Result.WARN if is_optional else Result.FAIL
+                    results.append(Result(severity, name, "NOT FOUND"))
+                continue
 
         # Check staleness
         char_data = _load_character(catalog_dir, found_id)
@@ -154,13 +209,18 @@ def check_independent_characters(
         )
         turn_display = f"turn-{last_turn}" if last_turn else "unknown"
 
+        # Note if entity was found via name/alias under a non-canonical ID
+        id_note = ""
+        if match_type:
+            id_note = f" (matched by {match_type}, expected ID from id_patterns)"
+
         expected_min = entry.get("expected_last_updated_min")
         if expected_min and last_turn is None:
             results.append(Result(
                 Result.FAIL,
                 name,
                 f"{found_id:30s} ({turn_display}) — last_updated_turn missing "
-                f"(expected >={expected_min})",
+                f"(expected >={expected_min}){id_note}",
             ))
         elif expected_min and last_turn and last_turn < expected_min:
             gap = expected_min - last_turn
@@ -169,11 +229,11 @@ def check_independent_characters(
                 severity,
                 name,
                 f"{found_id:30s} ({turn_display}) — stale by {gap} turns "
-                f"(expected >={expected_min})",
+                f"(expected >={expected_min}){id_note}",
             ))
         else:
             results.append(Result(
-                Result.PASS, name, f"{found_id:30s} ({turn_display})",
+                Result.PASS, name, f"{found_id:30s} ({turn_display}){id_note}",
             ))
 
     return results
@@ -325,12 +385,19 @@ def check_coreference_groups(
         expected_id = group["expected_id"]
         variants = group.get("variants_to_merge", [])
 
-        # Check canonical exists
+        # Check canonical exists (with name/alias fallback)
+        actual_id = expected_id
+        id_note = ""
         if expected_id not in all_ids:
-            results.append(Result(
-                Result.FAIL, canonical, f"{expected_id} NOT FOUND",
-            ))
-            continue
+            match = _find_character_by_name(canonical, catalog_dir)
+            if match:
+                actual_id = match[0]
+                id_note = f" (matched by {match[1]} as {actual_id})"
+            else:
+                results.append(Result(
+                    Result.FAIL, canonical, f"{expected_id} NOT FOUND",
+                ))
+                continue
 
         # Check for fragmented variants
         fragments = []
@@ -341,14 +408,16 @@ def check_coreference_groups(
                 fragments.append(variant_id)
 
         if fragments:
-            frag_list = ", ".join([expected_id] + fragments)
+            frag_list = ", ".join([actual_id] + fragments)
             results.append(Result(
                 Result.WARN,
                 canonical,
-                f"{len(fragments) + 1} FRAGMENTS: {frag_list}",
+                f"{len(fragments) + 1} FRAGMENTS: {frag_list}{id_note}",
             ))
         else:
-            results.append(Result(Result.PASS, canonical, f"{expected_id} — unified"))
+            results.append(Result(
+                Result.PASS, canonical, f"{actual_id} — unified{id_note}",
+            ))
 
     return results
 
@@ -365,11 +434,20 @@ def check_staleness(
         reason = target.get("reason", "")
 
         char_data = _load_character(catalog_dir, entity_id)
+        id_note = ""
         if not char_data:
-            results.append(Result(
-                Result.FAIL, entity_id, f"NOT FOUND — {reason}",
-            ))
-            continue
+            # Fallback: try to find by scanning name/alias
+            # Derive a human name from the ID for lookup
+            human_name = entity_id.replace("char-", "").replace("-", " ").title()
+            match = _find_character_by_name(human_name, catalog_dir)
+            if match:
+                char_data = _load_character(catalog_dir, match[0])
+                id_note = f" (matched by {match[1]} as {match[0]})"
+            if not char_data:
+                results.append(Result(
+                    Result.FAIL, entity_id, f"NOT FOUND — {reason}",
+                ))
+                continue
 
         last_turn = _turn_number(char_data.get("last_updated_turn", ""))
         if last_turn is None:
@@ -382,16 +460,16 @@ def check_staleness(
         if gap > 50:
             results.append(Result(
                 Result.FAIL, entity_id,
-                f"turn-{last_turn} (expected >={expected_min}, gap={gap})",
+                f"turn-{last_turn} (expected >={expected_min}, gap={gap}){id_note}",
             ))
         elif gap > 20:
             results.append(Result(
                 Result.WARN, entity_id,
-                f"turn-{last_turn} (expected >={expected_min}, gap={gap})",
+                f"turn-{last_turn} (expected >={expected_min}, gap={gap}){id_note}",
             ))
         else:
             results.append(Result(
-                Result.PASS, entity_id, f"turn-{last_turn}",
+                Result.PASS, entity_id, f"turn-{last_turn}{id_note}",
             ))
 
     return results

--- a/tools/validate_extraction.py
+++ b/tools/validate_extraction.py
@@ -109,7 +109,7 @@ def _find_character_by_name(
             continue
         try:
             char = _load_json(f)
-        except Exception:
+        except (json.JSONDecodeError, OSError):
             continue
         if char.get("name", "").lower() == target:
             return (f.stem, "name")
@@ -124,7 +124,7 @@ def _find_character_by_name(
             continue
         try:
             char = _load_json(f)
-        except Exception:
+        except (json.JSONDecodeError, OSError):
             continue
         aliases = _normalize_aliases(
             char.get("stable_attributes", {}).get("aliases", {}).get("value"),
@@ -452,7 +452,8 @@ def check_staleness(
         last_turn = _turn_number(char_data.get("last_updated_turn", ""))
         if last_turn is None:
             results.append(Result(
-                Result.FAIL, entity_id, f"no last_updated_turn — {reason}",
+                Result.FAIL, entity_id,
+                f"no last_updated_turn — {reason}{id_note}",
             ))
             continue
 


### PR DESCRIPTION
## Summary

Ground truth validation reported false FAILs when extracted entities existed under non-canonical IDs. For example, Kael stored as `char-companion` (name="Kael") was marked NOT FOUND because the ground truth expected `char-kael`.

This adds fallback name/alias matching to the validator so entities are found regardless of their file-level ID, while still noting the ID mismatch in the output.

## Changes

### `tools/validate_extraction.py`

- Added `_find_character_by_name()` helper that scans all character files for a case-insensitive name match, then alias match
- Updated `check_independent_characters` to use name/alias fallback when `id_patterns` don't match any catalog file
- Updated `check_coreference_groups` to use name fallback when `expected_id` is not found
- Updated `check_staleness` to use name fallback when the target entity ID is not found
- Results annotate the match type (e.g. "matched by name, expected ID from id_patterns") so reviewers can identify non-canonical IDs

### `tests/test_extraction_ground_truth.py`

Added 10 new tests covering:
- Name-based fallback finds entity under a different ID
- Alias-based fallback finds entity
- Case-insensitive matching works
- Exact ID match still works as before (no regression)
- NOT FOUND is still reported when no match exists
- Coreference group name fallback
- Staleness check name fallback
- Direct `_find_character_by_name()` unit tests

## Evidence from Issue #216

The three false FAILs from Run 12 that motivated this fix:
- **Kael** → `char-companion` (name="Kael"), expected `char-kael`
- **Lyrawyn** → `char-new-life` (name="Lyrawyn"), expected `char-lyrawyn`
- **The Elder** → `char-older-commanding-figure` (name="The elder"), expected `char-elder`

## Testing

- 1024 tests pass (up from 1014 baseline)
- `python tools/validate.py --all` passes (18/18)

Closes #216
