### PR TITLE
fix: protect char-player name/identity from overwrite during merge (#247, #248)

### DIFF
--- a/tests/test_catalog_merger_v2.py
+++ b/tests/test_catalog_merger_v2.py
@@ -555,6 +555,72 @@ class TestMergeEntityV2:
 
 
 # ---------------------------------------------------------------------------
+# PC name/identity protection (#247)
+# ---------------------------------------------------------------------------
+
+class TestPCNameProtection:
+    """char-player name and identity must not be overwritten by per-turn updates."""
+
+    def test_pc_name_not_overwritten(self):
+        catalogs = {
+            "characters.json": [
+                _make_v2_entity("char-player", "Player Character", turn="turn-001")
+            ]
+        }
+        update = _make_v2_entity("char-player", "Elder Lyra", turn="turn-314")
+        update["current_status"] = "Discussing tribal matters."
+        merge_entity(catalogs, update)
+        pc = catalogs["characters.json"][0]
+        # Name must remain unchanged
+        assert pc["name"] == "Player Character"
+        # But current_status should still merge
+        assert pc["current_status"] == "Discussing tribal matters."
+
+    def test_pc_identity_not_overwritten(self):
+        catalogs = {
+            "characters.json": [
+                _make_v2_entity("char-player", "Player Character", turn="turn-001")
+            ]
+        }
+        catalogs["characters.json"][0]["identity"] = "An elf warlock."
+        update = _make_v2_entity("char-player", "Player Character", turn="turn-314")
+        update["identity"] = "A Riverfolk shaman and elder."
+        merge_entity(catalogs, update)
+        pc = catalogs["characters.json"][0]
+        assert pc["identity"] == "An elf warlock."
+
+    def test_pc_mismatched_name_becomes_alias(self):
+        catalogs = {
+            "characters.json": [
+                _make_v2_entity("char-player", "Player Character", turn="turn-001")
+            ]
+        }
+        catalogs["characters.json"][0]["stable_attributes"] = {
+            "aliases": {"value": []}
+        }
+        update = _make_v2_entity("char-player", "Fenouille Moonwind", turn="turn-050")
+        merge_entity(catalogs, update)
+        pc = catalogs["characters.json"][0]
+        # Name unchanged
+        assert pc["name"] == "Player Character"
+        # But the proposed name should be recorded as an alias
+        aliases = pc["stable_attributes"]["aliases"]["value"]
+        assert "Fenouille Moonwind" in aliases
+
+    def test_non_pc_name_still_updates(self):
+        catalogs = {
+            "characters.json": [
+                _make_v2_entity("char-elder", "The Elder", turn="turn-015")
+            ]
+        }
+        update = _make_v2_entity("char-elder", "Tribal Authority", turn="turn-100")
+        merge_entity(catalogs, update)
+        npc = catalogs["characters.json"][0]
+        # Non-PC entities should still have their name updated
+        assert npc["name"] == "Tribal Authority"
+
+
+# ---------------------------------------------------------------------------
 # parse_turn_number
 # ---------------------------------------------------------------------------
 

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -631,8 +631,14 @@ def merge_entity(catalogs: dict, entity: dict) -> None:
 
 def _update_existing_entity(current: dict, update: dict) -> None:
     """Update an existing entity with new information."""
+    is_pc = current.get("id") == "char-player"
+
+    # Never overwrite the PC's identity from a per-turn update — the PC's
+    # identity is established early and should not be replaced by an NPC
+    # description that happens to land on the same entity ID.
     if update.get("identity") and update["identity"] != current.get("identity"):
-        current["identity"] = update["identity"]
+        if not is_pc:
+            current["identity"] = update["identity"]
 
     if update.get("current_status"):
         current["current_status"] = update["current_status"]
@@ -654,7 +660,9 @@ def _update_existing_entity(current: dict, update: dict) -> None:
             current["volatile_state"][key] = value
 
     # Handle name changes / aliases via stable_attributes.aliases
-    if update.get("name") and update["name"] != current.get("name"):
+    # Never rename char-player — NPC names that the LLM attributes to the PC
+    # entity should become aliases, not overwrite the canonical PC name (#247).
+    if update.get("name") and update["name"] != current.get("name") and not is_pc:
         old_name = current["name"]
         if "stable_attributes" not in current:
             current["stable_attributes"] = {}

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -660,32 +660,47 @@ def _update_existing_entity(current: dict, update: dict) -> None:
             current["volatile_state"][key] = value
 
     # Handle name changes / aliases via stable_attributes.aliases
-    # Never rename char-player — NPC names that the LLM attributes to the PC
-    # entity should become aliases, not overwrite the canonical PC name (#247).
-    if update.get("name") and update["name"] != current.get("name") and not is_pc:
-        old_name = current["name"]
-        if "stable_attributes" not in current:
-            current["stable_attributes"] = {}
-        sa = current["stable_attributes"]
-        existing_aliases = sa.get("aliases", {})
-        if isinstance(existing_aliases, dict):
-            val = existing_aliases.get("value", [])
-            if isinstance(val, str):
-                val = [a.strip() for a in val.split(",") if a.strip()]
-            if old_name not in val:
-                val.append(old_name)
-            alias_turn = (update.get("last_updated_turn")
-                          or current.get("last_updated_turn")
-                          or current.get("first_seen_turn", ""))
-            sa["aliases"] = {"value": val, "inference": False,
-                             "source_turn": alias_turn}
+    # For char-player, never overwrite the canonical name — but still record
+    # the mismatched name as an alias for downstream coreference (#247).
+    if update.get("name") and update["name"] != current.get("name"):
+        if is_pc:
+            # Record the LLM-proposed name as a PC alias without renaming
+            from semantic_extraction import _filter_pc_aliases
+            candidate_name = update["name"]
+            filtered = _filter_pc_aliases([candidate_name])
+            if filtered:  # Only add if it passes alias validation
+                sa_pc = current.setdefault("stable_attributes", {})
+                aliases_pc = sa_pc.setdefault("aliases", {"value": []})
+                alias_list_pc = aliases_pc.get("value", [])
+                if isinstance(alias_list_pc, str):
+                    alias_list_pc = [a.strip() for a in alias_list_pc.split(",") if a.strip()]
+                if candidate_name not in alias_list_pc:
+                    alias_list_pc.append(candidate_name)
+                    aliases_pc["value"] = alias_list_pc
         else:
-            alias_turn = (update.get("last_updated_turn")
-                          or current.get("last_updated_turn")
-                          or current.get("first_seen_turn", ""))
-            sa["aliases"] = {"value": [old_name], "inference": False,
-                             "source_turn": alias_turn}
-        current["name"] = update["name"]
+            old_name = current["name"]
+            if "stable_attributes" not in current:
+                current["stable_attributes"] = {}
+            sa = current["stable_attributes"]
+            existing_aliases = sa.get("aliases", {})
+            if isinstance(existing_aliases, dict):
+                val = existing_aliases.get("value", [])
+                if isinstance(val, str):
+                    val = [a.strip() for a in val.split(",") if a.strip()]
+                if old_name not in val:
+                    val.append(old_name)
+                alias_turn = (update.get("last_updated_turn")
+                              or current.get("last_updated_turn")
+                              or current.get("first_seen_turn", ""))
+                sa["aliases"] = {"value": val, "inference": False,
+                                 "source_turn": alias_turn}
+            else:
+                alias_turn = (update.get("last_updated_turn")
+                              or current.get("last_updated_turn")
+                              or current.get("first_seen_turn", ""))
+                sa["aliases"] = {"value": [old_name], "inference": False,
+                                 "source_turn": alias_turn}
+            current["name"] = update["name"]
 
     # Update last_updated_turn
     if update.get("last_updated_turn"):

--- a/tools/recover_postprocess.py
+++ b/tools/recover_postprocess.py
@@ -95,29 +95,38 @@ def main():
     removed = []
     if pc_entity:
         # Restore PC name/identity if corrupted by a prior merge (#248)
-        pc_name = pc_entity.get("name", "")
+        pc_name_normalized = str(pc_entity.get("name") or "").lower().strip()
         valid_pc_names = {"player character", "fenouille moonwind", "fenouille"}
-        if pc_name.lower().strip() not in valid_pc_names:
+        if pc_name_normalized not in valid_pc_names:
             # Name was overwritten — restore from aliases if available
             sa = pc_entity.get("stable_attributes", {})
-            alias_val = sa.get("aliases", {}).get("value", [])
+            aliases_attr = sa.get("aliases", {})
+            if isinstance(aliases_attr, dict):
+                alias_val = aliases_attr.get("value", [])
+            elif isinstance(aliases_attr, list):
+                alias_val = aliases_attr
+            elif isinstance(aliases_attr, str):
+                alias_val = [aliases_attr]
+            else:
+                alias_val = []
             restored_name = None
             for a in (alias_val if isinstance(alias_val, list) else []):
-                if a.lower().strip() in valid_pc_names and len(a) > 3:
-                    restored_name = a
+                a_str = a if isinstance(a, str) else str(a)
+                if a_str.lower().strip() in valid_pc_names and len(a_str) > 3:
+                    restored_name = a_str
                     break
             if not restored_name:
                 restored_name = "Player Character"
-            print(f"  Restored PC name: '{pc_name}' → '{restored_name}'")
+            print(f"  Restored PC name: '{pc_entity.get('name')}' -> '{restored_name}'")
             pc_entity["name"] = restored_name
             # Clear corrupted identity if it doesn't describe the PC
-            ident = (pc_entity.get("identity") or "").lower()
+            ident = str(pc_entity.get("identity") or "").lower()
             if not any(w in ident for w in ["player", "fenouille", "warlock", "elf", "moon"]):
                 pc_entity["identity"] = (
-                    "The player character — an elf warlock guided by a celestial "
+                    "The player character \u2014 an elf warlock guided by a celestial "
                     "pact with a silent star."
                 )
-                print(f"  Restored PC identity (was describing a different character)")
+                print("  Restored PC identity (was describing a different character)")
 
         sa = pc_entity.setdefault("stable_attributes", {})
         aliases_attr = sa.get("aliases")

--- a/tools/recover_postprocess.py
+++ b/tools/recover_postprocess.py
@@ -86,7 +86,7 @@ def main():
     # --- Pass 1: Strip false-positive PC aliases FIRST ---
     # Must happen before dedup, otherwise dedup will re-merge NPCs whose
     # names appear in the PC's alias list from the broken original merge.
-    print("\n=== Pass 1: Strip false-positive PC aliases ===")
+    print("\n=== Pass 1: Strip false-positive PC aliases + restore PC name ===")
     pc_entity = None
     for ent in catalogs.get("characters.json", []):
         if ent.get("id") == "char-player":
@@ -94,6 +94,31 @@ def main():
             break
     removed = []
     if pc_entity:
+        # Restore PC name/identity if corrupted by a prior merge (#248)
+        pc_name = pc_entity.get("name", "")
+        valid_pc_names = {"player character", "fenouille moonwind", "fenouille"}
+        if pc_name.lower().strip() not in valid_pc_names:
+            # Name was overwritten — restore from aliases if available
+            sa = pc_entity.get("stable_attributes", {})
+            alias_val = sa.get("aliases", {}).get("value", [])
+            restored_name = None
+            for a in (alias_val if isinstance(alias_val, list) else []):
+                if a.lower().strip() in valid_pc_names and len(a) > 3:
+                    restored_name = a
+                    break
+            if not restored_name:
+                restored_name = "Player Character"
+            print(f"  Restored PC name: '{pc_name}' → '{restored_name}'")
+            pc_entity["name"] = restored_name
+            # Clear corrupted identity if it doesn't describe the PC
+            ident = (pc_entity.get("identity") or "").lower()
+            if not any(w in ident for w in ["player", "fenouille", "warlock", "elf", "moon"]):
+                pc_entity["identity"] = (
+                    "The player character — an elf warlock guided by a celestial "
+                    "pact with a silent star."
+                )
+                print(f"  Restored PC identity (was describing a different character)")
+
         sa = pc_entity.setdefault("stable_attributes", {})
         aliases_attr = sa.get("aliases")
         # Normalize aliases to canonical {"value": [...]} structure


### PR DESCRIPTION
## Summary

Protect `char-player` name and identity from being overwritten during entity merges, and restore corrupted PC data during recovery postprocessing.

## Root Cause (#247)

`_update_existing_entity()` in `catalog_merger.py` unconditionally overwrites `name` and `identity` when a per-turn extraction returns different values. When the LLM attributes an NPC's name/description to the `char-player` entity ID (e.g., returning `name: "Elder Lyra"` for a turn discussing Elder Lyra), the PC's canonical identity is destroyed.

In the qwen3.5 full run, this caused:
- `char-player.name` = "Elder Lyra" (should be "Fenouille Moonwind")  
- `char-player.identity` = Riverfolk shaman description (should describe the PC)

## Fix

### catalog_merger.py — `_update_existing_entity()`

- Added `is_pc` guard: when updating `char-player`, `name` and `identity` fields are never overwritten by per-turn updates
- NPC names that the LLM erroneously attributes to the PC entity will still be captured as aliases but won't replace the canonical name

### recover_postprocess.py — Pass 1

- Added PC name/identity restoration: if the PC's name doesn't match known valid names ("Player Character", "Fenouille Moonwind", "Fenouille"), restore from the first valid alias
- If the PC's identity doesn't mention PC-relevant terms (player, fenouille, warlock, elf), replace with a generic PC identity

## Testing

- 1050 tests pass, 0 failures

Closes #247
Closes #248
