### PR TITLE
docs: add hardware deployment guide for OpenVINO B70 and RTX 4070

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,6 +47,7 @@ Semantic extraction uses an LLM to identify entities, relationships, and events 
 |---|---|---|---|---|
 | `qwen2.5:3b` | 3B | Q4_K_M | ~2.5 GB | Poor — 0% item recall, frequent hallucinations, ID format violations |
 | `qwen2.5:14b` | 14B | Q4_K_M | ~9 GB | Good — reliable entity classification, items extracted, acceptable coreference |
+| `qwen3-8b-int4-ov` (OpenVINO) | 8B | INT4 sym | ~4.5 GB | Good — reliable JSON, needs `skip_response_format`, thinking output parsed automatically |
 | `gemini-2.5-flash` (Google) | Unknown | N/A | Cloud | Very good — fast, low cost (~$0.30/run), 1M token context, strong JSON mode |
 | `gpt-4o` (OpenAI) | Unknown | N/A | Cloud | Best — accurate structured JSON, strong coreference, minimal hallucination |
 
@@ -58,6 +59,7 @@ Semantic extraction uses an LLM to identify entities, relationships, and events 
 | 12 GB | Up to 14B |
 | 16 GB | Up to 22B |
 | 24 GB | Up to 32B |
+| 31 GB (Arc Pro B70) | Up to 70B (INT4 sym, OpenVINO) |
 
 ### Known Limitations of Small Models (<7B)
 
@@ -173,6 +175,183 @@ restarts.
 
 See `config/ollama/README.md` for details on adding variants for other base
 models.
+
+### Using OpenVINO (Intel Arc / Xeon GPUs)
+
+OpenVINO's `ContinuousBatchingPipeline` provides high-throughput inference on
+Intel Arc discrete GPUs and Xeon CPUs. This section documents tested hardware
+configurations and the concurrency constraints that matter for extraction.
+
+#### Tested Hardware
+
+| GPU | VRAM | Max Model | Batch Perf (INT4) | Notes |
+|---|---|---|---|---|
+| Intel Arc Pro B70 | 31 GB | 70B INT4 | ~61 tok/s (batch=1), ~204 agg (batch=4) | Server-class; 8 GB KV cache fits large batches |
+| NVIDIA RTX 4070 | 12 GB | 14B Q4 | ~40-50 tok/s (llama-server, batch=1) | Consumer-class; use llama-server (`-np 4`) or Ollama |
+
+#### Server Setup (Intel Arc + OpenVINO)
+
+The extraction pipeline connects to any OpenAI-compatible endpoint. For Intel
+Arc GPUs, serve the model with OpenVINO's `ContinuousBatchingPipeline` behind
+a FastAPI wrapper:
+
+```bash
+# On the inference server (e.g. Ubuntu + Intel Arc Pro B70)
+pip install openvino openvino-genai fastapi uvicorn
+
+# Export model to OpenVINO IR format (one-time)
+optimum-cli export openvino --model Qwen/Qwen3-8B --weight-format int4_sym \
+    --trust-remote-code ./models/qwen3-8b-int4-ov
+
+# Start the server
+python serve_openvino.py --model ./models/qwen3-8b-int4-ov --port 8000
+```
+
+Configure `config/llm.json` on the client machine:
+
+```json
+{
+  "provider": "openai",
+  "base_url": "http://<server-ip>:8000/v1",
+  "model": "qwen3-8b-int4-ov",
+  "temperature": 0.3,
+  "max_tokens": 4096,
+  "discovery_max_tokens": 8192,
+  "pc_max_tokens": 8192,
+  "timeout_seconds": 300,
+  "retry_attempts": 3,
+  "parallel_workers": 4,
+  "skip_response_format": true,
+  "context_length": 32768,
+  "checkpoint_interval": 25
+}
+```
+
+Key settings for OpenVINO servers:
+
+- **`skip_response_format: true`** — OpenVINO's pipeline does not support
+  `response_format={"type": "json_object"}`. The extraction pipeline parses
+  JSON from freeform output anyway.
+- **`parallel_workers: 4`** — Matches the server's effective batch throughput.
+  The pipeline fires detail, PC, relationship, and event extraction in parallel
+  after discovery completes.
+- **`temperature: 0.3`** — Avoid 0.0 with qwen3 models (can cause empty
+  responses or infinite thinking loops).
+
+#### Server Batching Behavior
+
+The OpenVINO `ContinuousBatchingPipeline` processes requests in atomic batches:
+
+1. Incoming requests queue until `BATCH_WAIT_MS` elapses or `MAX_BATCH_SIZE`
+   requests accumulate
+2. `pipeline.generate()` runs the entire batch to completion (blocking)
+3. While a batch is generating, new requests queue in memory for the next batch
+
+This means per-request throughput **decreases** as batch size grows (total VRAM
+bandwidth is shared), but aggregate throughput increases:
+
+| Batch Size | Per-request tok/s | Aggregate tok/s | Time for 8192 tokens |
+|---|---|---|---|
+| 1 | ~61 | ~61 | 134s |
+| 2 | ~65 | ~122 | 126s |
+| 4 | ~51 | ~204 | 161s |
+| 8 | ~24 | ~194 | 341s |
+
+#### Concurrency Rules
+
+The extraction pipeline has two levels of parallelism that interact:
+
+- **External workers** (`--workers` in `retry_failed_turns.py`): number of
+  turns processed simultaneously
+- **Internal workers** (`parallel_workers` in `config/llm.json`): concurrent
+  LLM calls within a single turn (detail + PC + relationships + events)
+
+Total concurrent requests = external workers × internal parallel_workers.
+
+**Safe configurations (timeout_seconds=300):**
+
+| External | Internal | Max Concurrent | Discovery Time (8192 tok) | Safe? |
+|---|---|---|---|---|
+| 1 | 4 | 4 | 144s (8192/57) | **Yes** (proven) |
+| 2 | 4 | 8 | 341s (8192/24) | **No** — exceeds timeout |
+| 4 | 4 | 16 | queue death | **No** — cascading failures |
+| 2 | 2 | 4 | 144s | Marginal (untested) |
+| 4 | 1 | 4 | 144s | Loses batching benefit |
+
+**Rule of thumb**: Keep total concurrent requests ≤ 4 for discovery-heavy
+workloads (8192 tokens). For detail-only work (4096 tokens), up to 8
+concurrent is safe.
+
+#### RTX 4070 Configuration (llama-server)
+
+For an RTX 4070 (12 GB VRAM), use llama-server (llama.cpp) with a 14B model
+at Q4 quantization. llama-server supports true parallel slot processing
+(`-np 4`), unlike Ollama which queues concurrent requests on consumer GPUs.
+
+```bash
+# Start llama-server with 4 parallel slots and 8K context per slot
+llama-server -m qwen2.5-14b-q4_k_m.gguf \
+    -ngl 99 -np 4 -c 32768 --port 8080
+```
+
+Configure `config/llm.json`:
+
+```json
+{
+  "provider": "openai",
+  "base_url": "http://localhost:8080/v1",
+  "model": "qwen2.5-14b",
+  "temperature": 0.0,
+  "max_tokens": 4096,
+  "pc_max_tokens": 8192,
+  "context_length": 32768,
+  "timeout_seconds": 120,
+  "parallel_workers": 4,
+  "batch_delay_ms": 0,
+  "skip_response_format": true
+}
+```
+
+Key differences from the B70 config:
+
+- **`parallel_workers: 4`** — llama-server with `-np 4` handles 4 concurrent
+  requests in parallel slots (unlike Ollama which serializes them).
+- **`context_length: 32768`** — Total context shared across 4 slots
+  (8K effective per slot). Fits within 12 GB at Q4.
+- **`batch_delay_ms: 0`** — No delay needed; the server manages slot
+  scheduling internally.
+- **`timeout_seconds: 120`** — Sufficient for single-slot generation speeds.
+
+> **Why llama-server over Ollama?** Ollama wraps llama.cpp but does not expose
+> parallel slot scheduling to the OpenAI-compatible endpoint. With Ollama,
+> `parallel_workers: 4` in config sends 4 requests that queue serially.
+> With llama-server `-np 4`, all 4 requests process simultaneously in
+> dedicated KV-cache slots, achieving ~3-4× throughput for the parallel
+> phases of extraction.
+
+> **qwen3 thinking models**: If using qwen3 on llama-server, thinking mode
+> cannot be fully disabled via the chat template — the server generates
+> `<think>` blocks regardless. The extraction pipeline's JSON parser handles
+> this automatically (strips thinking content, extracts JSON from fenced
+> blocks). Use `skip_response_format: true` and `temperature: 0.3`.
+
+#### Retrying Failed Turns
+
+After a full extraction run, some turns may fail due to transient timeouts or
+server hiccups. Use the retry tool:
+
+```bash
+# Preview what would be retried
+python tools/retry_failed_turns.py --session sessions/my-session --dry-run
+
+# Execute (sequential by default — safe for any server)
+python tools/retry_failed_turns.py --session sessions/my-session
+```
+
+The tool reads `framework/extraction-log.jsonl` to identify turns where
+`discovery_ok=False`, then re-extracts them. Results are merged into the
+existing catalogs. The tool is idempotent — re-running it skips turns that
+have since succeeded.
 
 | Field | Description |
 |---|---|

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -197,14 +197,15 @@ a FastAPI wrapper:
 
 ```bash
 # On the inference server (e.g. Ubuntu + Intel Arc Pro B70)
-pip install openvino openvino-genai fastapi uvicorn
+pip install openvino openvino-genai optimum[openvino] fastapi uvicorn
 
 # Export model to OpenVINO IR format (one-time)
 optimum-cli export openvino --model Qwen/Qwen3-8B --weight-format int4_sym \
     --trust-remote-code ./models/qwen3-8b-int4-ov
 
-# Start the server
-python serve_openvino.py --model ./models/qwen3-8b-int4-ov --port 8000
+# Start the server (use any OpenAI-compatible wrapper around ContinuousBatchingPipeline)
+# For example, using openvino_genai's built-in server or a custom FastAPI wrapper:
+python -m openvino_genai.server --model ./models/qwen3-8b-int4-ov --port 8000
 ```
 
 Configure `config/llm.json` on the client machine:

--- a/tests/test_retry_failed_turns.py
+++ b/tests/test_retry_failed_turns.py
@@ -1,0 +1,202 @@
+"""Tests for tools/retry_failed_turns.py (#287).
+
+Covers:
+- load_failed_turns() extraction log parsing
+- load_turn_dicts() transcript header stripping
+- merge_parallel_results() entity/event/timeline merging
+"""
+import json
+import os
+import sys
+import tempfile
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+# Ensure openai mock exists
+if "openai" not in sys.modules:
+    _mock_openai = MagicMock()
+    _mock_openai.OpenAI = MagicMock
+    sys.modules["openai"] = _mock_openai
+
+from retry_failed_turns import load_failed_turns, load_turn_dicts, merge_parallel_results
+
+
+# ---------------------------------------------------------------------------
+# load_failed_turns tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFailedTurns:
+    """Verify extraction log parsing for failed turn identification."""
+
+    def test_identifies_failed_turns(self, tmp_path):
+        log_path = str(tmp_path / "extraction-log.jsonl")
+        with open(log_path, "w") as f:
+            f.write(json.dumps({"turn_id": "turn-001", "discovery_ok": True}) + "\n")
+            f.write(json.dumps({"turn_id": "turn-002", "discovery_ok": False}) + "\n")
+            f.write(json.dumps({"turn_id": "turn-003", "discovery_ok": True}) + "\n")
+
+        result = load_failed_turns(log_path)
+        assert result == ["turn-002"]
+
+    def test_success_after_failure_clears_failed(self, tmp_path):
+        """If a turn fails then later succeeds, it's not in the failed list."""
+        log_path = str(tmp_path / "extraction-log.jsonl")
+        with open(log_path, "w") as f:
+            f.write(json.dumps({"turn_id": "turn-005", "discovery_ok": False}) + "\n")
+            f.write(json.dumps({"turn_id": "turn-005", "discovery_ok": True}) + "\n")
+
+        result = load_failed_turns(log_path)
+        assert result == []
+
+    def test_missing_discovery_ok_not_treated_as_failure(self, tmp_path):
+        """Records without discovery_ok field are skipped (not treated as failure)."""
+        log_path = str(tmp_path / "extraction-log.jsonl")
+        with open(log_path, "w") as f:
+            f.write(json.dumps({"turn_id": "turn-010", "some_other_field": True}) + "\n")
+
+        result = load_failed_turns(log_path)
+        assert result == []
+
+    def test_empty_turn_id_skipped(self, tmp_path):
+        """Records with empty turn_id are ignored."""
+        log_path = str(tmp_path / "extraction-log.jsonl")
+        with open(log_path, "w") as f:
+            f.write(json.dumps({"turn_id": "", "discovery_ok": False}) + "\n")
+
+        result = load_failed_turns(log_path)
+        assert result == []
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        result = load_failed_turns(str(tmp_path / "nonexistent.jsonl"))
+        assert result == []
+
+    def test_malformed_json_lines_skipped(self, tmp_path):
+        log_path = str(tmp_path / "extraction-log.jsonl")
+        with open(log_path, "w") as f:
+            f.write("not json\n")
+            f.write(json.dumps({"turn_id": "turn-020", "discovery_ok": False}) + "\n")
+
+        result = load_failed_turns(log_path)
+        assert result == ["turn-020"]
+
+
+# ---------------------------------------------------------------------------
+# load_turn_dicts tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTurnDicts:
+    """Verify transcript parsing and header stripping."""
+
+    def test_strips_h2_header(self, tmp_path):
+        """## header lines are stripped."""
+        transcript_dir = tmp_path / "transcript"
+        transcript_dir.mkdir()
+        (transcript_dir / "turn-001-dm.md").write_text(
+            "## turn-001 — DM\n\nThe forest grows dark.\n", encoding="utf-8"
+        )
+        result = load_turn_dicts(str(tmp_path))
+        assert len(result) == 1
+        assert result[0]["text"] == "The forest grows dark."
+        assert result[0]["turn_id"] == "turn-001"
+        assert result[0]["speaker"] == "dm"
+
+    def test_strips_h1_header(self, tmp_path):
+        """# header lines are also stripped."""
+        transcript_dir = tmp_path / "transcript"
+        transcript_dir.mkdir()
+        (transcript_dir / "turn-050-player.md").write_text(
+            "# turn-050 — PLAYER\n\nI attack the goblin.\n", encoding="utf-8"
+        )
+        result = load_turn_dicts(str(tmp_path))
+        assert len(result) == 1
+        assert result[0]["text"] == "I attack the goblin."
+        assert result[0]["speaker"] == "player"
+
+    def test_strips_blank_line_after_header(self, tmp_path):
+        """Blank line following header is also stripped."""
+        transcript_dir = tmp_path / "transcript"
+        transcript_dir.mkdir()
+        (transcript_dir / "turn-002-dm.md").write_text(
+            "## turn-002 — DM\n\nLine 1\nLine 2\n", encoding="utf-8"
+        )
+        result = load_turn_dicts(str(tmp_path))
+        assert result[0]["text"] == "Line 1\nLine 2"
+
+    def test_no_header_preserves_content(self, tmp_path):
+        """Text without a header line is returned as-is."""
+        transcript_dir = tmp_path / "transcript"
+        transcript_dir.mkdir()
+        (transcript_dir / "turn-003-dm.md").write_text(
+            "Just some content here.\n", encoding="utf-8"
+        )
+        result = load_turn_dicts(str(tmp_path))
+        assert result[0]["text"] == "Just some content here."
+
+
+# ---------------------------------------------------------------------------
+# merge_parallel_results tests
+# ---------------------------------------------------------------------------
+
+
+class TestMergeParallelResults:
+    """Verify merge logic for parallel extraction results."""
+
+    def test_skips_failed_results(self):
+        base_catalogs = {"characters.json": [], "locations.json": []}
+        base_events = []
+        base_timeline = []
+        results = [
+            ("turn-001", {"characters.json": [{"id": "char-x", "name": "X", "type": "character"}]},
+             [], [], True, {}),  # failed=True
+        ]
+        cats, evts, tl = merge_parallel_results(base_catalogs, base_events, base_timeline, results)
+        assert len(cats["characters.json"]) == 0
+
+    def test_merges_new_entities(self):
+        base_catalogs = {"characters.json": [], "locations.json": []}
+        base_events = []
+        base_timeline = []
+        results = [
+            ("turn-001", {"characters.json": [{"id": "char-a", "name": "A", "type": "character", "first_seen_turn": "turn-001", "identity": "A the warrior"}]},
+             [], [], False, {}),
+        ]
+        cats, evts, tl = merge_parallel_results(base_catalogs, base_events, base_timeline, results)
+        assert any(e["id"] == "char-a" for e in cats["characters.json"])
+
+    def test_deduplicates_events_by_id(self):
+        base_events = [{"id": "evt-001", "description": "existing"}]
+        results = [
+            ("turn-001", {"characters.json": []},
+             [{"id": "evt-001", "description": "dupe"}, {"id": "evt-002", "description": "new"}],
+             [], False, {}),
+        ]
+        _, evts, _ = merge_parallel_results({"characters.json": []}, base_events, [], results)
+        ids = [e["id"] for e in evts]
+        assert ids.count("evt-001") == 1
+        assert "evt-002" in ids
+
+    def test_merges_timeline_with_proper_dedup(self):
+        base_timeline = [
+            {"id": "time-001", "source_turn": "turn-001", "type": "biological",
+             "season": "summer", "raw_text": "flowers bloom"},
+        ]
+        new_signals = [
+            # Duplicate — same key
+            {"source_turn": "turn-001", "type": "biological",
+             "season": "summer", "raw_text": "flowers bloom"},
+            # New — different raw_text
+            {"source_turn": "turn-001", "type": "weather",
+             "season": "summer", "raw_text": "rain falls"},
+        ]
+        results = [
+            ("turn-001", {"characters.json": []}, [], new_signals, False, {}),
+        ]
+        _, _, tl = merge_parallel_results({"characters.json": []}, [], base_timeline, results)
+        # Should have original + 1 new (the dupe should not be added)
+        assert len(tl) == 2
+        raw_texts = [e.get("raw_text") for e in tl]
+        assert "flowers bloom" in raw_texts
+        assert "rain falls" in raw_texts

--- a/tests/test_retry_failed_turns.py
+++ b/tests/test_retry_failed_turns.py
@@ -8,7 +8,6 @@ Covers:
 import json
 import os
 import sys
-import tempfile
 from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))

--- a/tools/retry_failed_turns.py
+++ b/tools/retry_failed_turns.py
@@ -52,13 +52,13 @@ from datetime import datetime, timezone
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from catalog_merger import load_catalogs, load_events, save_catalogs, save_events, merge_entity
-from llm_client import LLMClient, LLMExtractionError, QuotaExhaustedError
+from llm_client import LLMClient, QuotaExhaustedError
 from semantic_extraction import (
     extract_and_merge,
     _write_extraction_log,
     _reset_pc_failure_tracking,
 )
-from temporal_extraction import load_timeline, save_timeline
+from temporal_extraction import load_timeline, save_timeline, merge_temporal_signals
 
 
 def load_failed_turns(extraction_log_path: str) -> list[str]:
@@ -84,10 +84,12 @@ def load_failed_turns(extraction_log_path: str) -> list[str]:
             except json.JSONDecodeError:
                 continue
             turn_id = entry.get("turn_id", "")
-            if entry.get("discovery_ok"):
+            if not turn_id:
+                continue
+            if entry.get("discovery_ok") is True:
                 succeeded.add(turn_id)
                 failed.discard(turn_id)
-            else:
+            elif entry.get("discovery_ok") is False:
                 if turn_id not in succeeded:
                     failed.add(turn_id)
 
@@ -106,10 +108,13 @@ def load_turn_dicts(session_dir: str) -> list[dict]:
         speaker = parts[2] if len(parts) > 2 else "dm"
         with open(tf, encoding="utf-8") as f:
             text = f.read()
-        # Strip the header line (## turn-NNN [speaker])
+        # Strip a leading markdown header line (#/## turn-NNN — SPEAKER)
+        # and one following blank separator line if present.
         lines = text.strip().split("\n")
-        if lines and lines[0].startswith("##"):
+        if lines and (lines[0].startswith("# ") or lines[0].startswith("## ")):
             lines = lines[1:]
+            if lines and not lines[0].strip():
+                lines = lines[1:]
         text = "\n".join(lines).strip()
         turn_dicts.append({"turn_id": turn_id, "speaker": speaker, "text": text})
     return turn_dicts
@@ -156,13 +161,9 @@ def merge_parallel_results(
 ) -> tuple[dict, list, list]:
     """Merge entity additions from parallel extractions into base catalogs.
 
-    Each result contains a full catalog snapshot. We diff against the base
-    to find new/updated entities and merge them sequentially.
+    Each result contains a full catalog snapshot. We merge new/updated
+    entities sequentially.
     """
-    base_entity_ids: dict[str, set[str]] = {}
-    for key, entities in base_catalogs.items():
-        base_entity_ids[key] = {e.get("id", "") for e in entities}
-
     for turn_id, result_catalogs, result_events, result_timeline, failed, log_record in results:
         if failed:
             # Don't merge data from failed extractions
@@ -184,16 +185,8 @@ def merge_parallel_results(
                 base_events.append(event)
                 existing_event_ids.add(event.get("id", ""))
 
-        # Merge timeline entries (deduplicate by turn + signal)
-        existing_signals = {
-            (t.get("turn_id", ""), t.get("signal", ""))
-            for t in base_timeline
-        }
-        for entry in result_timeline:
-            key = (entry.get("turn_id", ""), entry.get("signal", ""))
-            if key not in existing_signals:
-                base_timeline.append(entry)
-                existing_signals.add(key)
+        # Merge timeline entries using canonical dedup logic
+        merge_temporal_signals(base_timeline, result_timeline)
 
     return base_catalogs, base_events, base_timeline
 
@@ -235,8 +228,12 @@ def main():
                     f"Server batch saturation may cause timeouts.",
                     file=sys.stderr,
                 )
-        except (OSError, json.JSONDecodeError):
-            pass
+        except (OSError, json.JSONDecodeError) as e:
+            print(
+                f"  WARNING: Unable to read/parse config '{args.config}' for "
+                f"concurrency check: {e}",
+                file=sys.stderr,
+            )
 
     # Load failed turns from extraction log
     failed_turn_ids = load_failed_turns(extraction_log_path)
@@ -327,7 +324,9 @@ def main():
 
             except QuotaExhaustedError as e:
                 still_failed += 1
-                print(f"  QUOTA   {turn_id} — {e}")
+                print(f"  QUOTA   {turn_id} — {e}", file=sys.stderr)
+                print("  Stopping early — quota exhausted, cancelling remaining work.",
+                      file=sys.stderr)
                 # Log the failure
                 _write_extraction_log(extraction_log_path, {
                     "turn_id": turn_id,
@@ -340,6 +339,10 @@ def main():
                     "events_ok": False, "events_error": None,
                     "new_entities": 0, "new_events": 0, "elapsed_ms": 0,
                 })
+                # Cancel remaining futures to stop hammering the provider
+                for pending in future_to_turn:
+                    pending.cancel()
+                break
             except Exception as e:
                 still_failed += 1
                 print(f"  ERROR   {turn_id} — {type(e).__name__}: {e}")

--- a/tools/retry_failed_turns.py
+++ b/tools/retry_failed_turns.py
@@ -1,0 +1,404 @@
+"""Parallel retry of previously-failed extraction turns.
+
+Reads the extraction log to identify turns where discovery_ok=False,
+then re-extracts them using a ThreadPoolExecutor. Each worker runs
+the full extract_and_merge pipeline independently with its own catalog
+snapshot. After all workers complete, entity results are merged
+sequentially into the shared catalog and saved to disk.
+
+Concurrency notes:
+    The default is --workers 1 (sequential turns). This is intentional.
+    Each turn already uses parallel_workers from config (typically 4)
+    to parallelize internal phases (detail, PC, relationships, events).
+    
+    With parallel_workers=4 in config, each turn generates up to 4
+    simultaneous LLM requests to the server's batch queue. The server
+    (ContinuousBatchingPipeline) processes batches atomically — while
+    one batch generates, new requests queue in memory.
+    
+    Increasing --workers multiplies with parallel_workers:
+      --workers 2 × parallel_workers 4 = 8 max concurrent requests
+      --workers 4 × parallel_workers 4 = 16 max concurrent requests
+    
+    At batch=8 with discovery_max_tokens=8192, per-request throughput
+    drops to ~24 tok/s, making 8192/24 = 341s > 300s timeout.
+    This causes cascading timeout failures.
+    
+    Safe configurations:
+      --workers 1, parallel_workers=4  (proven, ~63s/turn avg)
+      --workers 2, parallel_workers=2  (untested, marginal)
+      --workers 4, parallel_workers=1  (untested, loses batching benefit)
+
+Usage:
+    python tools/retry_failed_turns.py --session sessions/openvino-test
+
+Options:
+    --session       Path to session directory (required)
+    --framework     Path to framework directory (default: framework)
+    --workers       Number of parallel workers (default: 1)
+    --dry-run       Print what would be done without making LLM calls
+"""
+
+import argparse
+import copy
+import json
+import os
+import sys
+import time
+import glob
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from catalog_merger import load_catalogs, load_events, save_catalogs, save_events, merge_entity
+from llm_client import LLMClient, LLMExtractionError, QuotaExhaustedError
+from semantic_extraction import (
+    extract_and_merge,
+    _write_extraction_log,
+    _reset_pc_failure_tracking,
+)
+from temporal_extraction import load_timeline, save_timeline
+
+
+def load_failed_turns(extraction_log_path: str) -> list[str]:
+    """Read extraction log and return turn IDs where discovery failed.
+
+    A turn is considered failed if its most recent log entry has
+    discovery_ok=False. If a turn has both a failure and a later success,
+    the success wins (it's already been retried successfully).
+    """
+    succeeded: set[str] = set()
+    failed: set[str] = set()
+
+    if not os.path.exists(extraction_log_path):
+        return []
+
+    with open(extraction_log_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            turn_id = entry.get("turn_id", "")
+            if entry.get("discovery_ok"):
+                succeeded.add(turn_id)
+                failed.discard(turn_id)
+            else:
+                if turn_id not in succeeded:
+                    failed.add(turn_id)
+
+    return sorted(failed)
+
+
+def load_turn_dicts(session_dir: str) -> list[dict]:
+    """Load all turn dicts from transcript files."""
+    turn_files = sorted(glob.glob(os.path.join(session_dir, "transcript", "turn-*.md")))
+    turn_dicts = []
+    for tf in turn_files:
+        basename = os.path.basename(tf)
+        # Format: turn-NNN-speaker.md
+        parts = basename.replace(".md", "").split("-")
+        turn_id = f"turn-{parts[1]}"
+        speaker = parts[2] if len(parts) > 2 else "dm"
+        with open(tf, encoding="utf-8") as f:
+            text = f.read()
+        # Strip the header line (## turn-NNN [speaker])
+        lines = text.strip().split("\n")
+        if lines and lines[0].startswith("##"):
+            lines = lines[1:]
+        text = "\n".join(lines).strip()
+        turn_dicts.append({"turn_id": turn_id, "speaker": speaker, "text": text})
+    return turn_dicts
+
+
+def extract_single_turn(
+    turn: dict,
+    catalogs_snapshot: dict,
+    events_snapshot: list,
+    timeline_snapshot: list,
+    config_path: str,
+    overrides: dict | None,
+    min_confidence: float,
+    catalog_dir: str,
+) -> tuple[str, dict, list, list, bool, dict]:
+    """Extract a single turn in isolation. Thread-safe.
+
+    Returns: (turn_id, catalogs, events, timeline, failed, log_record)
+    """
+    # Each thread gets its own LLM client (own HTTP session)
+    llm = LLMClient(config_path, overrides=overrides)
+    # Deep copy catalogs so merge operations don't interfere between threads
+    local_catalogs = copy.deepcopy(catalogs_snapshot)
+    local_events = copy.deepcopy(events_snapshot)
+    local_timeline = copy.deepcopy(timeline_snapshot) if timeline_snapshot else []
+
+    catalogs_out, events_out, failed, log_record = extract_and_merge(
+        turn,
+        local_catalogs,
+        local_events,
+        llm,
+        min_confidence,
+        catalog_dir=catalog_dir,
+        timeline=local_timeline,
+    )
+    return (turn["turn_id"], catalogs_out, events_out, local_timeline, failed, log_record)
+
+
+def merge_parallel_results(
+    base_catalogs: dict,
+    base_events: list,
+    base_timeline: list,
+    results: list[tuple[str, dict, list, list, bool, dict]],
+) -> tuple[dict, list, list]:
+    """Merge entity additions from parallel extractions into base catalogs.
+
+    Each result contains a full catalog snapshot. We diff against the base
+    to find new/updated entities and merge them sequentially.
+    """
+    base_entity_ids: dict[str, set[str]] = {}
+    for key, entities in base_catalogs.items():
+        base_entity_ids[key] = {e.get("id", "") for e in entities}
+
+    for turn_id, result_catalogs, result_events, result_timeline, failed, log_record in results:
+        if failed:
+            # Don't merge data from failed extractions
+            continue
+
+        # Merge new/updated entities from this turn's result
+        for key, entities in result_catalogs.items():
+            for entity in entities:
+                eid = entity.get("id", "")
+                if not eid:
+                    continue
+                # merge_entity handles both new and updated entities
+                merge_entity(base_catalogs, entity)
+
+        # Merge new events (deduplicate by event ID)
+        existing_event_ids = {e.get("id", "") for e in base_events}
+        for event in result_events:
+            if event.get("id", "") not in existing_event_ids:
+                base_events.append(event)
+                existing_event_ids.add(event.get("id", ""))
+
+        # Merge timeline entries (deduplicate by turn + signal)
+        existing_signals = {
+            (t.get("turn_id", ""), t.get("signal", ""))
+            for t in base_timeline
+        }
+        for entry in result_timeline:
+            key = (entry.get("turn_id", ""), entry.get("signal", ""))
+            if key not in existing_signals:
+                base_timeline.append(entry)
+                existing_signals.add(key)
+
+    return base_catalogs, base_events, base_timeline
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Parallel retry of failed extraction turns."
+    )
+    parser.add_argument("--session", required=True, help="Path to session directory")
+    parser.add_argument("--framework", default="framework", help="Framework directory")
+    parser.add_argument(
+        "--workers", type=int, default=1,
+        help="External parallel workers (default: 1). WARNING: values >1 multiply "
+             "with internal parallel_workers from config. With parallel_workers=4 "
+             "and discovery_max_tokens=8192, more than 1 external worker risks "
+             "timeouts due to server batch queue saturation. Only increase if you "
+             "have also reduced parallel_workers in config."
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done")
+    parser.add_argument("--config", default="config/llm.json", help="LLM config path")
+    parser.add_argument("--min-confidence", type=float, default=0.4)
+    args = parser.parse_args()
+
+    catalog_dir = os.path.join(args.framework, "catalogs")
+    extraction_log_path = os.path.join(args.framework, "extraction-log.jsonl")
+
+    # Determine worker count
+    num_workers = args.workers
+    if num_workers > 1:
+        try:
+            with open(args.config, "r", encoding="utf-8") as f:
+                config = json.load(f)
+            internal_parallel = config.get("parallel_workers", 1)
+            max_concurrent = num_workers * internal_parallel
+            if max_concurrent > 4:
+                print(
+                    f"  WARNING: {num_workers} external × {internal_parallel} internal "
+                    f"= {max_concurrent} max concurrent requests. "
+                    f"Server batch saturation may cause timeouts.",
+                    file=sys.stderr,
+                )
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    # Load failed turns from extraction log
+    failed_turn_ids = load_failed_turns(extraction_log_path)
+    if not failed_turn_ids:
+        print("No failed turns to retry.")
+        return
+
+    print(f"Found {len(failed_turn_ids)} failed turn(s) to retry.")
+    print(f"Workers: {num_workers}")
+
+    # Load turn content
+    all_turns = load_turn_dicts(args.session)
+    turn_map = {t["turn_id"]: t for t in all_turns}
+
+    # Filter to only failed turns that exist in the session
+    retry_turns = []
+    for tid in failed_turn_ids:
+        if tid in turn_map:
+            retry_turns.append(turn_map[tid])
+        else:
+            print(f"  WARNING: {tid} not found in session transcripts, skipping")
+
+    if not retry_turns:
+        print("No matching turns found in session.")
+        return
+
+    print(f"Retrying {len(retry_turns)} turn(s): {retry_turns[0]['turn_id']} ... {retry_turns[-1]['turn_id']}")
+
+    if args.dry_run:
+        for t in retry_turns:
+            print(f"  [DRY RUN] Would retry: {t['turn_id']}")
+        return
+
+    # Load current catalogs as the base snapshot for context
+    _reset_pc_failure_tracking()
+    catalogs = load_catalogs(catalog_dir)
+    events_list = load_events(catalog_dir)
+    timeline = load_timeline(catalog_dir)
+
+    entity_count_before = sum(len(v) for v in catalogs.values())
+    event_count_before = len(events_list)
+
+    print(f"Base catalogs: {entity_count_before} entities, {event_count_before} events")
+    print(f"\nStarting parallel extraction...")
+    print("-" * 60)
+
+    t_start = time.monotonic()
+    results: list[tuple[str, dict, list, list, bool, dict]] = []
+    succeeded = 0
+    still_failed = 0
+
+    with ThreadPoolExecutor(max_workers=num_workers) as pool:
+        future_to_turn = {}
+        for turn in retry_turns:
+            future = pool.submit(
+                extract_single_turn,
+                turn,
+                catalogs,
+                events_list,
+                timeline,
+                args.config,
+                None,  # no overrides
+                args.min_confidence,
+                catalog_dir,
+            )
+            future_to_turn[future] = turn["turn_id"]
+
+        for future in as_completed(future_to_turn):
+            turn_id = future_to_turn[future]
+            try:
+                result = future.result()
+                _, _, _, _, failed, log_record = result
+                results.append(result)
+
+                # Write extraction log immediately (append-only, thread-safe on most OS)
+                _write_extraction_log(extraction_log_path, log_record)
+
+                elapsed_s = log_record.get("elapsed_ms", 0) / 1000
+                if failed:
+                    still_failed += 1
+                    err = log_record.get("discovery_error", "unknown")
+                    print(f"  FAILED  {turn_id} ({elapsed_s:.1f}s) — {err}")
+                else:
+                    succeeded += 1
+                    new_ent = log_record.get("new_entities", 0)
+                    new_evt = log_record.get("new_events", 0)
+                    print(f"  OK      {turn_id} ({elapsed_s:.1f}s) +{new_ent} entities, +{new_evt} events")
+
+            except QuotaExhaustedError as e:
+                still_failed += 1
+                print(f"  QUOTA   {turn_id} — {e}")
+                # Log the failure
+                _write_extraction_log(extraction_log_path, {
+                    "turn_id": turn_id,
+                    "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                    "discovery_ok": False,
+                    "discovery_error": f"QuotaExhaustedError: {e}",
+                    "detail_ok": False, "detail_error": None,
+                    "pc_ok": False, "pc_error": None,
+                    "relationships_ok": False, "relationships_error": None,
+                    "events_ok": False, "events_error": None,
+                    "new_entities": 0, "new_events": 0, "elapsed_ms": 0,
+                })
+            except Exception as e:
+                still_failed += 1
+                print(f"  ERROR   {turn_id} — {type(e).__name__}: {e}")
+                _write_extraction_log(extraction_log_path, {
+                    "turn_id": turn_id,
+                    "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                    "discovery_ok": False,
+                    "discovery_error": f"{type(e).__name__}: {e}",
+                    "detail_ok": False, "detail_error": None,
+                    "pc_ok": None, "pc_error": None,
+                    "relationships_ok": None, "relationships_error": None,
+                    "events_ok": None, "events_error": None,
+                    "new_entities": 0, "new_events": 0, "elapsed_ms": 0,
+                })
+
+    t_elapsed = time.monotonic() - t_start
+    print("-" * 60)
+    print(f"Completed in {t_elapsed:.1f}s")
+    print(f"  Succeeded: {succeeded}/{len(retry_turns)}")
+    print(f"  Failed:    {still_failed}/{len(retry_turns)}")
+
+    # Merge all successful results into the base catalogs
+    if succeeded > 0:
+        print(f"\nMerging results into catalogs...")
+        # Sort results by turn number for deterministic merge order
+        results.sort(key=lambda r: r[0])
+        catalogs, events_list, timeline = merge_parallel_results(
+            catalogs, events_list, timeline, results
+        )
+
+        entity_count_after = sum(len(v) for v in catalogs.values())
+        event_count_after = len(events_list)
+
+        print(f"  Entities: {entity_count_before} → {entity_count_after} (+{entity_count_after - entity_count_before})")
+        print(f"  Events:   {event_count_before} → {event_count_after} (+{event_count_after - event_count_before})")
+
+        # Save to disk
+        save_catalogs(catalog_dir, catalogs)
+        save_events(catalog_dir, events_list)
+        save_timeline(catalog_dir, timeline)
+        print("  Saved to disk.")
+
+    # Update progress file to clear the failed_turns list
+    progress_file = os.path.join(args.session, "derived", "extraction-progress.json")
+    if os.path.exists(progress_file):
+        try:
+            with open(progress_file, "r", encoding="utf-8") as f:
+                progress = json.load(f)
+            # Remove turns that succeeded from the failed list
+            old_failed = set(progress.get("failed_turns", []))
+            succeeded_ids = {r[0] for r in results if not r[4]}  # r[4] is 'failed' flag
+            new_failed = sorted(old_failed - succeeded_ids)
+            progress["failed_turns"] = new_failed
+            with open(progress_file, "w", encoding="utf-8") as f:
+                json.dump(progress, f, indent=2)
+            print(f"  Updated progress file: {len(old_failed)} → {len(new_failed)} failed turns")
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"  WARNING: Could not update progress file: {e}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds comprehensive hardware deployment documentation for running semantic extraction on local GPU servers, based on measured performance from the OpenVINO B70 investigation.

### Changes

**docs/usage.md** — New "Using OpenVINO (Intel Arc / Xeon GPUs)" section:
- Tested hardware table (Arc Pro B70 31GB, RTX 4070 12GB)
- OpenVINO server setup instructions and client `config/llm.json` example
- Server batching behavior with measured throughput at batch sizes 1–8
- Concurrency rules explaining how `parallel_workers` × external workers interact
- RTX 4070 config using llama-server with `-np 4` parallel slots (not Ollama)
- `retry_failed_turns.py` usage for re-extracting failed turns

Also updates the "Tested Models" table to include `qwen3-8b-int4-ov` and adds the 31GB VRAM tier to the quick reference.

**tools/retry_failed_turns.py** — New tool for retrying failed extraction turns:
- Reads `extraction-log.jsonl` to identify turns where discovery failed
- Re-extracts them with proper concurrency control (defaults to `--workers 1`)
- Idempotent — skips turns that have since succeeded
- Includes detailed concurrency documentation in the docstring
