### PR TITLE
docs: rewrite README positioning (#193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 A structured knowledge extraction and state-tracking engine for AI-driven narrative systems. It builds and maintains a canonical, evolving world model from sequential text — enabling coherent long-running reasoning over state that grows across hundreds of interactions.
 
-**Flagship use case:** A player-side "second brain" for tabletop RPG campaigns played against AI Dungeon Masters — tracking every character, location, relationship, and event across sessions that span months, surfacing contradictions, and supporting strategic reasoning beyond human memory limits.
+**Flagship use case:** A player-side "second brain" for tabletop RPG campaigns played against AI Dungeon Masters — tracking every character, location, relationship, and event across sessions that span months, making contradictions easier to spot through a canonical, provenance-tracked state model, and supporting strategic reasoning beyond human memory limits.
 
 ---
 
 ## What This Is
 
-- A **structured state layer** that extracts entities, relationships, and events from narrative text and maintains them as a validated, evolving knowledge graph
+- A **structured state layer** that extracts entities, relationships, and events from narrative text and maintains them as a schema-defined, evolving knowledge base (validated when `jsonschema` is installed or when running `tools/validate.py`)
 - A **player-side assistant** that independently tracks canonical world state, not relying on the DM's narration alone
 - A **schema-first extraction pipeline** using LLMs (local or cloud) to convert unstructured narrative into structured, provenance-tracked data
 - **Provider-agnostic** — runs on local models (Ollama) or cloud APIs (Gemini, OpenAI) with a config change
@@ -36,7 +36,7 @@ Given a sequence of DM outputs and player prompts, the system:
 
 1. **Preserves** the exact transcript as an immutable source of truth
 2. **Extracts** entities, relationships, events, and temporal markers via a four-agent LLM pipeline
-3. **Maintains** a validated knowledge graph of characters, locations, factions, items, and plot threads
+3. **Maintains** a schema-defined knowledge base of characters, locations, factions, items, relationships, and events — plot threads are tracked separately and currently maintained manually or with Copilot assistance rather than by the automated extraction pipeline
 4. **Tracks** player objectives, evidence classification, and DM behavior patterns
 5. **Analyzes** the current situation and generates candidate next-player prompts
 6. **Evolves** — every entity carries `first_seen_turn` and `last_updated_turn` provenance, and the world model updates incrementally with each new turn

--- a/README.md
+++ b/README.md
@@ -4,25 +4,42 @@
   <img src="assets/artwork.png" alt="Narrative State Engine" width="800">
 </p>
 
-A player-side assistant framework for AI-driven RPG and interactive fiction sessions.
+A structured knowledge extraction and state-tracking engine for AI-driven narrative systems. It builds and maintains a canonical, evolving world model from sequential text — enabling coherent long-running reasoning over state that grows across hundreds of interactions.
 
-This system captures DM responses and player prompts, preserves full transcripts, extracts structured narrative state, maintains catalogs and storyline continuity, tracks player objectives, analyzes strategy, and generates suggested next player prompts.
-
-**This is NOT a DM engine.** It supports the player interacting with an external AI DM.
+**Flagship use case:** A player-side "second brain" for tabletop RPG campaigns played against AI Dungeon Masters — tracking every character, location, relationship, and event across sessions that span months, surfacing contradictions, and supporting strategic reasoning beyond human memory limits.
 
 ---
 
-## Purpose
+## What This Is
+
+- A **structured state layer** that extracts entities, relationships, and events from narrative text and maintains them as a validated, evolving knowledge graph
+- A **player-side assistant** that independently tracks canonical world state, not relying on the DM's narration alone
+- A **schema-first extraction pipeline** using LLMs (local or cloud) to convert unstructured narrative into structured, provenance-tracked data
+- **Provider-agnostic** — runs on local models (Ollama) or cloud APIs (Gemini, OpenAI) with a config change
+
+## What This Is Not
+
+- Not a workflow engine, UI state machine, or statechart library (not XState, not an onboarding flow tool)
+- Not a DM or story generator — it supports the *player* interacting with an external AI DM
+- Not a RAG system — it builds structured state, not a retrieval index
+- Not a chat memory buffer — it maintains a canonical world model with temporal provenance, not conversation history
+
+## Why This Exists
+
+LLMs lose coherence over long interactions. Chat history is not memory. When a campaign reaches hundreds of turns, the AI forgets who died, what was promised, where the player lives, and which NPCs are allies. This engine solves that by extracting and maintaining structured state that persists independently of any conversation window.
+
+---
+
+## How It Works
 
 Given a sequence of DM outputs and player prompts, the system:
 
-1. Preserves the exact transcript (immutable source)
-2. Maintains a structured understanding of the narrative state
-3. Tracks player objectives (short-term and long-term)
-4. Identifies evidence, inference, and possible DM bait
-5. Infers DM behavior patterns over time
-6. Analyzes the current situation
-7. Suggests multiple candidate player prompts
+1. **Preserves** the exact transcript as an immutable source of truth
+2. **Extracts** entities, relationships, events, and temporal markers via a four-agent LLM pipeline
+3. **Maintains** a validated knowledge graph of characters, locations, factions, items, and plot threads
+4. **Tracks** player objectives, evidence classification, and DM behavior patterns
+5. **Analyzes** the current situation and generates candidate next-player prompts
+6. **Evolves** — every entity carries `first_seen_turn` and `last_updated_turn` provenance, and the world model updates incrementally with each new turn
 
 ---
 


### PR DESCRIPTION
## Summary

Rewrite the README introduction to clearly position the project as a structured knowledge extraction and state-tracking engine for AI-driven narrative systems — not a workflow engine, UI state machine, or statechart library.

## Changes

- Replaced the opening paragraph with a clear description of what the project actually does: structured knowledge extraction with temporal state tracking
- Added the flagship RPG "second brain" use case prominently at the top
- Added "What This Is" section — 4 concrete bullet points
- Added "What This Is Not" section — explicitly distances from XState/workflow/RAG/chat-memory categories
- Added "Why This Exists" section — explains the gap (LLMs lose coherence, chat history ≠ memory)
- Renamed "Purpose" to "How It Works" and expanded the numbered list to reflect the actual extraction pipeline
- All existing content below the intro (repo structure, quick start, design principles, etc.) is unchanged

## Motivation

External feedback (including LLM-based analysis) consistently misinterprets this project as a workflow/UI state machine engine. The original README led with implementation details rather than purpose, allowing the project to be placed in a crowded, less differentiated category.

Closes #193
