### PR TITLE
fix: detect discovery truncation and retry with larger token limit

### DIFF
--- a/templates/extraction/entity-discovery.md
+++ b/templates/extraction/entity-discovery.md
@@ -8,7 +8,7 @@ For each entity, return a JSON object with these fields:
 - "is_new": true if this entity is NOT in the known-entities list
 - "existing_id": if is_new is false, the ID from the known-entities list. Must be null if is_new is true.
 - "proposed_id": if is_new is true, a proposed ID following the prefix convention (char-, loc-, faction-, item-, creature-, concept-). Must be null if is_new is false. Use lowercase, hyphen-separated words.
-- "description": one-sentence factual description based ONLY on what appears in THIS turn's text
+- "description": one-sentence factual description based ONLY on what appears in THIS turn's text. **OMIT this field entirely when is_new is false** (existing entities already have descriptions in the catalog).
 - "confidence": 0.0-1.0 confidence that this is a distinct, nameable entity worth cataloging
 - "source_turn": the turn ID provided in the input
 
@@ -46,6 +46,9 @@ Examples:
 {"entities": [{"name": "Kael", "type": "character", "is_new": true, "existing_id": null, "proposed_id": "char-kael", "description": "A young hunter mentioned by the elder.", "confidence": 0.9, "source_turn": "turn-019"}]}
 
 {"entities": [{"name": "Crude spear", "type": "item", "is_new": true, "existing_id": null, "proposed_id": "item-crude-spear", "description": "A roughly-made spear carried by one of the warriors.", "confidence": 0.85, "source_turn": "turn-007"}]}
+
+Example with existing entities (no description field):
+{"entities": [{"name": "Kael", "type": "character", "is_new": false, "existing_id": "char-kael", "proposed_id": null, "confidence": 0.95, "source_turn": "turn-042"}, {"name": "the longhouse", "type": "location", "is_new": false, "existing_id": "loc-communal-longhouse", "proposed_id": null, "confidence": 0.9, "source_turn": "turn-042"}]}
 
 {"entities": [{"name": "Tripwire", "type": "item", "is_new": true, "existing_id": null, "proposed_id": "item-tripwire", "description": "A hidden trap mechanism stretched across the path.", "confidence": 0.9, "source_turn": "turn-005"}]}
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -343,7 +343,6 @@ class TestTruncationDetection:
         mock_response.choices = [mock_choice]
 
         call_count = 0
-        original_create = client.client.chat.completions.create
 
         def counting_create(**kwargs):
             nonlocal call_count

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -3,7 +3,8 @@
 import json
 import os
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
@@ -14,7 +15,7 @@ if "openai" not in sys.modules:
     _mock_openai.OpenAI = MagicMock
     sys.modules["openai"] = _mock_openai
 
-from llm_client import LLMClient
+from llm_client import LLMClient, LLMTruncationError, LLMExtractionError
 
 
 def _write_config(tmp_dir, overrides=None):
@@ -281,3 +282,80 @@ class TestOllamaConfigKnobs:
         })
         client = LLMClient(config_path=cfg)
         assert client.config.get("ollama_think") is False
+
+
+# ---------------------------------------------------------------------------
+# LLMTruncationError detection
+# ---------------------------------------------------------------------------
+
+
+class TestTruncationDetection:
+    """Verify extract_json raises LLMTruncationError on finish_reason=length."""
+
+    def test_finish_reason_length_raises_truncation_error(self, tmp_path):
+        cfg = _write_config(tmp_path, {"retry_attempts": 1})
+        client = LLMClient(config_path=cfg)
+
+        # Mock the OpenAI response with finish_reason="length"
+        mock_choice = MagicMock()
+        mock_choice.message.content = '{"entities": [{"id": "char-foo"'
+        mock_choice.finish_reason = "length"
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        with patch.object(client.client.chat.completions, "create",
+                          return_value=mock_response):
+            with pytest.raises(LLMTruncationError) as exc_info:
+                client.extract_json(
+                    system_prompt="test",
+                    user_prompt="test",
+                )
+            assert exc_info.value.partial_text == '{"entities": [{"id": "char-foo"'
+            assert "finish_reason=length" in str(exc_info.value)
+
+    def test_finish_reason_stop_does_not_raise(self, tmp_path):
+        cfg = _write_config(tmp_path, {"retry_attempts": 1})
+        client = LLMClient(config_path=cfg)
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = '{"entities": []}'
+        mock_choice.finish_reason = "stop"
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        with patch.object(client.client.chat.completions, "create",
+                          return_value=mock_response):
+            result = client.extract_json(
+                system_prompt="test",
+                user_prompt="test",
+            )
+            assert result == {"entities": []}
+
+    def test_truncation_error_not_retried(self, tmp_path):
+        """LLMTruncationError should propagate immediately, not retry."""
+        cfg = _write_config(tmp_path, {"retry_attempts": 3})
+        client = LLMClient(config_path=cfg)
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = '{"partial": true'
+        mock_choice.finish_reason = "length"
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        call_count = 0
+        original_create = client.client.chat.completions.create
+
+        def counting_create(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            return mock_response
+
+        with patch.object(client.client.chat.completions, "create",
+                          side_effect=counting_create):
+            with pytest.raises(LLMTruncationError):
+                client.extract_json(
+                    system_prompt="test",
+                    user_prompt="test",
+                )
+            # Should only be called once — no retries
+            assert call_count == 1

--- a/tests/test_truncation_recovery.py
+++ b/tests/test_truncation_recovery.py
@@ -14,7 +14,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
-from semantic_extraction import _repair_truncated_discovery
+from semantic_extraction import _repair_truncated_discovery, _repair_truncated_relationships
 
 # Ensure openai mock exists for llm_client import
 if "openai" not in sys.modules:
@@ -168,3 +168,55 @@ class TestDiscoveryTruncationRetry:
         assert repair_first is not None
         assert len(repair_first["entities"]) == 1
         assert repair_first["entities"][0]["id"] == "char-a"
+
+
+# ---------------------------------------------------------------------------
+# _repair_truncated_relationships tests
+# ---------------------------------------------------------------------------
+
+
+class TestRepairTruncatedRelationships:
+    """Verify JSON repair logic for truncated relationship-mapper responses."""
+
+    def test_recovers_complete_relationships(self):
+        """Truncation mid-second-relationship recovers the first complete one."""
+        partial = '{"relationships": [{"source_id": "char-player", "target_id": "char-kael", "current_relationship": "ally", "type": "social", "direction": "bidirectional", "status": "active", "confidence": 0.9, "first_seen_turn": "turn-100", "last_updated_turn": "turn-318"}, {"source_id": "char-player", "target_id": "char-bo'
+        result = _repair_truncated_relationships(partial)
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["source_id"] == "char-player"
+        assert result[0]["target_id"] == "char-kael"
+
+    def test_returns_none_for_no_complete_relationships(self):
+        """When truncation happens inside the first relationship, returns None."""
+        partial = '{"relationships": [{"source_id": "char-player", "target_id": "char-ka'
+        result = _repair_truncated_relationships(partial)
+        assert result is None
+
+    def test_multiple_complete_relationships_preserved(self):
+        """All complete relationship objects before truncation are kept."""
+        partial = '{"relationships": [{"source_id": "char-a", "target_id": "char-b", "current_relationship": "ally", "type": "social", "direction": "bidirectional", "status": "active", "confidence": 0.9, "first_seen_turn": "turn-1", "last_updated_turn": "turn-1"}, {"source_id": "char-b", "target_id": "char-c", "current_relationship": "rival", "type": "social", "direction": "bidirectional", "status": "active", "confidence": 0.8, "first_seen_turn": "turn-1", "last_updated_turn": "turn-1"}, {"source_id": "char-c", "target_id": "char-trunc'
+        result = _repair_truncated_relationships(partial)
+        assert result is not None
+        assert len(result) == 2
+        assert result[0]["target_id"] == "char-b"
+        assert result[1]["target_id"] == "char-c"
+
+    def test_handles_think_block_prefix(self):
+        """<think> blocks are stripped before repair."""
+        partial = '<think>Analyzing relationships...</think>{"relationships": [{"source_id": "char-player", "target_id": "char-kael", "current_relationship": "ally", "type": "social", "direction": "bidirectional", "status": "active", "confidence": 0.9, "first_seen_turn": "turn-1", "last_updated_turn": "turn-1"}, {"source_id": "trunc'
+        result = _repair_truncated_relationships(partial)
+        assert result is not None
+        assert len(result) == 1
+
+    def test_returns_none_for_garbage(self):
+        """Non-JSON input returns None."""
+        result = _repair_truncated_relationships("not json at all")
+        assert result is None
+
+    def test_complete_json_passes_through(self):
+        """Already-valid JSON returns the relationships list."""
+        complete = '{"relationships": [{"source_id": "char-player", "target_id": "char-kael", "current_relationship": "ally", "type": "social", "direction": "bidirectional", "status": "active", "confidence": 0.9, "first_seen_turn": "turn-1", "last_updated_turn": "turn-1"}]}'
+        result = _repair_truncated_relationships(complete)
+        assert result is not None
+        assert len(result) == 1

--- a/tests/test_truncation_recovery.py
+++ b/tests/test_truncation_recovery.py
@@ -10,7 +10,6 @@ import json
 import os
 import sys
 from unittest.mock import MagicMock, patch
-import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
@@ -146,7 +145,6 @@ class TestDiscoveryTruncationRetry:
 
     def test_repair_fallback_on_double_truncation(self):
         """When retry also truncates, repair is attempted on the larger partial."""
-        first_partial = '{"entities": [{"id": "char-a", "name": "A", "type": "character", "is_new": true, "confidence": 0.9, "description": "test"}, {"id": "char-trunc'
         second_partial = '{"entities": [{"id": "char-a", "name": "A", "type": "character", "is_new": true, "confidence": 0.9, "description": "test"}, {"id": "char-b", "name": "B", "type": "character", "is_new": true, "confidence": 0.8, "description": "second"}, {"id": "char-trunc'
 
         # Simulate: first call truncates, retry truncates with more data

--- a/tests/test_truncation_recovery.py
+++ b/tests/test_truncation_recovery.py
@@ -1,0 +1,170 @@
+"""Tests for discovery truncation detection and retry/repair flow (#288).
+
+Covers:
+- _repair_truncated_discovery() JSON repair from partial output
+- Discovery retry with 2× max_tokens on truncation
+- Fallback to repair when retry also truncates
+- Correct turn_failed / _phase_log state on total failure
+"""
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from semantic_extraction import _repair_truncated_discovery
+
+# Ensure openai mock exists for llm_client import
+if "openai" not in sys.modules:
+    _mock_openai = MagicMock()
+    _mock_openai.OpenAI = MagicMock
+    sys.modules["openai"] = _mock_openai
+
+from llm_client import LLMTruncationError
+
+
+# ---------------------------------------------------------------------------
+# _repair_truncated_discovery tests
+# ---------------------------------------------------------------------------
+
+
+class TestRepairTruncatedDiscovery:
+    """Verify JSON repair logic for truncated discovery responses."""
+
+    def test_recovers_complete_entities_from_truncated_output(self):
+        """Truncation mid-second-entity recovers the first complete entity."""
+        partial = '{"entities": [{"id": "char-kael", "name": "Kael", "type": "character", "is_new": true, "confidence": 0.9, "description": "A warrior"}, {"id": "loc-for'
+        result = _repair_truncated_discovery(partial)
+        assert result is not None
+        assert len(result["entities"]) == 1
+        assert result["entities"][0]["id"] == "char-kael"
+
+    def test_returns_none_for_no_complete_entities(self):
+        """When truncation happens inside the first entity, returns None."""
+        partial = '{"entities": [{"id": "char-kael", "name": "Ka'
+        result = _repair_truncated_discovery(partial)
+        assert result is None
+
+    def test_returns_complete_json_unchanged(self):
+        """Already-valid JSON passes through (returns parsed dict)."""
+        complete = '{"entities": [{"id": "char-kael", "name": "Kael", "type": "character", "is_new": true, "confidence": 0.9, "description": "A warrior"}]}'
+        result = _repair_truncated_discovery(complete)
+        assert result is not None
+        assert len(result["entities"]) == 1
+
+    def test_handles_think_block_prefix(self):
+        """<think> blocks are stripped before repair."""
+        partial = '<think>Let me analyze this turn carefully...</think>{"entities": [{"id": "char-kael", "name": "Kael", "type": "character", "is_new": true, "confidence": 0.9, "description": "A warrior"}, {"id": "loc-trunc'
+        result = _repair_truncated_discovery(partial)
+        assert result is not None
+        assert result["entities"][0]["id"] == "char-kael"
+
+    def test_handles_markdown_fence_prefix(self):
+        """Markdown code fences are stripped before repair."""
+        partial = '```json\n{"entities": [{"id": "char-kael", "name": "Kael", "type": "character", "is_new": true, "confidence": 0.9, "description": "A warrior"}, {"id": "char-trunc'
+        result = _repair_truncated_discovery(partial)
+        assert result is not None
+        assert result["entities"][0]["id"] == "char-kael"
+
+    def test_returns_none_for_garbage(self):
+        """Non-JSON garbage returns None."""
+        result = _repair_truncated_discovery("this is not json at all")
+        assert result is None
+
+    def test_multiple_complete_entities_preserved(self):
+        """All complete entity objects before truncation point are kept."""
+        partial = '{"entities": [{"id": "char-a", "name": "A", "type": "character", "is_new": true, "confidence": 0.9, "description": "x"}, {"id": "char-b", "name": "B", "type": "character", "is_new": false, "confidence": 0.8}, {"id": "char-c", "name": "C", "type": "chara'
+        result = _repair_truncated_discovery(partial)
+        assert result is not None
+        assert len(result["entities"]) == 2
+        assert result["entities"][0]["id"] == "char-a"
+        assert result["entities"][1]["id"] == "char-b"
+
+
+# ---------------------------------------------------------------------------
+# Discovery truncation retry flow tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryTruncationRetry:
+    """Verify the truncation-aware retry logic in the discovery extraction path.
+
+    These tests mock the LLM client to simulate truncation scenarios and verify
+    the retry/repair fallback behavior.
+    """
+
+    def _make_discovery_result(self, entities):
+        """Build a valid discovery result dict."""
+        return {"entities": entities}
+
+    def test_retry_uses_doubled_max_tokens(self):
+        """On first truncation, retry is called with 2× the original max_tokens."""
+        from llm_client import LLMClient
+        cfg_data = {
+            "provider": "openai", "base_url": "http://localhost:8000/v1",
+            "model": "test", "api_key_env": "", "temperature": 0.0,
+            "max_tokens": 4096, "timeout_seconds": 10, "retry_attempts": 1,
+            "batch_delay_ms": 0, "discovery_max_tokens": 8192,
+        }
+        import tempfile
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(cfg_data, f)
+            cfg_path = f.name
+
+        try:
+            client = LLMClient(config_path=cfg_path)
+            calls = []
+
+            def mock_extract_json(system_prompt, user_prompt, temperature=None, max_tokens=None):
+                calls.append({"max_tokens": max_tokens})
+                if len(calls) == 1:
+                    raise LLMTruncationError("truncated", partial_text='{"entities": [{"id": "char-x"')
+                return {"entities": [{"id": "char-a", "name": "A", "type": "character", "is_new": True, "confidence": 0.9, "description": "test"}]}
+
+            with patch.object(client, "extract_json", side_effect=mock_extract_json):
+                # Simulate the retry logic from semantic_extraction
+                discovery_max = 8192
+                try:
+                    result = client.extract_json(
+                        system_prompt="test", user_prompt="test",
+                        max_tokens=discovery_max,
+                    )
+                except LLMTruncationError:
+                    retry_max = discovery_max * 2
+                    result = client.extract_json(
+                        system_prompt="test", user_prompt="test",
+                        max_tokens=retry_max,
+                    )
+
+            assert calls[0]["max_tokens"] == 8192
+            assert calls[1]["max_tokens"] == 16384
+            assert result["entities"][0]["id"] == "char-a"
+        finally:
+            os.unlink(cfg_path)
+
+    def test_repair_fallback_on_double_truncation(self):
+        """When retry also truncates, repair is attempted on the larger partial."""
+        first_partial = '{"entities": [{"id": "char-a", "name": "A", "type": "character", "is_new": true, "confidence": 0.9, "description": "test"}, {"id": "char-trunc'
+        second_partial = '{"entities": [{"id": "char-a", "name": "A", "type": "character", "is_new": true, "confidence": 0.9, "description": "test"}, {"id": "char-b", "name": "B", "type": "character", "is_new": true, "confidence": 0.8, "description": "second"}, {"id": "char-trunc'
+
+        # Simulate: first call truncates, retry truncates with more data
+        # Repair on second partial should recover 2 entities
+        repaired = _repair_truncated_discovery(second_partial)
+        assert repaired is not None
+        assert len(repaired["entities"]) == 2
+
+    def test_repair_falls_back_to_first_partial(self):
+        """When repair on retry partial fails, try repair on original partial."""
+        first_partial = '{"entities": [{"id": "char-a", "name": "A", "type": "character", "is_new": true, "confidence": 0.9, "description": "good"}, {"id": "char-trunc'
+        # Second partial is garbage (e.g. model produced non-JSON on retry)
+        second_partial = "Internal server error"
+
+        repair_second = _repair_truncated_discovery(second_partial)
+        assert repair_second is None  # Can't repair garbage
+
+        repair_first = _repair_truncated_discovery(first_partial)
+        assert repair_first is not None
+        assert len(repair_first["entities"]) == 1
+        assert repair_first["entities"][0]["id"] == "char-a"

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -18,6 +18,18 @@ class LLMExtractionError(Exception):
     """Raised when the LLM response cannot be parsed or validated."""
 
 
+class LLMTruncationError(LLMExtractionError):
+    """Raised when the LLM response was truncated due to max_tokens limit.
+
+    The partial response text is available via the `partial_text` attribute
+    for callers that want to attempt JSON repair.
+    """
+
+    def __init__(self, message: str, partial_text: str = ""):
+        super().__init__(message)
+        self.partial_text = partial_text
+
+
 class QuotaExhaustedError(LLMExtractionError):
     """Raised when consecutive rate-limit (429) errors suggest daily quota exhaustion."""
 
@@ -431,9 +443,18 @@ class LLMClient:
 
                     response = self.client.chat.completions.create(**kwargs)
                     raw_text = response.choices[0].message.content
+                    finish_reason = getattr(response.choices[0], "finish_reason", None)
 
                     if not raw_text:
                         raise LLMExtractionError("Empty response from LLM.")
+
+                    # Detect token-limit truncation before attempting JSON parse
+                    if finish_reason == "length":
+                        raise LLMTruncationError(
+                            f"Response truncated (finish_reason=length, "
+                            f"max_tokens={effective_max})",
+                            partial_text=raw_text,
+                        )
 
                 parsed = self._parse_json_response(raw_text)
 
@@ -453,6 +474,8 @@ class LLMClient:
                 self.stats.record_success()
                 return parsed
 
+            except (LLMTruncationError, QuotaExhaustedError):
+                raise
             except Exception as e:
                 last_error = e
                 self._handle_retry(attempt, e)

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -272,6 +272,14 @@ class LLMClient:
                 file=sys.stderr,
             )
             raise LLMExtractionError("Empty response from LLM.")
+
+        # Detect token-limit truncation in streaming path
+        if done_reason == "length":
+            raise LLMTruncationError(
+                f"Response truncated (done_reason=length, "
+                f"num_predict={max_tokens or self.max_tokens})",
+                partial_text=raw,
+            )
         return raw
 
     @property

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -955,6 +955,71 @@ def _repair_truncated_discovery(partial_text: str) -> dict | None:
     return None
 
 
+def _repair_truncated_relationships(partial_text: str) -> list | None:
+    """Attempt to repair a truncated relationship-mapper JSON response.
+
+    Same strategy as _repair_truncated_discovery but looks for the
+    "relationships" array key.
+
+    Returns:
+        List of relationship dicts if repair succeeds, None otherwise.
+    """
+    import json as _json
+
+    text = partial_text.strip()
+
+    # Strip thinking blocks and markdown fences
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+    fence_match = re.match(r"^```(?:json)?\s*\n(.*)", text, re.DOTALL)
+    if fence_match:
+        text = fence_match.group(1).strip()
+        if text.endswith("```"):
+            text = text[:-3].strip()
+
+    # Find the last complete object boundary in the relationships array
+    last_complete = -1
+    brace_depth = 0
+    in_string = False
+    escape_next = False
+
+    for i, ch in enumerate(text):
+        if escape_next:
+            escape_next = False
+            continue
+        if ch == '\\' and in_string:
+            escape_next = True
+            continue
+        if ch == '"' and not escape_next:
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == '{':
+            brace_depth += 1
+        elif ch == '}':
+            brace_depth -= 1
+            if brace_depth == 1:
+                # Closed a relationship object (depth 2→1)
+                last_complete = i
+
+    if last_complete <= 0:
+        return None
+
+    repaired = text[:last_complete + 1] + "]}"
+
+    try:
+        parsed = _json.loads(repaired)
+        if isinstance(parsed, dict) and "relationships" in parsed:
+            rels = parsed["relationships"]
+            if isinstance(rels, list) and len(rels) > 0:
+                return rels
+    except _json.JSONDecodeError as exc:
+        print(f"  [repair] Relationship JSON decode failed after truncation repair: {exc}",
+              file=sys.stderr)
+
+    return None
+
+
 # Stable attribute keys considered when trimming PC prior context.
 #
 # Why these are included:
@@ -1639,17 +1704,63 @@ def _extract_relationships_parallel(
     turn: dict,
     mentioned_entities: list,
     existing_rels_json: str,
+    max_tokens: int | None = None,
 ) -> list | None:
     """Run relationship-mapper extraction.  Returns list of relationships or
-    None on failure.  Designed to run inside a ThreadPoolExecutor."""
+    None on failure.  Designed to run inside a ThreadPoolExecutor.
+
+    Handles truncation by retrying with 2× max_tokens, then attempting
+    lossy JSON repair as a last resort.
+    """
     turn_id = turn["turn_id"]
+    _sys_prompt = load_template("relationship-mapper")
+    _user_prompt = format_relationship_prompt(turn, mentioned_entities, existing_rels_json)
     try:
         rel_result = llm.extract_json(
-            system_prompt=load_template("relationship-mapper"),
-            user_prompt=format_relationship_prompt(turn, mentioned_entities,
-                                                   existing_rels_json),
+            system_prompt=_sys_prompt,
+            user_prompt=_user_prompt,
+            max_tokens=max_tokens,
         )
         return rel_result.get("relationships", [])
+    except LLMTruncationError as trunc_err:
+        # Retry with 2× token budget
+        _retry_max = (max_tokens or llm.max_tokens) * 2
+        print(f"  TRUNCATED: Relationships for {turn_id} hit max_tokens={max_tokens or llm.max_tokens}, "
+              f"retrying with max_tokens={_retry_max}...", file=sys.stderr)
+        try:
+            rel_result = llm.extract_json(
+                system_prompt=_sys_prompt,
+                user_prompt=_user_prompt,
+                max_tokens=_retry_max,
+            )
+            return rel_result.get("relationships", [])
+        except LLMTruncationError as retry_trunc:
+            # Still truncated — attempt repair on the larger partial
+            print(f"  TRUNCATED (2nd attempt): Relationships still hit limit at {_retry_max}, "
+                  f"attempting repair...", file=sys.stderr)
+            repaired = _repair_truncated_relationships(retry_trunc.partial_text) if retry_trunc.partial_text else None
+            if repaired is not None:
+                print(f"  REPAIRED: Recovered {len(repaired)} relationships from truncated response",
+                      file=sys.stderr)
+                return repaired
+            # Try repair on original partial
+            repaired_orig = _repair_truncated_relationships(trunc_err.partial_text) if trunc_err.partial_text else None
+            if repaired_orig is not None:
+                print(f"  REPAIRED (from 1st attempt): Recovered {len(repaired_orig)} relationships",
+                      file=sys.stderr)
+                return repaired_orig
+            print(f"  WARNING: Relationship mapping failed for {turn_id}: "
+                  f"truncated and repair failed", file=sys.stderr)
+            return None
+        except LLMExtractionError as retry_err:
+            # Non-truncation error on retry — try repair on original
+            repaired = _repair_truncated_relationships(trunc_err.partial_text) if trunc_err.partial_text else None
+            if repaired is not None:
+                print(f"  REPAIRED: Recovered {len(repaired)} relationships from original truncated response",
+                      file=sys.stderr)
+                return repaired
+            print(f"  WARNING: Relationship mapping failed for {turn_id}: {retry_err}", file=sys.stderr)
+            return None
     except QuotaExhaustedError:
         raise
     except LLMExtractionError as e:
@@ -1765,6 +1876,9 @@ def extract_and_merge(
     # discovery_max_tokens override (#191) — discovery responses grow with
     # catalog size; allow a higher output budget than the default max_tokens.
     _discovery_max_tokens = _cfg.get("discovery_max_tokens") if isinstance(_cfg, dict) else None
+    # relationship_max_tokens override — relationship responses grow with
+    # entity density; allow a higher output budget for entity-dense turns.
+    _rel_max_tokens = _cfg.get("relationship_max_tokens") if isinstance(_cfg, dict) else None
     try:
         discovery_result = llm.extract_json(
             system_prompt=load_template("entity-discovery"),
@@ -2033,6 +2147,7 @@ def extract_and_merge(
                 f = pool.submit(
                     _extract_relationships_parallel,
                     llm, turn, mentioned_entities, existing_rels_json,
+                    _rel_max_tokens,
                 )
                 futures_map[f] = ("relationship", None)
 
@@ -2360,11 +2475,57 @@ def extract_and_merge(
                     system_prompt=load_template("relationship-mapper"),
                     user_prompt=format_relationship_prompt(turn, mentioned_entities,
                                                            existing_rels_json),
+                    max_tokens=_rel_max_tokens,
                 )
                 relationships = rel_result.get("relationships", [])
                 if relationships:
                     merge_relationships(catalogs, relationships, turn_id)
                 _phase_log["relationships_ok"] = True
+            except LLMTruncationError as trunc_err:
+                # Retry with 2× token budget, then attempt repair
+                _retry_max = (_rel_max_tokens or llm.max_tokens) * 2
+                print(f"  TRUNCATED: Relationships for {turn_id} hit max_tokens="
+                      f"{_rel_max_tokens or llm.max_tokens}, retrying with "
+                      f"max_tokens={_retry_max}...", file=sys.stderr)
+                try:
+                    rel_result = llm.extract_json(
+                        system_prompt=load_template("relationship-mapper"),
+                        user_prompt=format_relationship_prompt(turn, mentioned_entities,
+                                                               existing_rels_json),
+                        max_tokens=_retry_max,
+                    )
+                    relationships = rel_result.get("relationships", [])
+                    if relationships:
+                        merge_relationships(catalogs, relationships, turn_id)
+                    _phase_log["relationships_ok"] = True
+                except LLMTruncationError as retry_trunc:
+                    # Still truncated — attempt repair
+                    partial = retry_trunc.partial_text
+                    repaired = _repair_truncated_relationships(partial) if partial else None
+                    if repaired is None:
+                        repaired = _repair_truncated_relationships(trunc_err.partial_text) if trunc_err.partial_text else None
+                    if repaired is not None:
+                        print(f"  REPAIRED: Recovered {len(repaired)} relationships",
+                              file=sys.stderr)
+                        merge_relationships(catalogs, repaired, turn_id)
+                        _phase_log["relationships_ok"] = True
+                    else:
+                        turn_failed = True
+                        _phase_log["relationships_ok"] = False
+                        _phase_log["relationships_error"] = str(retry_trunc)
+                except (QuotaExhaustedError, LLMExtractionError) as retry_err:
+                    repaired = _repair_truncated_relationships(trunc_err.partial_text) if trunc_err.partial_text else None
+                    if repaired is not None:
+                        print(f"  REPAIRED: Recovered {len(repaired)} relationships from original",
+                              file=sys.stderr)
+                        merge_relationships(catalogs, repaired, turn_id)
+                        _phase_log["relationships_ok"] = True
+                    else:
+                        if isinstance(retry_err, QuotaExhaustedError):
+                            raise
+                        turn_failed = True
+                        _phase_log["relationships_ok"] = False
+                        _phase_log["relationships_error"] = str(retry_err)
             except QuotaExhaustedError:
                 raise
             except LLMExtractionError as e:

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -948,8 +948,9 @@ def _repair_truncated_discovery(partial_text: str) -> dict | None:
             entities = parsed["entities"]
             if isinstance(entities, list) and len(entities) > 0:
                 return parsed
-    except _json.JSONDecodeError:
-        pass
+    except _json.JSONDecodeError as exc:
+        print(f"  [repair] JSON decode failed after truncation repair: {exc}",
+              file=sys.stderr)
 
     return None
 

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -890,8 +890,9 @@ def _repair_truncated_discovery(partial_text: str) -> dict | None:
     When the model hits max_tokens mid-array, the JSON is cut off like:
         {"entities": [..., {"name": "foo", "type": "cha
     
-    Strategy: find the last complete entity object in the array by locating
-    the last `}, {` or `}]` boundary, then close the array and object.
+    Strategy: walk the partial JSON tracking brace depth — each time depth
+    drops from 2→1, we've just closed a complete entity object.  Truncate
+    after the last such close and append `]}` to finish the structure.
 
     Returns:
         Parsed dict with entities array if repair succeeds, None otherwise.
@@ -1890,7 +1891,8 @@ def extract_and_merge(
         # Discovery hit the token ceiling. Retry with 2× token budget first
         # (prefer complete response over lossy repair).
         _retry_max = (_discovery_max_tokens or llm.max_tokens) * 2
-        print(f"  TRUNCATED: Discovery for {turn_id} hit max_tokens={_discovery_max_tokens}, "
+        _effective_max = _discovery_max_tokens or llm.max_tokens
+        print(f"  TRUNCATED: Discovery for {turn_id} hit max_tokens={_effective_max}, "
               f"retrying with max_tokens={_retry_max}...", file=sys.stderr)
         try:
             discovery_result = llm.extract_json(

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -44,7 +44,7 @@ from catalog_merger import (
     _levenshtein,
     CATALOG_KEYS,
 )
-from llm_client import LLMClient, LLMExtractionError, QuotaExhaustedError
+from llm_client import LLMClient, LLMExtractionError, LLMTruncationError, QuotaExhaustedError
 from temporal_extraction import (
     extract_temporal_signals,
     merge_temporal_signals,
@@ -884,6 +884,76 @@ def format_discovery_prompt(turn: dict, known_entities: str) -> str:
     )
 
 
+def _repair_truncated_discovery(partial_text: str) -> dict | None:
+    """Attempt to repair a truncated discovery JSON response.
+
+    When the model hits max_tokens mid-array, the JSON is cut off like:
+        {"entities": [..., {"name": "foo", "type": "cha
+    
+    Strategy: find the last complete entity object in the array by locating
+    the last `}, {` or `}]` boundary, then close the array and object.
+
+    Returns:
+        Parsed dict with entities array if repair succeeds, None otherwise.
+    """
+    import json as _json
+
+    text = partial_text.strip()
+
+    # Strip thinking blocks and markdown fences
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+    fence_match = re.match(r"^```(?:json)?\s*\n(.*)", text, re.DOTALL)
+    if fence_match:
+        text = fence_match.group(1).strip()
+        # Remove trailing ``` if present
+        if text.endswith("```"):
+            text = text[:-3].strip()
+
+    # Find the last complete object boundary in the entities array
+    # Look for the pattern `}` followed by `,` or end — the last complete entry
+    last_complete = -1
+    brace_depth = 0
+    in_string = False
+    escape_next = False
+
+    for i, ch in enumerate(text):
+        if escape_next:
+            escape_next = False
+            continue
+        if ch == '\\' and in_string:
+            escape_next = True
+            continue
+        if ch == '"' and not escape_next:
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == '{':
+            brace_depth += 1
+        elif ch == '}':
+            brace_depth -= 1
+            if brace_depth == 1:
+                # We just closed an entity object (depth goes from 2→1)
+                last_complete = i
+
+    if last_complete <= 0:
+        return None
+
+    # Truncate after the last complete entity object, close the array and outer object
+    repaired = text[:last_complete + 1] + "]}"
+
+    try:
+        parsed = _json.loads(repaired)
+        if isinstance(parsed, dict) and "entities" in parsed:
+            entities = parsed["entities"]
+            if isinstance(entities, list) and len(entities) > 0:
+                return parsed
+    except _json.JSONDecodeError:
+        pass
+
+    return None
+
+
 # Stable attribute keys considered when trimming PC prior context.
 #
 # Why these are included:
@@ -1701,6 +1771,60 @@ def extract_and_merge(
             temperature=_discovery_temp,
             max_tokens=_discovery_max_tokens,
         )
+    except LLMTruncationError as trunc_err:
+        # Discovery hit the token ceiling. Retry with 2× token budget first
+        # (prefer complete response over lossy repair).
+        _retry_max = (_discovery_max_tokens or llm.max_tokens) * 2
+        print(f"  TRUNCATED: Discovery for {turn_id} hit max_tokens={_discovery_max_tokens}, "
+              f"retrying with max_tokens={_retry_max}...", file=sys.stderr)
+        try:
+            discovery_result = llm.extract_json(
+                system_prompt=load_template("entity-discovery"),
+                user_prompt=format_discovery_prompt(turn, known),
+                temperature=_discovery_temp,
+                max_tokens=_retry_max,
+            )
+        except LLMTruncationError as retry_trunc:
+            # Still truncated at 2× — fall back to lossy JSON repair
+            partial = retry_trunc.partial_text
+            print(f"  TRUNCATED (2nd attempt): Still hit limit at {_retry_max}, "
+                  f"attempting repair...", file=sys.stderr)
+            repaired = _repair_truncated_discovery(partial) if partial else None
+            if repaired is not None:
+                print(f"  REPAIRED: Recovered {len(repaired.get('entities', []))} entities "
+                      f"from truncated response", file=sys.stderr)
+                discovery_result = repaired
+            else:
+                # Repair on 2nd attempt failed — try repair on 1st attempt's partial
+                repaired_orig = _repair_truncated_discovery(trunc_err.partial_text)
+                if repaired_orig is not None:
+                    print(f"  REPAIRED (from 1st attempt): Recovered "
+                          f"{len(repaired_orig.get('entities', []))} entities",
+                          file=sys.stderr)
+                    discovery_result = repaired_orig
+                else:
+                    print(f"  WARNING: Entity discovery failed for {turn_id}: "
+                          f"{retry_trunc}", file=sys.stderr)
+                    discovery_result = {"entities": []}
+                    turn_failed = True
+                    _phase_log["discovery_ok"] = False
+                    _phase_log["discovery_error"] = str(retry_trunc)
+        except LLMExtractionError as retry_err:
+            # Non-truncation failure on retry — fall back to repair on original
+            print(f"  WARNING: Retry failed for {turn_id}: {retry_err}, "
+                  f"attempting repair on original...", file=sys.stderr)
+            repaired = _repair_truncated_discovery(trunc_err.partial_text)
+            if repaired is not None:
+                print(f"  REPAIRED: Recovered {len(repaired.get('entities', []))} entities "
+                      f"from original truncated response", file=sys.stderr)
+                discovery_result = repaired
+            else:
+                print(f"  WARNING: Entity discovery failed for {turn_id}: "
+                      f"{retry_err}", file=sys.stderr)
+                discovery_result = {"entities": []}
+                turn_failed = True
+                _phase_log["discovery_ok"] = False
+                _phase_log["discovery_error"] = str(retry_err)
     except QuotaExhaustedError:
         raise
     except LLMExtractionError as e:


### PR DESCRIPTION
## Summary

Fixes #288 — discovery responses for entity-dense turns exceed `discovery_max_tokens` and produce truncated, unparseable JSON.

Three changes that work together:

### 1. Slim discovery output for existing entities (Option D)

The discovery prompt now instructs the model to **omit the `description` field** when `is_new: false`. Existing entities already have descriptions in the catalog — repeating them in discovery output wastes ~30-50 tokens per entity reference. For turns referencing 20+ existing entities, this reduces output by 50-60%.

### 2. `LLMTruncationError` exception + `finish_reason` detection

`llm_client.py` now checks `finish_reason == "length"` on the API response. When detected, it raises `LLMTruncationError` (carrying the partial text) immediately — no point retrying at the same token limit.

### 3. Truncation-aware retry in discovery (retry-first, repair as fallback)

When discovery truncates:
1. **Retry with 2× max_tokens** (e.g. 8192 → 16384) for a complete, lossless response
2. If the retry also truncates: **JSON repair** on the larger partial (find last complete entity object, close the array)
3. If retry errors differently: **JSON repair** on the original partial

Quality/correctness is prioritized over speed — the lossless retry runs first.

### Files Changed

- `templates/extraction/entity-discovery.md` — omit description for existing entities, added slim example
- `tools/llm_client.py` — `LLMTruncationError` class, finish_reason detection, immediate propagation (no retry loop)
- `tools/semantic_extraction.py` — `_repair_truncated_discovery()` JSON repair function, retry-first truncation handler in discovery call

### Testing

- 1369 existing tests pass
- JSON repair function validated against 6 edge cases (truncated mid-object, think blocks, garbage input, empty arrays)

### Observed Failures (from current extraction run, pre-fix)

| Turn | Failure Mode |
|---|---|
| turn-217 | Truncated at char 8606 (JSON parse error) |
| turn-288 | Truncated at char 28266 |
| turn-300 | Malformed confidence (`0-1.0`) + truncation |
| turn-302 | Truncated at char 21717 |
| turn-309 | Malformed confidence (`0-9`) at char 134 |

All except turn-300/309 (which have a different model output bug) would be resolved by this fix.

Closes #288
