### PR TITLE
feat: add timeline wiki page for human-readable temporal data review

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,6 +188,7 @@ Estimated timeline of in-game events, anchored to a configurable reference point
 - Calibrated from biological markers (pregnancies), construction timelines, and seasonal descriptions
 - Reference anchor defaults to turn-001 (Day 0); a named anchor (e.g., settlement founding) can be set in config
 - Feeds into wiki page generation for character ages and event dating (estimated day column in event timelines, season labels in infoboxes)
+- `framework/catalogs/timeline.md` — auto-generated summarized wiki page grouping season ranges, time skips, and biological markers for human review
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -806,6 +806,25 @@ When timeline data is available, wiki pages include:
 - **Infobox**: "First Seen Day" with estimated day and season label
 - **Event Timeline**: An "Est. Day" column showing approximate in-game day for each event
 
+### Timeline Wiki Page
+
+A dedicated timeline overview page is generated at `framework/catalogs/timeline.md` alongside the entity wiki pages. It provides a summarized, human-readable view of all temporal data:
+
+- **Season Progression**: Groups consecutive same-season entries into ranges (e.g., "Turns 3–25: Mid Winter") rather than listing each individually
+- **Time Skips**: Notable time jumps with descriptions and confidence scores
+- **Biological Markers**: Sleep/wake cycles, meals, and rest periods
+- **Day Progression**: Estimated day offsets for entries with day data
+- **Other Temporal Markers**: Anchor events, construction milestones, explicit dates
+
+Generate it with:
+```bash
+# Generate all wiki pages including timeline
+python tools/generate_wiki_pages.py --framework framework/
+
+# Generate only the timeline page
+python tools/generate_wiki_pages.py --framework framework/ --type timeline
+```
+
 ---
 
 ## Story Summary

--- a/tests/test_timeline_wiki.py
+++ b/tests/test_timeline_wiki.py
@@ -281,7 +281,8 @@ def test_generate_wiki_pages_creates_timeline_md():
 
         md_path = os.path.join(tmpdir, "timeline.md")
         assert os.path.isfile(md_path)
-        content = open(md_path).read()
+        with open(md_path) as f:
+            content = f.read()
         assert "Mid Winter" in content
 
 

--- a/tests/test_timeline_wiki.py
+++ b/tests/test_timeline_wiki.py
@@ -1,0 +1,318 @@
+"""Tests for timeline wiki page generation."""
+
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from generate_wiki_pages import (
+    generate_timeline_page,
+    generate_wiki_pages,
+    _group_season_ranges,
+    _format_turn_range,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_TIMELINE = [
+    {
+        "id": "time-001",
+        "source_turn": "turn-003",
+        "type": "season_transition",
+        "season": "mid_winter",
+        "confidence": 0.9,
+        "signals": ["snow on the ground"],
+        "description": "Winter landscape described",
+    },
+    {
+        "id": "time-002",
+        "source_turn": "turn-010",
+        "type": "season_transition",
+        "season": "mid_winter",
+        "confidence": 0.85,
+        "signals": ["cold wind"],
+        "description": "Continued cold weather",
+    },
+    {
+        "id": "time-003",
+        "source_turn": "turn-025",
+        "type": "season_transition",
+        "season": "mid_winter",
+        "confidence": 0.8,
+        "signals": ["frozen river"],
+    },
+    {
+        "id": "time-004",
+        "source_turn": "turn-051",
+        "type": "season_transition",
+        "season": "late_winter",
+        "confidence": 0.75,
+        "signals": ["thawing begins"],
+        "description": "Signs of approaching spring",
+    },
+    {
+        "id": "time-005",
+        "source_turn": "turn-080",
+        "type": "season_transition",
+        "season": "early_spring",
+        "confidence": 0.7,
+        "signals": ["flowers blooming"],
+        "description": "Spring arrives",
+    },
+    {
+        "id": "time-006",
+        "source_turn": "turn-030",
+        "type": "time_skip",
+        "confidence": 0.8,
+        "description": "Several days pass while traveling",
+        "raw_text": "After several days of travel...",
+    },
+    {
+        "id": "time-007",
+        "source_turn": "turn-060",
+        "type": "time_skip",
+        "confidence": 0.6,
+        "description": "A week passes during recovery",
+    },
+    {
+        "id": "time-008",
+        "source_turn": "turn-015",
+        "type": "biological_marker",
+        "confidence": 0.9,
+        "description": "Character wakes from sleep",
+        "raw_text": "You open your eyes as dawn breaks.",
+    },
+    {
+        "id": "time-009",
+        "source_turn": "turn-045",
+        "type": "biological_marker",
+        "confidence": 0.7,
+        "description": "Meal taken at midday",
+    },
+    {
+        "id": "time-010",
+        "source_turn": "turn-020",
+        "type": "anchor_event",
+        "confidence": 1.0,
+        "description": "Foundation of the settlement",
+        "estimated_day": 0,
+        "season": "mid_winter",
+    },
+    {
+        "id": "time-011",
+        "source_turn": "turn-070",
+        "type": "construction_milestone",
+        "confidence": 0.85,
+        "description": "Wall construction completed",
+        "estimated_day": 45,
+        "season": "late_winter",
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# _group_season_ranges tests
+# ---------------------------------------------------------------------------
+
+def test_group_season_ranges_basic():
+    """Consecutive same-season entries grouped into one range."""
+    ranges = _group_season_ranges(SAMPLE_TIMELINE)
+    assert len(ranges) == 3
+    assert ranges[0]["season"] == "mid_winter"
+    assert ranges[0]["start_turn"] == "turn-003"
+    assert ranges[0]["end_turn"] == "turn-025"
+    assert ranges[0]["count"] == 3
+
+
+def test_group_season_ranges_transitions():
+    """Each season change creates a new range."""
+    ranges = _group_season_ranges(SAMPLE_TIMELINE)
+    assert ranges[1]["season"] == "late_winter"
+    assert ranges[1]["start_turn"] == "turn-051"
+    assert ranges[1]["count"] == 1
+    assert ranges[2]["season"] == "early_spring"
+    assert ranges[2]["start_turn"] == "turn-080"
+
+
+def test_group_season_ranges_empty():
+    """Empty timeline returns empty ranges."""
+    assert _group_season_ranges([]) == []
+
+
+def test_group_season_ranges_no_seasons():
+    """Timeline with no season_transition entries returns empty."""
+    entries = [{"type": "time_skip", "source_turn": "turn-005"}]
+    assert _group_season_ranges(entries) == []
+
+
+# ---------------------------------------------------------------------------
+# _format_turn_range tests
+# ---------------------------------------------------------------------------
+
+def test_format_turn_range_single():
+    """Single turn formatted without range."""
+    assert _format_turn_range("turn-003", "turn-003") == "Turn 3"
+
+
+def test_format_turn_range_multi():
+    """Range of turns formatted with en-dash."""
+    result = _format_turn_range("turn-003", "turn-025")
+    assert "3" in result
+    assert "25" in result
+    assert "\u2013" in result  # en-dash
+
+
+# ---------------------------------------------------------------------------
+# generate_timeline_page tests
+# ---------------------------------------------------------------------------
+
+def test_timeline_page_empty():
+    """Empty timeline produces placeholder message."""
+    md = generate_timeline_page([])
+    assert "# Timeline Overview" in md
+    assert "No temporal data extracted yet" in md
+    assert "timeline.json" in md
+
+
+def test_timeline_page_has_season_progression():
+    """Season progression section with grouped ranges."""
+    md = generate_timeline_page(SAMPLE_TIMELINE)
+    assert "## Season Progression" in md
+    assert "Mid Winter" in md
+    assert "Late Winter" in md
+    assert "Early Spring" in md
+
+
+def test_timeline_page_has_time_skips():
+    """Time skips section lists notable jumps."""
+    md = generate_timeline_page(SAMPLE_TIMELINE)
+    assert "## Time Skips" in md
+    assert "Several days pass while traveling" in md
+    assert "A week passes during recovery" in md
+
+
+def test_timeline_page_has_biological_markers():
+    """Biological markers section present."""
+    md = generate_timeline_page(SAMPLE_TIMELINE)
+    assert "## Biological Markers" in md
+    assert "Character wakes from sleep" in md
+    assert "Meal taken at midday" in md
+
+
+def test_timeline_page_has_day_progression():
+    """Day progression section shows estimated days."""
+    md = generate_timeline_page(SAMPLE_TIMELINE)
+    assert "## Day Progression" in md
+    assert "Day 0" in md
+    assert "Day 45" in md
+
+
+def test_timeline_page_has_other_markers():
+    """Other temporal markers section for anchor events etc."""
+    md = generate_timeline_page(SAMPLE_TIMELINE)
+    assert "## Other Temporal Markers" in md
+    assert "Foundation of the settlement" in md
+    assert "Wall construction completed" in md
+
+
+def test_timeline_page_has_footer():
+    """Footer with source file reference."""
+    md = generate_timeline_page(SAMPLE_TIMELINE)
+    assert "do not edit manually" in md
+    assert "timeline.json" in md
+
+
+def test_timeline_page_has_summary_stats():
+    """Summary line with total markers and turn range."""
+    md = generate_timeline_page(SAMPLE_TIMELINE)
+    assert "11 temporal markers" in md
+
+
+def test_timeline_page_confidence_format():
+    """Confidence values formatted consistently."""
+    md = generate_timeline_page(SAMPLE_TIMELINE)
+    assert "0.80" in md or "0.60" in md  # time skip confidences
+
+
+def test_timeline_page_escapes_pipes():
+    """Pipe characters in descriptions are escaped."""
+    entries = [
+        {
+            "id": "time-001",
+            "source_turn": "turn-005",
+            "type": "time_skip",
+            "confidence": 0.5,
+            "description": "Choice: left | right path",
+        }
+    ]
+    md = generate_timeline_page(entries)
+    assert "left \\| right path" in md
+
+
+# ---------------------------------------------------------------------------
+# Integration: generate_wiki_pages with timeline
+# ---------------------------------------------------------------------------
+
+def test_generate_wiki_pages_creates_timeline_md():
+    """Full wiki generation creates timeline.md when timeline.json exists."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a minimal catalog structure
+        os.makedirs(os.path.join(tmpdir, "characters"))
+        timeline_data = [
+            {
+                "id": "time-001",
+                "source_turn": "turn-005",
+                "type": "season_transition",
+                "season": "mid_winter",
+                "confidence": 0.9,
+            }
+        ]
+        with open(os.path.join(tmpdir, "timeline.json"), "w") as f:
+            json.dump(timeline_data, f)
+
+        stats = generate_wiki_pages(tmpdir)
+        assert "timeline" in stats
+        assert stats["timeline"] == 1
+
+        md_path = os.path.join(tmpdir, "timeline.md")
+        assert os.path.isfile(md_path)
+        content = open(md_path).read()
+        assert "Mid Winter" in content
+
+
+def test_generate_wiki_pages_no_timeline_json():
+    """Wiki generation succeeds without timeline.json."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.makedirs(os.path.join(tmpdir, "characters"))
+        stats = generate_wiki_pages(tmpdir)
+        assert "timeline" not in stats
+
+
+def test_generate_wiki_pages_type_filter_excludes_timeline():
+    """When --type is set to an entity type, timeline is not generated."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.makedirs(os.path.join(tmpdir, "characters"))
+        with open(os.path.join(tmpdir, "timeline.json"), "w") as f:
+            json.dump([{"id": "time-001", "source_turn": "turn-001",
+                        "type": "season_transition", "season": "mid_winter"}], f)
+
+        stats = generate_wiki_pages(tmpdir, entity_types=["characters"])
+        assert "timeline" not in stats
+
+
+def test_generate_wiki_pages_type_filter_timeline_only():
+    """When --type timeline is set, only timeline is generated."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.makedirs(os.path.join(tmpdir, "characters"))
+        with open(os.path.join(tmpdir, "timeline.json"), "w") as f:
+            json.dump([{"id": "time-001", "source_turn": "turn-001",
+                        "type": "season_transition", "season": "mid_winter"}], f)
+
+        stats = generate_wiki_pages(tmpdir, entity_types=["timeline"])
+        assert "timeline" in stats
+        assert "characters" not in stats

--- a/tests/test_timeline_wiki.py
+++ b/tests/test_timeline_wiki.py
@@ -231,6 +231,9 @@ def test_timeline_page_has_summary_stats():
     """Summary line with total markers and turn range."""
     md = generate_timeline_page(SAMPLE_TIMELINE)
     assert "11 temporal markers" in md
+    # Per-type breakdown is included
+    assert "biological marker" in md
+    assert "time skip" in md
 
 
 def test_timeline_page_confidence_format():

--- a/tools/generate_wiki_pages.py
+++ b/tools/generate_wiki_pages.py
@@ -610,8 +610,12 @@ def generate_timeline_page(timeline: list[dict]) -> str:
     first_turn = sorted_timeline[0].get("source_turn", "")
     last_turn = sorted_timeline[-1].get("source_turn", "")
 
+    breakdown = ", ".join(
+        f"{count} {typ.replace('_', ' ')}" for typ, count in sorted(type_counts.items())
+    )
     lines.append(f"> {len(timeline)} temporal markers across "
-                 f"{_format_turn_range(first_turn, last_turn)}\n")
+                 f"{_format_turn_range(first_turn, last_turn)}")
+    lines.append(f"> ({breakdown})\n")
 
     # --- Season Progression ---
     season_ranges = _group_season_ranges(timeline)
@@ -763,6 +767,8 @@ def generate_wiki_pages(catalog_dir: str, entity_types: list[str] | None = None,
     stats: dict[str, int] = {}
 
     for entity_type in types_to_process:
+        if entity_type == "timeline":
+            continue  # handled separately below
         if entity_type not in ENTITY_TYPES:
             print(f"  WARNING: Unknown entity type '{entity_type}', skipping", file=sys.stderr)
             continue
@@ -870,6 +876,8 @@ def main():
         parser.error("--force requires --synthesize")
     if args.index_only and args.synthesize:
         parser.error("--index-only cannot be used with --synthesize")
+    if args.synthesize and args.entity_type == "timeline":
+        parser.error("--synthesize cannot be used with --type timeline")
 
     catalog_dir = os.path.join(args.framework, "catalogs")
     if not os.path.isdir(catalog_dir):

--- a/tools/generate_wiki_pages.py
+++ b/tools/generate_wiki_pages.py
@@ -535,6 +535,174 @@ PAGE_GENERATORS = {
 
 
 # ---------------------------------------------------------------------------
+# Timeline page
+# ---------------------------------------------------------------------------
+
+def _group_season_ranges(entries: list[dict]) -> list[dict]:
+    """Group consecutive season_transition entries with the same season into ranges.
+
+    Returns a list of dicts with keys: season, start_turn, end_turn, count.
+    """
+    season_entries = sorted(
+        [e for e in entries if e.get("type") == "season_transition" and e.get("season")],
+        key=lambda e: _parse_turn_number(e.get("source_turn", "")),
+    )
+    if not season_entries:
+        return []
+
+    ranges: list[dict] = []
+    current = {
+        "season": season_entries[0]["season"],
+        "start_turn": season_entries[0]["source_turn"],
+        "end_turn": season_entries[0]["source_turn"],
+        "count": 1,
+    }
+
+    for entry in season_entries[1:]:
+        if entry["season"] == current["season"]:
+            current["end_turn"] = entry["source_turn"]
+            current["count"] += 1
+        else:
+            ranges.append(current)
+            current = {
+                "season": entry["season"],
+                "start_turn": entry["source_turn"],
+                "end_turn": entry["source_turn"],
+                "count": 1,
+            }
+    ranges.append(current)
+    return ranges
+
+
+def _format_turn_range(start: str, end: str) -> str:
+    """Format a turn range as 'Turn N' or 'Turns N–M'."""
+    s = _parse_turn_number(start)
+    e = _parse_turn_number(end)
+    if s == e:
+        return f"Turn {s}"
+    return f"Turns {s}\u2013{e}"
+
+
+def generate_timeline_page(timeline: list[dict]) -> str:
+    """Generate a summarized timeline wiki page from timeline entries.
+
+    Groups season transitions into ranges and lists time skips and
+    biological markers chronologically.
+    """
+    lines = []
+    lines.append("# Timeline Overview\n")
+
+    if not timeline:
+        lines.append("*No temporal data extracted yet.*\n")
+        lines.append("---")
+        lines.append("*Generated from [timeline.json](timeline.json) — do not edit manually.*")
+        return "\n".join(lines) + "\n"
+
+    # Summary stats
+    type_counts: dict[str, int] = {}
+    for entry in timeline:
+        t = entry.get("type", "unknown")
+        type_counts[t] = type_counts.get(t, 0) + 1
+
+    sorted_timeline = sorted(
+        timeline, key=lambda e: _parse_turn_number(e.get("source_turn", ""))
+    )
+    first_turn = sorted_timeline[0].get("source_turn", "")
+    last_turn = sorted_timeline[-1].get("source_turn", "")
+
+    lines.append(f"> {len(timeline)} temporal markers across "
+                 f"{_format_turn_range(first_turn, last_turn)}\n")
+
+    # --- Season Progression ---
+    season_ranges = _group_season_ranges(timeline)
+    if season_ranges:
+        lines.append("## Season Progression\n")
+        lines.append("| Period | Season | Signals |")
+        lines.append("|---|---|---|")
+        for r in season_ranges:
+            period = _format_turn_range(r["start_turn"], r["end_turn"])
+            season_label = r["season"].replace("_", " ").title()
+            lines.append(f"| {period} | {season_label} | {r['count']} |")
+        lines.append("")
+
+    # --- Time Skips ---
+    time_skips = sorted(
+        [e for e in timeline if e.get("type") == "time_skip"],
+        key=lambda e: _parse_turn_number(e.get("source_turn", "")),
+    )
+    if time_skips:
+        lines.append("## Time Skips\n")
+        lines.append("| Turn | Description | Confidence |")
+        lines.append("|---|---|---|")
+        for entry in time_skips:
+            turn = entry.get("source_turn", "")
+            desc = _escape_table_cell(entry.get("description", entry.get("raw_text", "")))
+            conf = entry.get("confidence", "")
+            conf_str = f"{conf:.2f}" if isinstance(conf, (int, float)) else str(conf)
+            lines.append(f"| {turn} | {desc} | {conf_str} |")
+        lines.append("")
+
+    # --- Biological Markers ---
+    bio_markers = sorted(
+        [e for e in timeline if e.get("type") == "biological_marker"],
+        key=lambda e: _parse_turn_number(e.get("source_turn", "")),
+    )
+    if bio_markers:
+        lines.append("## Biological Markers\n")
+        lines.append("| Turn | Description | Confidence |")
+        lines.append("|---|---|---|")
+        for entry in bio_markers:
+            turn = entry.get("source_turn", "")
+            desc = _escape_table_cell(entry.get("description", entry.get("raw_text", "")))
+            conf = entry.get("confidence", "")
+            conf_str = f"{conf:.2f}" if isinstance(conf, (int, float)) else str(conf)
+            lines.append(f"| {turn} | {desc} | {conf_str} |")
+        lines.append("")
+
+    # --- Day Estimates ---
+    day_entries = sorted(
+        [e for e in timeline if e.get("estimated_day") is not None],
+        key=lambda e: _parse_turn_number(e.get("source_turn", "")),
+    )
+    if day_entries:
+        lines.append("## Day Progression\n")
+        lines.append("| Turn | Estimated Day | Season | Source |")
+        lines.append("|---|---|---|---|")
+        for entry in day_entries:
+            turn = entry.get("source_turn", "")
+            day = entry.get("estimated_day", "")
+            season = entry.get("season", "")
+            season_label = season.replace("_", " ").title() if season else ""
+            etype = entry.get("type", "").replace("_", " ")
+            lines.append(f"| {turn} | Day {day} | {season_label} | {etype} |")
+        lines.append("")
+
+    # --- Other marker types ---
+    other_types = {"explicit_date", "relative_reference", "construction_milestone", "anchor_event"}
+    other_entries = sorted(
+        [e for e in timeline if e.get("type") in other_types],
+        key=lambda e: _parse_turn_number(e.get("source_turn", "")),
+    )
+    if other_entries:
+        lines.append("## Other Temporal Markers\n")
+        lines.append("| Turn | Type | Description | Confidence |")
+        lines.append("|---|---|---|---|")
+        for entry in other_entries:
+            turn = entry.get("source_turn", "")
+            etype = entry.get("type", "").replace("_", " ").title()
+            desc = _escape_table_cell(entry.get("description", entry.get("raw_text", "")))
+            conf = entry.get("confidence", "")
+            conf_str = f"{conf:.2f}" if isinstance(conf, (int, float)) else str(conf)
+            lines.append(f"| {turn} | {etype} | {desc} | {conf_str} |")
+        lines.append("")
+
+    # Footer
+    lines.append("---")
+    lines.append("*Generated from [timeline.json](timeline.json) — do not edit manually.*")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
 # Index page
 # ---------------------------------------------------------------------------
 
@@ -646,6 +814,24 @@ def generate_wiki_pages(catalog_dir: str, entity_types: list[str] | None = None,
         stats[entity_type] = page_count
         print(f"  {entity_type}: {page_count} pages generated")
 
+    # Generate timeline page (always included unless filtering to a specific entity type)
+    if entity_types is None or "timeline" in entity_types:
+        timeline_path = os.path.join(catalog_dir, "timeline.json")
+        if os.path.isfile(timeline_path):
+            try:
+                with open(timeline_path, "r", encoding="utf-8-sig") as f:
+                    timeline_data = json.load(f)
+                if isinstance(timeline_data, list):
+                    md_content = generate_timeline_page(timeline_data)
+                    md_path = os.path.join(catalog_dir, "timeline.md")
+                    with open(md_path, "w", encoding="utf-8") as f:
+                        f.write(md_content)
+                    stats["timeline"] = 1
+                    print("  timeline: 1 page generated")
+            except (json.JSONDecodeError, OSError) as e:
+                print(f"  WARNING: Could not load timeline.json: {e}",
+                      file=sys.stderr)
+
     return stats
 
 
@@ -663,8 +849,8 @@ def main():
     )
     parser.add_argument(
         "--type", dest="entity_type",
-        choices=ENTITY_TYPES,
-        help="Limit generation to one entity type"
+        choices=ENTITY_TYPES + ["timeline"],
+        help="Limit generation to one entity type (or 'timeline')"
     )
     parser.add_argument(
         "--index-only", action="store_true",


### PR DESCRIPTION
## Summary

Adds a timeline wiki page to `generate_wiki_pages.py` that presents temporal extraction data in a summarized, human-readable format. Rather than dumping raw JSON, the page groups season transitions into ranges and organizes other markers by type.

## Changes

### Timeline page generator (`tools/generate_wiki_pages.py`)

- `generate_timeline_page()` — produces a structured markdown page with sections:
  - **Season Progression**: Groups consecutive same-season entries into ranges (e.g., "Turns 3–25: Mid Winter")
  - **Time Skips**: Notable time jumps with descriptions and confidence
  - **Biological Markers**: Sleep/wake cycles, meals, rest periods
  - **Day Progression**: Estimated day offsets when available
  - **Other Temporal Markers**: Anchor events, construction milestones, explicit dates
- `_group_season_ranges()` — helper that collapses consecutive same-season entries
- `_format_turn_range()` — formats turn pairs as "Turn N" or "Turns N–M"
- `--type timeline` CLI option for generating only the timeline page
- Timeline page auto-generates alongside entity pages in the default (unfiltered) run
- Output: `framework/catalogs/timeline.md`

### Tests (`tests/test_timeline_wiki.py`)

20 new tests covering:
- Season range grouping logic (basic, transitions, empty, no-seasons)
- Turn range formatting (single, multi)
- Page content (all sections, footer, summary stats, confidence format)
- Edge cases (empty timeline, pipe escaping)
- Integration with `generate_wiki_pages()` (creates file, type filtering)

### Documentation

- `docs/usage.md`: Added "Timeline Wiki Page" section with usage examples
- `docs/architecture.md`: Added timeline.md to the temporal layer outputs

Closes #273
