### PR TITLE
feat: integrate temporal extraction into pipeline to populate timeline.json

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,8 @@ tools/update_state.py                  tools/semantic_extraction.py  (optional, 
       |                                          |     +---> reconcile_segments()
       |                                          |     +---> framework/catalogs/*.json
       |                                          |
-      v                                          +---> framework/catalogs/events.json
+      |                                          +---> framework/catalogs/events.json
+      |                                          +---> framework/catalogs/timeline.json (temporal #263)
       v                                          |
       +------------------------------------------+
       |
@@ -132,7 +133,7 @@ A running profile of inferred DM behavior patterns, populated from two data sour
 
 An automated pipeline that uses an LLM to extract structured data from transcript turns.
 
-- **Four-agent pipeline**: Entity Discovery → Entity Detail → Relationship Mapper → Event Extractor
+- **Five-agent pipeline**: Entity Discovery → Entity Detail → Relationship Mapper → Event Extractor → Temporal Signal Extractor
 - Prompt templates in `templates/extraction/` define each agent's behavior
 - `tools/semantic_extraction.py` orchestrates the pipeline
 - `tools/catalog_merger.py` merges agent outputs into `framework/catalogs/`; includes per-pair relationship consolidation, `_dedup_relationships()` safety net (#183), and `cleanup_dangling_relationships()` to remove refs to non-existent entities (#184)
@@ -164,6 +165,7 @@ An automated pipeline that uses an LLM to extract structured data from transcrip
 - Biography sections use LLM-generated descriptive titles (not generic "Phase" labels), cached in `.synthesis.json` sidecars
 - Wiki pages include cross-page entity links: the first mention of each known entity in biography prose, relationship tables, event timelines, and member/connection lists is a clickable markdown link to that entity's wiki page. Link resolution uses relative paths across entity types.
 - **Coreference hints** (`apply_coreference_hints`): Optional manual merge rules in `sessions/*/coreference-hints.json`. Each entry maps a canonical entity ID to variant names and ID patterns. After the automatic dedup pass, the pipeline loads any hints file from the session directory and deterministically merges variant entities into their canonical counterpart — absorbing relationships, events, and stable attributes, deleting variant files, and rewriting all dangling references. Validated against `schemas/coreference-hints.schema.json`.
+- **Temporal extraction integration** (#263): The semantic extraction pipeline calls `temporal_extraction.extract_temporal_signals()` per-turn after event extraction (Phase 5). Pattern-based detection identifies season transitions, time-skip language, biological markers, and construction milestones directly from turn text and finalized events. Signals are merged into the timeline via `merge_temporal_signals()` with deduplication by `(source_turn, type, season, raw_text)`. The timeline is loaded alongside catalogs and events, saved at every checkpoint and at the end of extraction, and reconciled across segments in segmented mode. The extraction log records `temporal_ok`, `temporal_error`, and `new_temporal_signals` per turn. When `timeline` is not passed to `extract_and_merge()` (legacy callers), temporal extraction is skipped gracefully.
 
 ### Timeline Layer (Framework)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,7 +40,7 @@ Divide session processing across multiple specialized agents, each with a focuse
 | Timeline agent | Extract temporal signals and estimate in-game time progression | **Implemented** (#137) |
 | Planning layer | Synthesize catalog data into actionable derived planning files | **Implemented** (#259) |
 
-The **Catalog agent** is implemented as `tools/semantic_extraction.py` — a four-agent LLM pipeline (Entity Discovery → Entity Detail → Relationship Mapper → Event Extractor) that runs during bootstrap and incremental ingestion. It uses prompt templates in `templates/extraction/` and a provider-agnostic LLM client (`tools/llm_client.py`) supporting OpenAI and Ollama.
+The **Catalog agent** is implemented as `tools/semantic_extraction.py` — a five-agent LLM pipeline (Entity Discovery → Entity Detail → Relationship Mapper → Event Extractor → Temporal Signal Extractor) that runs during bootstrap and incremental ingestion. It uses prompt templates in `templates/extraction/` and a provider-agnostic LLM client (`tools/llm_client.py`) supporting OpenAI and Ollama.
 
 Post-extraction quality passes include:
 - **Dedup** — name, token-overlap, ID-stem, and Levenshtein matching (with minimum 6-char stem guard, #132)
@@ -58,11 +58,16 @@ Post-extraction quality passes include:
 - **Periodic entity refresh** (#161, #182) — re-extracts stale entities every N turns (`entity_refresh_interval`, default 50) using recent transcript context. Up to `entity_refresh_batch_size` (default 10) entities are refreshed per interval, with dynamic scaling for large catalogs (60+ entities scale to `catalog_size // 5`, capped at 25). Type-aware slot allocation gives characters 50% of refresh slots, locations 20%, items 20%, and factions 10%, with overflow redistribution. Event-frequency tiebreaking prioritizes narratively important entities.
 - **Scene graph / spatial index** (#257) — cross-type queryable index (`framework/catalogs/scene-graph.json`) built from entity catalogs by `tools/build_scene_graph.py`. Location index maps location IDs to present entities, turn activity index maps turns to active entity IDs, and location connections track spatial edges between locations. Integrated into `build_context.py` for O(T) nearby-entity lookups. Additive capability — no re-extraction required.
 
-**Timeline tracking** (#137): The pipeline extracts temporal signals (season transitions,
+**Timeline tracking** (#137, #263): The pipeline extracts temporal signals (season transitions,
 biological markers, construction milestones) and estimates in-game day offsets from a
 configurable reference anchor. Implemented in `tools/temporal_extraction.py` with
-pattern-based detection plus an optional LLM template. Integrated into wiki page display
-(estimated day column in event timelines, season-enriched infoboxes).
+pattern-based detection plus an optional LLM template. Integrated into the semantic
+extraction pipeline (#263) as Phase 5: `extract_temporal_signals()` runs per-turn after
+event extraction, signals are merged with dedup into `framework/catalogs/timeline.json`,
+and the timeline is saved at checkpoints and reconciled across segments. The extraction
+log records `temporal_ok`, `temporal_error`, and `new_temporal_signals` per turn.
+Also integrated into wiki page display (estimated day column in event timelines,
+season-enriched infoboxes).
 
 Benefits:
 - Narrower per-agent context window → lower token cost

--- a/tests/test_checkpoint_persistence.py
+++ b/tests/test_checkpoint_persistence.py
@@ -59,7 +59,7 @@ class TestSegmentedCheckpointPersistence:
         turn_count = 0
         entity_counter = [0]
 
-        def mock_extract_and_merge(turn, catalogs, events, llm, min_conf, catalog_dir=None):
+        def mock_extract_and_merge(turn, catalogs, events, llm, min_conf, catalog_dir=None, **kwargs):
             nonlocal turn_count
             turn_count += 1
             entity_counter[0] += 1
@@ -98,7 +98,7 @@ class TestSegmentedCheckpointPersistence:
         segment_calls = [0]
         catalog_snapshots = []
 
-        def mock_extract_and_merge(turn, catalogs, events, llm, min_conf, catalog_dir=None):
+        def mock_extract_and_merge(turn, catalogs, events, llm, min_conf, catalog_dir=None, **kwargs):
             catalogs["characters.json"].append(
                 _make_entity(f"char-seg-ent-{len(catalogs['characters.json']) + 1}",
                              f"Ent {len(catalogs['characters.json']) + 1}")
@@ -152,7 +152,7 @@ class TestIntraSegmentCheckpoint:
         checkpoint_disk_snapshots = []
         call_count = [0]
 
-        def mock_extract_and_merge(turn, catalogs, events, llm, min_conf, catalog_dir=None):
+        def mock_extract_and_merge(turn, catalogs, events, llm, min_conf, catalog_dir=None, **kwargs):
             call_count[0] += 1
             catalogs["characters.json"].append(
                 _make_entity(f"char-intra-{call_count[0]}",
@@ -208,7 +208,7 @@ class TestErrorPathPersistence:
 
         call_count = [0]
 
-        def mock_extract_and_merge(turn, catalogs, events, llm, min_conf, catalog_dir=None):
+        def mock_extract_and_merge(turn, catalogs, events, llm, min_conf, catalog_dir=None, **kwargs):
             call_count[0] += 1
             if call_count[0] == 3:
                 raise RuntimeError("Simulated extraction failure")
@@ -282,7 +282,7 @@ class TestResumeLoadsPersisted:
 
         loaded_catalogs = [None]
 
-        def mock_extract_and_merge(turn, catalogs, events, llm, min_conf, catalog_dir=None):
+        def mock_extract_and_merge(turn, catalogs, events, llm, min_conf, catalog_dir=None, **kwargs):
             # On the first call (turn 3), record what catalogs were loaded
             if loaded_catalogs[0] is None:
                 loaded_catalogs[0] = {k: list(v) for k, v in catalogs.items()}

--- a/tests/test_extraction_log.py
+++ b/tests/test_extraction_log.py
@@ -137,7 +137,7 @@ class TestExtractionLogFile:
 
         call_count = [0]
 
-        def mock_extract(turn, catalogs, events, llm, min_conf, catalog_dir=None):
+        def mock_extract(turn, catalogs, events, llm, min_conf, catalog_dir=None, **kwargs):
             call_count[0] += 1
             log = {
                 "turn_id": turn["turn_id"],
@@ -191,7 +191,7 @@ class TestExtractionLogFile:
         os.makedirs(os.path.join(session_dir, "derived"), exist_ok=True)
         os.makedirs(catalog_dir, exist_ok=True)
 
-        def mock_extract(turn, catalogs, events, llm, min_conf, catalog_dir=None):
+        def mock_extract(turn, catalogs, events, llm, min_conf, catalog_dir=None, **kwargs):
             return catalogs, events, False, {"turn_id": turn["turn_id"]}
 
         turns = [{"turn_id": "turn-001", "speaker": "dm", "text": "T1."}]
@@ -227,7 +227,7 @@ class TestExtractionLogFile:
 
         call_count = [0]
 
-        def mock_extract(turn, catalogs, events, llm, min_conf, catalog_dir=None):
+        def mock_extract(turn, catalogs, events, llm, min_conf, catalog_dir=None, **kwargs):
             call_count[0] += 1
             if call_count[0] == 2:
                 # Simulate a turn with discovery failure
@@ -295,7 +295,7 @@ class TestExtractionLogFile:
 
         call_count = [0]
 
-        def mock_extract(turn, catalogs, events, llm, min_conf, catalog_dir=None):
+        def mock_extract(turn, catalogs, events, llm, min_conf, catalog_dir=None, **kwargs):
             call_count[0] += 1
             if call_count[0] == 2:
                 raise RuntimeError("Simulated crash")

--- a/tests/test_temporal_pipeline_integration.py
+++ b/tests/test_temporal_pipeline_integration.py
@@ -1,0 +1,499 @@
+"""Tests for temporal extraction integration into the semantic pipeline (#263)."""
+
+import json
+import os
+import sys
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from catalog_merger import CATALOG_KEYS, load_catalogs, save_catalogs
+import semantic_extraction as se
+from temporal_extraction import (
+    extract_temporal_signals,
+    merge_temporal_signals,
+    load_timeline,
+    save_timeline,
+)
+
+
+def _fresh_catalogs():
+    return {fn: [] for fn in CATALOG_KEYS}
+
+
+def _make_turns(start, end, speaker="dm"):
+    """Create turn dicts from turn-{start} to turn-{end} (inclusive)."""
+    return [
+        {"turn_id": f"turn-{i:03d}", "speaker": speaker, "text": f"Turn {i} text."}
+        for i in range(start, end + 1)
+    ]
+
+
+def _setup_session(tmp_path):
+    session_dir = str(tmp_path / "sessions" / "test")
+    framework_dir = str(tmp_path / "framework")
+    catalog_dir = os.path.join(framework_dir, "catalogs")
+    os.makedirs(os.path.join(session_dir, "derived"), exist_ok=True)
+    os.makedirs(catalog_dir, exist_ok=True)
+    return session_dir, framework_dir, catalog_dir
+
+
+def _make_noop_extract(add_temporal=None):
+    """Create a mock extract_and_merge that optionally adds temporal signals."""
+    def mock_extract(turn, catalogs, events, llm, min_conf,
+                     catalog_dir=None, timeline=None):
+        if timeline is not None and add_temporal:
+            for sig in add_temporal(turn):
+                timeline.append(sig)
+        return catalogs, events, False, {"turn_id": turn["turn_id"]}
+    return mock_extract
+
+
+# ---------------------------------------------------------------------------
+# Unit test: temporal signals extraction (pattern-based, not pipeline)
+# ---------------------------------------------------------------------------
+
+class TestTemporalSignalExtraction:
+    """Verify that extract_temporal_signals produces correct results."""
+
+    def test_winter_text(self):
+        signals = extract_temporal_signals(
+            "The first snow falls across the valley, covering everything in frost.",
+            "turn-001",
+        )
+        assert len(signals) > 0
+        assert any(s["type"] == "season_transition" for s in signals)
+
+    def test_time_skip(self):
+        signals = extract_temporal_signals(
+            "Weeks pass in relative quiet. The settlement grows.",
+            "turn-010",
+        )
+        assert any(s["type"] == "time_skip" for s in signals)
+
+    def test_no_signals(self):
+        signals = extract_temporal_signals(
+            "The merchant offers you a choice of weapons.",
+            "turn-003",
+        )
+        assert signals == []
+
+    def test_spring_text(self):
+        signals = extract_temporal_signals(
+            "The thaw begins. First true signs of spring arrive.",
+            "turn-005",
+        )
+        assert any(s["type"] == "season_transition" for s in signals)
+
+
+# ---------------------------------------------------------------------------
+# Unit test: merge_temporal_signals dedup
+# ---------------------------------------------------------------------------
+
+class TestMergeTemporalSignals:
+    """Verify merge and dedup behavior."""
+
+    def test_dedup_same_signal(self):
+        timeline = []
+        signals = [
+            {"source_turn": "turn-001", "type": "season_transition",
+             "season": "mid_winter", "signals": ["first"]},
+        ]
+        merge_temporal_signals(timeline, signals)
+        assert len(timeline) == 1
+
+        # Same signal again — should NOT duplicate
+        signals2 = [
+            {"source_turn": "turn-001", "type": "season_transition",
+             "season": "mid_winter", "signals": ["second"]},
+        ]
+        merge_temporal_signals(timeline, signals2)
+        assert len(timeline) == 1
+
+    def test_different_signals_kept(self):
+        timeline = []
+        merge_temporal_signals(timeline, [
+            {"source_turn": "turn-001", "type": "season_transition",
+             "season": "mid_winter", "signals": ["a"]},
+        ])
+        merge_temporal_signals(timeline, [
+            {"source_turn": "turn-005", "type": "time_skip",
+             "signals": ["b"]},
+        ])
+        assert len(timeline) == 2
+
+
+# ---------------------------------------------------------------------------
+# Integration: extract_and_merge populates timeline
+# ---------------------------------------------------------------------------
+
+class TestExtractAndMergeTemporalIntegration:
+    """Verify temporal phase in extract_and_merge via mocked pipeline."""
+
+    def test_temporal_signals_populated(self):
+        """Mock extract_and_merge confirms timeline arg is received and used."""
+        timeline = []
+        turn = {"turn_id": "turn-001", "speaker": "dm",
+                "text": "Snow covers the land."}
+
+        mock = _make_noop_extract(add_temporal=lambda t: [
+            {"source_turn": t["turn_id"], "type": "season_transition",
+             "season": "mid_winter", "signals": ["mock"]}
+        ])
+
+        mock(turn, _fresh_catalogs(), [], None, 0.6, timeline=timeline)
+        assert len(timeline) == 1
+        assert timeline[0]["type"] == "season_transition"
+
+    def test_no_timeline_param_no_signals(self):
+        """When timeline is None, no signals added."""
+        mock = _make_noop_extract(add_temporal=lambda t: [
+            {"source_turn": t["turn_id"], "type": "time_skip", "signals": ["x"]}
+        ])
+        turn = {"turn_id": "turn-001", "speaker": "dm", "text": "Test."}
+        mock(turn, _fresh_catalogs(), [], None, 0.6, timeline=None)
+        # No assertion failure = success (no crash when timeline is None)
+
+
+# ---------------------------------------------------------------------------
+# Real extract_and_merge with temporal (requires more mocking of LLM)
+# This tests the actual wiring in extract_and_merge
+# ---------------------------------------------------------------------------
+
+class TestExtractAndMergeRealWiring:
+    """Test the actual temporal extraction wiring in extract_and_merge."""
+
+    def test_temporal_phase_runs_after_events(self):
+        """With full mocking, extract_and_merge should run temporal extraction."""
+        turn = {"turn_id": "turn-001", "speaker": "dm",
+                "text": "The first snow of deep winter blankets the valley."}
+        catalogs = _fresh_catalogs()
+        events_list = []
+        timeline = []
+
+        mock_llm = MagicMock()
+        # Discovery returns no entities
+        mock_llm.extract_json.return_value = {"entities": [], "events": []}
+        mock_llm.delay.return_value = None
+        mock_llm.default_timeout = 60
+        mock_llm.max_tokens = 4096
+
+        with patch.object(se, "load_template", return_value="mock template"):
+            _, _, failed, log = se.extract_and_merge(
+                turn, catalogs, events_list, mock_llm, timeline=timeline,
+            )
+
+        assert not failed
+        assert len(timeline) > 0, "Expected temporal signals from deep winter text"
+        assert any(e["type"] == "season_transition" for e in timeline)
+        assert all("id" in e for e in timeline)
+        assert log.get("temporal_ok") is True
+        assert log.get("new_temporal_signals", 0) > 0
+
+    def test_log_records_temporal_none_when_no_timeline(self):
+        """When timeline is not passed, temporal_ok should be None."""
+        turn = {"turn_id": "turn-001", "speaker": "dm", "text": "Snow."}
+        catalogs = _fresh_catalogs()
+        events_list = []
+
+        mock_llm = MagicMock()
+        mock_llm.extract_json.return_value = {"entities": [], "events": []}
+        mock_llm.delay.return_value = None
+        mock_llm.default_timeout = 60
+        mock_llm.max_tokens = 4096
+
+        with patch.object(se, "load_template", return_value="mock template"):
+            _, _, _, log = se.extract_and_merge(
+                turn, catalogs, events_list, mock_llm, timeline=None,
+            )
+
+        assert log.get("temporal_ok") is None
+        assert log.get("temporal_error") is None
+
+    def test_no_signals_still_ok(self):
+        """A turn with no temporal language should not be an error."""
+        turn = {"turn_id": "turn-003", "speaker": "dm",
+                "text": "The merchant offers you a choice of weapons."}
+        catalogs = _fresh_catalogs()
+        events_list = []
+        timeline = []
+
+        mock_llm = MagicMock()
+        mock_llm.extract_json.return_value = {"entities": [], "events": []}
+        mock_llm.delay.return_value = None
+        mock_llm.default_timeout = 60
+        mock_llm.max_tokens = 4096
+
+        with patch.object(se, "load_template", return_value="mock template"):
+            _, _, _, log = se.extract_and_merge(
+                turn, catalogs, events_list, mock_llm, timeline=timeline,
+            )
+
+        assert log["temporal_ok"] is True
+        assert log["new_temporal_signals"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Batch extraction: timeline saved to disk
+# ---------------------------------------------------------------------------
+
+class TestBatchExtractionTimeline:
+    """Verify that batch extraction loads, populates, and saves timeline."""
+
+    def test_batch_saves_timeline(self, tmp_path):
+        """extract_semantic_batch should save timeline.json."""
+        session_dir, framework_dir, catalog_dir = _setup_session(tmp_path)
+
+        def mock_extract(turn, catalogs, events, llm, min_conf,
+                         catalog_dir=None, timeline=None):
+            if timeline is not None and "snow" in turn["text"].lower():
+                timeline.append({
+                    "source_turn": turn["turn_id"],
+                    "type": "season_transition",
+                    "season": "mid_winter",
+                    "signals": ["test mock"],
+                    "confidence": 0.8,
+                })
+            return catalogs, events, False, {"turn_id": turn["turn_id"]}
+
+        turns = [
+            {"turn_id": "turn-001", "speaker": "dm", "text": "Snow and frost blanket the land."},
+            {"turn_id": "turn-002", "speaker": "dm", "text": "You enter the tavern."},
+        ]
+
+        with patch("semantic_extraction.LLMClient") as mock_llm_cls, \
+             patch("semantic_extraction.extract_and_merge", side_effect=mock_extract), \
+             patch("semantic_extraction._ensure_player_character"), \
+             patch("semantic_extraction.find_stale_entities", return_value=[]), \
+             patch("semantic_extraction._dedup_catalogs", return_value=(0, {})), \
+             patch("semantic_extraction._post_batch_orphan_sweep", return_value=0), \
+             patch("semantic_extraction._name_mention_discovery", return_value=0), \
+             patch("semantic_extraction.cleanup_dangling_relationships", return_value={}):
+            mock_llm_cls.return_value = MagicMock(config={"checkpoint_interval": 100})
+
+            se.extract_semantic_batch(
+                turns, session_dir, framework_dir=framework_dir,
+                config_path="unused",
+            )
+
+        timeline_path = os.path.join(catalog_dir, "timeline.json")
+        assert os.path.isfile(timeline_path), "timeline.json not created"
+        timeline = json.loads(open(timeline_path, encoding="utf-8").read())
+        assert len(timeline) >= 1
+        assert timeline[0]["type"] == "season_transition"
+
+    def test_batch_loads_existing_timeline(self, tmp_path):
+        """Batch mode should load and extend an existing timeline."""
+        session_dir, framework_dir, catalog_dir = _setup_session(tmp_path)
+
+        # Pre-populate timeline
+        existing = [
+            {"id": "time-001", "source_turn": "turn-001", "type": "season_transition",
+             "season": "mid_winter", "signals": ["pre-existing"], "confidence": 0.8}
+        ]
+        save_timeline(catalog_dir, existing)
+
+        loaded_timelines = []
+
+        def mock_extract(turn, catalogs, events, llm, min_conf,
+                         catalog_dir=None, timeline=None):
+            if timeline is not None:
+                loaded_timelines.append(len(timeline))
+            return catalogs, events, False, {"turn_id": turn["turn_id"]}
+
+        turns = _make_turns(2, 3)
+
+        with patch("semantic_extraction.LLMClient") as mock_llm_cls, \
+             patch("semantic_extraction.extract_and_merge", side_effect=mock_extract), \
+             patch("semantic_extraction._ensure_player_character"), \
+             patch("semantic_extraction.find_stale_entities", return_value=[]), \
+             patch("semantic_extraction._dedup_catalogs", return_value=(0, {})), \
+             patch("semantic_extraction._post_batch_orphan_sweep", return_value=0), \
+             patch("semantic_extraction._name_mention_discovery", return_value=0), \
+             patch("semantic_extraction.cleanup_dangling_relationships", return_value={}):
+            mock_llm_cls.return_value = MagicMock(config={"checkpoint_interval": 100})
+
+            se.extract_semantic_batch(
+                turns, session_dir, framework_dir=framework_dir,
+                config_path="unused",
+            )
+
+        # First call should have received the pre-existing timeline entry
+        assert len(loaded_timelines) >= 1
+        assert loaded_timelines[0] == 1, \
+            f"Expected 1 pre-existing entry, got {loaded_timelines[0]}"
+
+
+# ---------------------------------------------------------------------------
+# Single-turn extraction: timeline saved to disk
+# ---------------------------------------------------------------------------
+
+class TestSingleTurnTimeline:
+    """Verify that single-turn extraction loads, populates, and saves timeline."""
+
+    def test_single_turn_saves_timeline(self, tmp_path):
+        """extract_semantic_single should save timeline.json."""
+        session_dir, framework_dir, catalog_dir = _setup_session(tmp_path)
+
+        def mock_extract(turn, catalogs, events, llm, min_conf,
+                         catalog_dir=None, timeline=None):
+            if timeline is not None:
+                timeline.append({
+                    "id": "time-001",
+                    "source_turn": turn["turn_id"],
+                    "type": "season_transition",
+                    "season": "early_spring",
+                    "signals": ["test mock single"],
+                    "confidence": 0.7,
+                })
+            return catalogs, events, False, {"turn_id": turn["turn_id"]}
+
+        with patch("semantic_extraction.LLMClient") as mock_llm_cls, \
+             patch("semantic_extraction.extract_and_merge", side_effect=mock_extract), \
+             patch("semantic_extraction._ensure_player_character"), \
+             patch("semantic_extraction.mark_dormant_relationships", return_value=0):
+            mock_llm_cls.return_value = MagicMock(config={})
+
+            se.extract_semantic_single(
+                "turn-010", "dm", "The thaw begins.",
+                session_dir, framework_dir=framework_dir,
+                config_path="unused",
+            )
+
+        timeline_path = os.path.join(catalog_dir, "timeline.json")
+        assert os.path.isfile(timeline_path), "timeline.json not created"
+        timeline = json.loads(open(timeline_path, encoding="utf-8").read())
+        assert len(timeline) == 1
+        assert timeline[0]["season"] == "early_spring"
+
+
+# ---------------------------------------------------------------------------
+# Segmented extraction: timeline reconciled across segments
+# ---------------------------------------------------------------------------
+
+class TestSegmentedTimeline:
+    """Verify timeline reconciliation in segmented extraction."""
+
+    def test_segmented_reconciles_timelines(self, tmp_path):
+        """Segments should each build timeline independently, then reconcile."""
+        session_dir, framework_dir, catalog_dir = _setup_session(tmp_path)
+
+        seg_counter = [0]
+
+        def mock_extract(turn, catalogs, events, llm, min_conf,
+                         catalog_dir=None, timeline=None):
+            if timeline is not None:
+                turn_num = int(turn["turn_id"].split("-")[1])
+                if turn_num <= 3:
+                    # Only add for first segment turns
+                    timeline.append({
+                        "source_turn": turn["turn_id"],
+                        "type": "season_transition",
+                        "season": "mid_winter",
+                        "signals": [f"segment signal {turn['turn_id']}"],
+                        "confidence": 0.8,
+                    })
+                elif turn_num >= 4:
+                    timeline.append({
+                        "source_turn": turn["turn_id"],
+                        "type": "season_transition",
+                        "season": "early_spring",
+                        "signals": [f"segment signal {turn['turn_id']}"],
+                        "confidence": 0.7,
+                    })
+            return catalogs, events, False, {}
+
+        turns = _make_turns(1, 6)
+
+        with patch("semantic_extraction.LLMClient") as mock_llm_cls, \
+             patch("semantic_extraction.extract_and_merge", side_effect=mock_extract), \
+             patch("semantic_extraction._ensure_player_character"), \
+             patch("semantic_extraction.find_stale_entities", return_value=[]), \
+             patch("semantic_extraction.cleanup_dangling_relationships", return_value={}), \
+             patch("semantic_extraction._post_batch_orphan_sweep", return_value=0), \
+             patch("semantic_extraction._name_mention_discovery", return_value=0):
+            mock_llm_cls.return_value = MagicMock(config={"checkpoint_interval": 25})
+
+            se.extract_semantic_batch(
+                turns, session_dir, framework_dir=framework_dir,
+                config_path="unused", segment_size=3,
+            )
+
+        timeline_path = os.path.join(catalog_dir, "timeline.json")
+        assert os.path.isfile(timeline_path), "timeline.json not created"
+        timeline = json.loads(open(timeline_path, encoding="utf-8").read())
+        assert len(timeline) == 6, f"Expected 6 signals, got {len(timeline)}"
+        # Check both seasons present (from both segments)
+        seasons = {e["season"] for e in timeline}
+        assert "mid_winter" in seasons
+        assert "early_spring" in seasons
+        # All should have IDs assigned
+        assert all("id" in e for e in timeline)
+        # IDs should be sequential
+        ids = sorted(e["id"] for e in timeline)
+        assert ids == [f"time-{i:03d}" for i in range(1, 7)]
+
+
+# ---------------------------------------------------------------------------
+# _reconcile_timelines helper
+# ---------------------------------------------------------------------------
+
+class TestReconcileTimelines:
+    """Unit tests for the _reconcile_timelines helper."""
+
+    def test_empty_segments(self):
+        segments = [
+            {"timeline": []},
+            {"timeline": []},
+        ]
+        result = se._reconcile_timelines(segments)
+        assert result == []
+
+    def test_dedup_across_segments(self):
+        """Duplicate signals across segments should be merged."""
+        segments = [
+            {"timeline": [
+                {"id": "time-001", "source_turn": "turn-001",
+                 "type": "season_transition", "season": "mid_winter",
+                 "signals": ["seg1"]},
+            ]},
+            {"timeline": [
+                {"id": "time-001", "source_turn": "turn-001",
+                 "type": "season_transition", "season": "mid_winter",
+                 "signals": ["seg2"]},
+            ]},
+        ]
+        result = se._reconcile_timelines(segments)
+        # Same (source_turn, type, season, raw_text) — should dedup to 1
+        assert len(result) == 1
+
+    def test_distinct_signals_preserved(self):
+        """Different signals across segments should both be kept."""
+        segments = [
+            {"timeline": [
+                {"id": "time-001", "source_turn": "turn-001",
+                 "type": "season_transition", "season": "mid_winter",
+                 "signals": ["seg1"]},
+            ]},
+            {"timeline": [
+                {"id": "time-001", "source_turn": "turn-004",
+                 "type": "season_transition", "season": "early_spring",
+                 "signals": ["seg2"]},
+            ]},
+        ]
+        result = se._reconcile_timelines(segments)
+        assert len(result) == 2
+
+    def test_missing_timeline_key(self):
+        """Segments without timeline key should be handled gracefully."""
+        segments = [
+            {"catalogs": {}, "events": []},
+            {"timeline": [
+                {"id": "time-001", "source_turn": "turn-001",
+                 "type": "time_skip", "signals": ["test"]},
+            ]},
+        ]
+        result = se._reconcile_timelines(segments)
+        assert len(result) == 1

--- a/tests/test_temporal_pipeline_integration.py
+++ b/tests/test_temporal_pipeline_integration.py
@@ -4,17 +4,15 @@ import json
 import os
 import sys
 
-import pytest
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
-from catalog_merger import CATALOG_KEYS, load_catalogs, save_catalogs
+from catalog_merger import CATALOG_KEYS
 import semantic_extraction as se
 from temporal_extraction import (
     extract_temporal_signals,
     merge_temporal_signals,
-    load_timeline,
     save_timeline,
 )
 
@@ -280,7 +278,8 @@ class TestBatchExtractionTimeline:
 
         timeline_path = os.path.join(catalog_dir, "timeline.json")
         assert os.path.isfile(timeline_path), "timeline.json not created"
-        timeline = json.loads(open(timeline_path, encoding="utf-8").read())
+        with open(timeline_path, encoding="utf-8") as f:
+            timeline = json.load(f)
         assert len(timeline) >= 1
         assert timeline[0]["type"] == "season_transition"
 
@@ -364,7 +363,8 @@ class TestSingleTurnTimeline:
 
         timeline_path = os.path.join(catalog_dir, "timeline.json")
         assert os.path.isfile(timeline_path), "timeline.json not created"
-        timeline = json.loads(open(timeline_path, encoding="utf-8").read())
+        with open(timeline_path, encoding="utf-8") as f:
+            timeline = json.load(f)
         assert len(timeline) == 1
         assert timeline[0]["season"] == "early_spring"
 
@@ -379,8 +379,6 @@ class TestSegmentedTimeline:
     def test_segmented_reconciles_timelines(self, tmp_path):
         """Segments should each build timeline independently, then reconcile."""
         session_dir, framework_dir, catalog_dir = _setup_session(tmp_path)
-
-        seg_counter = [0]
 
         def mock_extract(turn, catalogs, events, llm, min_conf,
                          catalog_dir=None, timeline=None):
@@ -423,7 +421,8 @@ class TestSegmentedTimeline:
 
         timeline_path = os.path.join(catalog_dir, "timeline.json")
         assert os.path.isfile(timeline_path), "timeline.json not created"
-        timeline = json.loads(open(timeline_path, encoding="utf-8").read())
+        with open(timeline_path, encoding="utf-8") as f:
+            timeline = json.load(f)
         assert len(timeline) == 6, f"Expected 6 signals, got {len(timeline)}"
         # Check both seasons present (from both segments)
         seasons = {e["season"] for e in timeline}

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -2,12 +2,14 @@
 """
 semantic_extraction.py — Core orchestrator for LLM-based semantic extraction.
 
-Processes RPG session transcript turns through five agent roles:
+Processes RPG session transcript turns through four core agent roles, with an
+optional fifth temporal-extraction phase when timeline state is provided:
 1. Entity Discovery — identify entities mentioned in a turn
 2. Entity Detail Extractor — extract/update attributes per entity
 3. Relationship Mapper — identify cross-entity relationships
 4. Event Extractor — identify narrative events
-5. Temporal Signal Extractor — extract season, time-skip, and biological markers (#263)
+5. Temporal Signal Extractor (optional) — extract season, time-skip, and
+   biological markers when timeline tracking is enabled (#263)
 
 Works in both batch (bootstrap) and incremental (ingest) modes.
 """
@@ -47,7 +49,6 @@ from temporal_extraction import (
     merge_temporal_signals,
     load_timeline,
     save_timeline,
-    get_next_timeline_id,
 )
 
 try:
@@ -3637,6 +3638,7 @@ def _extract_segmented(
                     "id": f"{segment_id}-partial",
                     "catalogs": seg_catalogs,
                     "events": seg_events,
+                    "timeline": seg_timeline,
                     "turn_range": (segment_turns[0]["turn_id"], turn_id),
                 }]
                 interim_catalogs, interim_events = _reconcile_segments(interim)
@@ -3647,6 +3649,8 @@ def _extract_segmented(
                 )
                 save_catalogs(catalog_dir, interim_catalogs)
                 save_events(catalog_dir, interim_events)
+                interim_timeline = _reconcile_timelines(interim)
+                save_timeline(catalog_dir, interim_timeline)
 
         # --- Final entity refresh for segment — catch entities stale since last modulo checkpoint (#212) ---
         # Skip refresh if quota was exhausted — no further LLM calls (#215)

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -2,11 +2,12 @@
 """
 semantic_extraction.py — Core orchestrator for LLM-based semantic extraction.
 
-Processes RPG session transcript turns through four agent roles:
+Processes RPG session transcript turns through five agent roles:
 1. Entity Discovery — identify entities mentioned in a turn
 2. Entity Detail Extractor — extract/update attributes per entity
 3. Relationship Mapper — identify cross-entity relationships
 4. Event Extractor — identify narrative events
+5. Temporal Signal Extractor — extract season, time-skip, and biological markers (#263)
 
 Works in both batch (bootstrap) and incremental (ingest) modes.
 """
@@ -41,6 +42,13 @@ from catalog_merger import (
     CATALOG_KEYS,
 )
 from llm_client import LLMClient, LLMExtractionError, QuotaExhaustedError
+from temporal_extraction import (
+    extract_temporal_signals,
+    merge_temporal_signals,
+    load_timeline,
+    save_timeline,
+    get_next_timeline_id,
+)
 
 try:
     import jsonschema
@@ -1516,6 +1524,7 @@ def extract_and_merge(
     llm: LLMClient,
     min_confidence: float = DEFAULT_MIN_CONFIDENCE,
     catalog_dir: str | None = None,
+    timeline: list | None = None,
 ) -> tuple[dict, list, bool, dict]:
     """Process one turn through all extraction agents.
 
@@ -1527,6 +1536,8 @@ def extract_and_merge(
         min_confidence: Minimum confidence to catalog an entity.
         catalog_dir: Optional path to the catalog directory, used to load
             arc sidecar files for relationship compaction (#120).
+        timeline: Optional list of timeline entries.  When provided, temporal
+            signals are extracted from the turn and merged in-place (#263).
 
     Returns:
         Tuple of (catalogs, events_list, turn_failed, log_record) where
@@ -1939,10 +1950,28 @@ def extract_and_merge(
 
     llm.delay()
 
+    # --- Phase 5: Temporal signal extraction (#263) ---
+    _temporal_before = len(timeline) if timeline is not None else 0
+    if timeline is not None:
+        try:
+            temporal_signals = extract_temporal_signals(
+                turn["text"], turn_id, events=events_list,
+            )
+            if temporal_signals:
+                merge_temporal_signals(timeline, temporal_signals)
+                _phase_log["temporal_ok"] = True
+            else:
+                _phase_log["temporal_ok"] = True  # No signals is not an error
+        except Exception as e:
+            print(f"  WARNING: Temporal extraction failed for {turn_id}: {e}", file=sys.stderr)
+            _phase_log["temporal_ok"] = False
+            _phase_log["temporal_error"] = str(e)
+
     # Build extraction log record (#217)
     _elapsed_ms = int((time.monotonic() - _t0) * 1000)
     _entities_after = sum(len(v) for v in catalogs.values())
     _events_after = len(events_list)
+    _temporal_after = len(timeline) if timeline is not None else 0
     _log_record = {
         "turn_id": turn_id,
         "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
@@ -1956,8 +1985,11 @@ def extract_and_merge(
         "relationships_error": _phase_log["relationships_error"],
         "events_ok": _phase_log["events_ok"],
         "events_error": _phase_log["events_error"],
+        "temporal_ok": _phase_log.get("temporal_ok"),
+        "temporal_error": _phase_log.get("temporal_error"),
         "new_entities": max(0, _entities_after - _entities_before),
         "new_events": max(0, _events_after - _events_before),
+        "new_temporal_signals": max(0, _temporal_after - _temporal_before),
         "discovery_proposals": _discovery_proposals,
         "discovery_filtered": _discovery_filtered,
         "elapsed_ms": _elapsed_ms,
@@ -3426,6 +3458,26 @@ def _reconcile_segments(segments):
     return merged_catalogs, merged_events
 
 
+def _reconcile_timelines(segments) -> list[dict]:
+    """Merge timeline entries from multiple extraction segments.
+
+    Concatenates all segment timelines and uses ``merge_temporal_signals``
+    to deduplicate and assign sequential IDs.
+    """
+    merged: list[dict] = []
+    for seg in segments:
+        seg_timeline = seg.get("timeline", [])
+        if seg_timeline:
+            # Strip segment-local IDs so merge_temporal_signals can re-assign
+            stripped = []
+            for entry in seg_timeline:
+                entry_copy = entry.copy()
+                entry_copy.pop("id", None)
+                stripped.append(entry_copy)
+            merge_temporal_signals(merged, stripped)
+    return merged
+
+
 def _print_retry_stats(llm) -> None:
     """Print API retry statistics from the LLM client (#215)."""
     stats = getattr(llm, "stats", None)
@@ -3477,6 +3529,7 @@ def _extract_segmented(
         # Fresh catalog for each segment
         seg_catalogs = {fn: [] for fn in CATALOG_KEYS}
         seg_events = []
+        seg_timeline: list[dict] = []
 
         # Pre-seed player character (always present)
         _ensure_player_character(seg_catalogs, segment_turns[0]["turn_id"])
@@ -3513,6 +3566,7 @@ def _extract_segmented(
                 seg_catalogs, seg_events, seg_turn_failed, seg_turn_log = extract_and_merge(
                     turn, seg_catalogs, seg_events, llm, min_confidence,
                     catalog_dir=None,
+                    timeline=seg_timeline,
                 )
             except QuotaExhaustedError as e:
                 print(f"\n  QUOTA EXHAUSTED at {turn_id}: {e}", file=sys.stderr)
@@ -3616,7 +3670,7 @@ def _extract_segmented(
                         print(f"  REFRESH: Successfully refreshed {refreshed} entity/entities at end of {segment_id}")
 
         seg_entity_count = sum(len(v) for v in seg_catalogs.values())
-        print(f"  {segment_id} complete: {seg_entity_count} entities, {len(seg_events)} events")
+        print(f"  {segment_id} complete: {seg_entity_count} entities, {len(seg_events)} events, {len(seg_timeline)} temporal signals")
         if seg_failed_turns:
             print(f"  {segment_id}: {len(seg_failed_turns)} turn(s) had extraction failures", file=sys.stderr)
 
@@ -3624,6 +3678,7 @@ def _extract_segmented(
             "id": segment_id,
             "catalogs": seg_catalogs,
             "events": seg_events,
+            "timeline": seg_timeline,
             "turn_range": (segment_turns[0]["turn_id"], segment_turns[-1]["turn_id"]),
             "failed_turns": seg_failed_turns,
         })
@@ -3641,6 +3696,8 @@ def _extract_segmented(
             interim_catalogs, interim_events = _reconcile_segments(segments)
             save_catalogs(catalog_dir, interim_catalogs)
             save_events(catalog_dir, interim_events)
+            interim_timeline = _reconcile_timelines(segments)
+            save_timeline(catalog_dir, interim_timeline)
 
         # Stop processing further segments if quota was exhausted (#215)
         if quota_exhausted:
@@ -3657,6 +3714,7 @@ def _extract_segmented(
     # Reconcile all segments into a single catalog
     print(f"\n  === Reconciliation: merging {len(segments)} segments ===")
     final_catalogs, final_events = _reconcile_segments(segments)
+    final_timeline = _reconcile_timelines(segments)
 
     # Run standard post-batch passes on the reconciled result
     dupes_merged, merge_map = _dedup_catalogs(final_catalogs)
@@ -3691,7 +3749,7 @@ def _extract_segmented(
             print(f"    - {tid}", file=sys.stderr)
         print(f"  These turns should be re-extracted when the LLM is available.", file=sys.stderr)
 
-    print(f"  Segmented extraction complete: {entities_final} entities, {len(final_events)} events")
+    print(f"  Segmented extraction complete: {entities_final} entities, {len(final_events)} events, {len(final_timeline)} temporal signals")
 
     # Report API retry statistics (#215)
     _print_retry_stats(llm)
@@ -3699,6 +3757,7 @@ def _extract_segmented(
     if not dry_run:
         save_catalogs(catalog_dir, final_catalogs)
         save_events(catalog_dir, final_events)
+        save_timeline(catalog_dir, final_timeline)
         _save_progress(progress_file, turn_dicts[-1]["turn_id"] if turn_dicts else "",
                        total, final_catalogs, dry_run=False, completed=True,
                        metadata={"failed_turns": all_failed_turns} if all_failed_turns else None)
@@ -3907,6 +3966,7 @@ def extract_semantic_batch(
 
     catalogs = load_catalogs(catalog_dir)
     events_list = load_events(catalog_dir)
+    timeline = load_timeline(catalog_dir)
 
     # Pre-seed the player character so it can be tracked every turn
     first_turn = turn_dicts[0]["turn_id"] if turn_dicts else None
@@ -3936,6 +3996,7 @@ def extract_semantic_batch(
                         # Reload catalogs since they may have been partially written
                         catalogs = load_catalogs(catalog_dir)
                         events_list = load_events(catalog_dir)
+                        timeline = load_timeline(catalog_dir)
         except (json.JSONDecodeError, KeyError):
             pass  # Corrupted progress file; start from beginning
 
@@ -3990,6 +4051,7 @@ def extract_semantic_batch(
                 catalogs, events_list, retry_disc_failed, retry_log = extract_and_merge(
                     retry_turn, catalogs, events_list, llm, min_confidence,
                     catalog_dir=catalog_dir,
+                    timeline=timeline,
                 )
                 if not dry_run:
                     _write_extraction_log(extraction_log_path, retry_log)
@@ -4029,6 +4091,7 @@ def extract_semantic_batch(
         if not dry_run:
             save_catalogs(catalog_dir, catalogs)
             save_events(catalog_dir, events_list)
+            save_timeline(catalog_dir, timeline)
         _print_retry_stats(llm)
         return
 
@@ -4046,6 +4109,7 @@ def extract_semantic_batch(
             catalogs, events_list, turn_failed, _turn_log = extract_and_merge(
                 turn, catalogs, events_list, llm, min_confidence,
                 catalog_dir=catalog_dir,
+                timeline=timeline,
             )
         except QuotaExhaustedError as e:
             print(f"\n  QUOTA EXHAUSTED at {turn_id}: {e}", file=sys.stderr)
@@ -4061,6 +4125,7 @@ def extract_semantic_batch(
             if not dry_run:
                 save_catalogs(catalog_dir, catalogs)
                 save_events(catalog_dir, events_list)
+                save_timeline(catalog_dir, timeline)
                 _write_extraction_log(extraction_log_path, {
                     "turn_id": turn_id,
                     "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
@@ -4093,6 +4158,7 @@ def extract_semantic_batch(
             if not dry_run:
                 save_catalogs(catalog_dir, catalogs)
                 save_events(catalog_dir, events_list)
+                save_timeline(catalog_dir, timeline)
 
         # Write per-turn extraction log (#217)
         if _turn_log and not dry_run:
@@ -4129,6 +4195,7 @@ def extract_semantic_batch(
             if not dry_run:
                 save_catalogs(catalog_dir, catalogs)
                 save_events(catalog_dir, events_list)
+                save_timeline(catalog_dir, timeline)
 
     # --- Final entity refresh — catch entities stale since last modulo checkpoint (#212) ---
     # Skip refresh if quota was exhausted — no further LLM calls (#215)
@@ -4206,7 +4273,7 @@ def extract_semantic_batch(
             f"{_PC_SKIP_COOLDOWN + _PC_RETRY_WINDOW} turns)",
         )
 
-    print(f"  Semantic extraction complete: {entities_after} entities, {events_after} events")
+    print(f"  Semantic extraction complete: {entities_after} entities, {events_after} events, {len(timeline)} temporal signals")
 
     # Report API retry statistics (#215)
     _print_retry_stats(llm)
@@ -4217,6 +4284,7 @@ def extract_semantic_batch(
         # is only meaningful during incremental single-turn extraction.
         save_catalogs(catalog_dir, catalogs)
         save_events(catalog_dir, events_list)
+        save_timeline(catalog_dir, timeline)
         _save_progress(progress_file, turn_dicts[-1]["turn_id"] if turn_dicts else "",
                        total, catalogs, dry_run=False, completed=True,
                        metadata={"failed_turns": failed_turns} if failed_turns else None)
@@ -4259,6 +4327,7 @@ def extract_semantic_single(
     extraction_log_path = os.path.join(framework_dir, "extraction-log.jsonl")
     catalogs = load_catalogs(catalog_dir)
     events_list = load_events(catalog_dir)
+    timeline = load_timeline(catalog_dir)
 
     # Pre-seed the player character so it can be tracked every turn
     _ensure_player_character(catalogs, turn_id)
@@ -4270,6 +4339,7 @@ def extract_semantic_single(
         catalogs, events_list, _turn_failed, _turn_log = extract_and_merge(
             turn, catalogs, events_list, llm, min_confidence,
             catalog_dir=catalog_dir,
+            timeline=timeline,
         )
     except Exception as e:
         _turn_log = {
@@ -4291,7 +4361,7 @@ def extract_semantic_single(
     _write_extraction_log(extraction_log_path, _turn_log)
 
     entities_total = sum(len(v) for v in catalogs.values())
-    print(f"  Catalog now has {entities_total} entities, {len(events_list)} events")
+    print(f"  Catalog now has {entities_total} entities, {len(events_list)} events, {len(timeline)} temporal signals")
 
     # Post-merge dormancy pass
     dormant_count = mark_dormant_relationships(catalogs, turn_id)
@@ -4300,6 +4370,7 @@ def extract_semantic_single(
 
     save_catalogs(catalog_dir, catalogs)
     save_events(catalog_dir, events_list)
+    save_timeline(catalog_dir, timeline)
 
 
 def _save_progress(


### PR DESCRIPTION
## Summary

Integrates the existing `temporal_extraction.py` pattern-based temporal signal extractor into the `semantic_extraction.py` pipeline as Phase 5. After event extraction, each turn's text and events are analyzed for season transitions, time-skip language, biological markers, and construction milestones. Signals are merged (with deduplication) into `framework/catalogs/timeline.json`, which is loaded alongside catalogs and events at pipeline startup.

## What changed

### Pipeline integration (`tools/semantic_extraction.py`)
- Import `temporal_extraction` functions (extract, merge, load, save)
- Add optional `timeline` parameter to `extract_and_merge()` — backward-compatible (None = skip temporal)
- **Phase 5**: After event extraction, call `extract_temporal_signals()` and `merge_temporal_signals()` per-turn
- Load timeline in batch, single-turn, and segmented modes
- Save timeline at every checkpoint, quota-exhaustion save, error save, and final save
- Add `_reconcile_timelines()` for segmented extraction — strips segment-local IDs and re-merges with dedup
- Extraction log now includes `temporal_ok`, `temporal_error`, and `new_temporal_signals` fields
- Summary output includes temporal signal count

### Tests
- 19 new tests in `tests/test_temporal_pipeline_integration.py` covering:
  - Pattern-based signal extraction (winter, spring, time-skip, no-signal)
  - Merge and dedup behavior
  - Real `extract_and_merge()` wiring with mocked LLM
  - Batch mode: timeline saved to disk, pre-existing timeline loaded
  - Single-turn mode: timeline saved to disk
  - Segmented mode: timeline reconciled across segments
  - `_reconcile_timelines()` edge cases (empty, dedup, distinct, missing key)
- Updated 5 existing mock functions in `test_checkpoint_persistence.py` to accept `**kwargs`
- Updated 4 existing mock functions in `test_extraction_log.py` to accept `**kwargs`

### Documentation
- `docs/architecture.md`: Updated pipeline description from four-agent to five-agent, added temporal extraction integration bullet, updated data flow diagram
- `docs/roadmap.md`: Updated timeline tracking section to reflect pipeline integration

## Design decisions

- **Optional parameter**: `timeline` defaults to `None` so legacy callers and tests are unaffected
- **Pattern-based only**: This integration uses the existing regex-based detection in `temporal_extraction.py`. The LLM-based temporal estimation template is not yet invoked — that can be added as a follow-up
- **In-place mutation**: Timeline is mutated in-place (same pattern as catalogs and events), avoiding a return-signature change
- **Segment reconciliation**: Each segment builds its own timeline; reconciliation strips local IDs and re-merges with dedup to handle overlapping signals

Closes #263
