### PR TITLE
fix: clarify thinking suppression behavior and add fallback JSON parser

### DIFF
--- a/docs/openvino-b70-findings.md
+++ b/docs/openvino-b70-findings.md
@@ -274,6 +274,6 @@ For 344 turns with realistic extraction prompts:
 - **Per-request speed is lower than llama-server**: 38 tok/s single-stream OpenVINO vs 60 tok/s llama-server. But this is irrelevant when batching gives 4x aggregate throughput
 - **OVMS is unnecessary**: The native Python `ContinuousBatchingPipeline` API provides batching, prefix caching, and KV management without Docker complexity
 - **Model cache eliminates startup cost**: 17.8s → 2.1s load time with `CACHE_DIR`
-- **Thinking suppression works**: `enable_thinking=false` in chat template suppresses structured `<think>` reasoning blocks (which would otherwise consume 2000–3000 tokens). The model may still emit brief inline reasoning text before JSON; this is handled by the fallback JSON extractor in `llm_client.py`
+- **Thinking suppression works**: `enable_thinking=false` in chat template suppresses structured `<think>` reasoning blocks (which would otherwise consume 2000–3000 tokens). The model may still emit brief inline reasoning text before JSON; this is handled by the fallback JSON extractor in `tools/llm_client.py`
 - **Practical implication**: If we process 4 extraction turns concurrently, 344 turns completes in ~35-50 minutes vs ~2h with llama-server
 - **Next step**: Build a simple Python REST wrapper around `ContinuousBatchingPipeline` to replace llama-server for extraction workloads

--- a/docs/openvino-b70-findings.md
+++ b/docs/openvino-b70-findings.md
@@ -192,7 +192,7 @@ This initial investigation has significant methodological problems that invalida
 ### Methodology Fixes Applied
 
 All Phase 1 caveats addressed:
-- **Thinking disabled**: Chat template with `enable_thinking=false` prepends empty `<think>\n</think>\n\n` block, model outputs clean JSON
+- **Thinking disabled**: Chat template with `enable_thinking=false` prepends empty `<think>\n</think>\n\n` block, suppressing structured reasoning tokens. Note: the model may still emit brief inline reasoning text (e.g. "Okay, let's analyze...") before JSON — this is not the `<think>` mechanism but normal model verbosity, handled client-side by the fallback JSON extractor in `tools/llm_client.py`
 - **Model cache enabled**: `CACHE_DIR` reduces load time from 17.8s → 2.1-2.4s
 - **ContinuousBatchingPipeline tested**: Batched inference with `SchedulerConfig`
 - **Prefix caching enabled**: `sched_cfg.enable_prefix_caching = True`
@@ -274,6 +274,6 @@ For 344 turns with realistic extraction prompts:
 - **Per-request speed is lower than llama-server**: 38 tok/s single-stream OpenVINO vs 60 tok/s llama-server. But this is irrelevant when batching gives 4x aggregate throughput
 - **OVMS is unnecessary**: The native Python `ContinuousBatchingPipeline` API provides batching, prefix caching, and KV management without Docker complexity
 - **Model cache eliminates startup cost**: 17.8s → 2.1s load time with `CACHE_DIR`
-- **Thinking suppression works**: `enable_thinking=false` in chat template produces clean JSON output
+- **Thinking suppression works**: `enable_thinking=false` in chat template suppresses structured `<think>` reasoning blocks (which would otherwise consume 2000–3000 tokens). The model may still emit brief inline reasoning text before JSON; this is handled by the fallback JSON extractor in `llm_client.py`
 - **Practical implication**: If we process 4 extraction turns concurrently, 344 turns completes in ~35-50 minutes vs ~2h with llama-server
 - **Next step**: Build a simple Python REST wrapper around `ContinuousBatchingPipeline` to replace llama-server for extraction workloads

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -235,6 +235,69 @@ class TestParseJsonThinkStripping:
 
 
 # ---------------------------------------------------------------------------
+# Fallback JSON extraction (inline preamble handling)
+# ---------------------------------------------------------------------------
+
+class TestFallbackJsonExtraction:
+    """Verify _parse_json_response fallback handles inline preamble text."""
+
+    def _make_client(self, tmp_path):
+        cfg = _write_config(tmp_path)
+        return LLMClient(config_path=cfg)
+
+    def test_preamble_before_json(self, tmp_path):
+        """Model emits reasoning text before JSON object."""
+        client = self._make_client(tmp_path)
+        raw = 'Okay, let\'s analyze this turn.\n\n{"entities": [{"name": "Elf"}]}'
+        result = client._parse_json_response(raw)
+        assert result == {"entities": [{"name": "Elf"}]}
+
+    def test_preamble_with_braces_before_json(self, tmp_path):
+        """Preamble contains non-JSON braces (e.g. {foo}) before real JSON."""
+        client = self._make_client(tmp_path)
+        raw = 'The structure {unclear} needs analysis.\n{"entities": []}'
+        result = client._parse_json_response(raw)
+        assert result == {"entities": []}
+
+    def test_braces_in_json_strings(self, tmp_path):
+        """JSON containing brace characters inside string values."""
+        client = self._make_client(tmp_path)
+        raw = 'Preamble text\n{"desc": "a {curly} thing", "count": 1}'
+        result = client._parse_json_response(raw)
+        assert result == {"desc": "a {curly} thing", "count": 1}
+
+    def test_trailing_text_after_json(self, tmp_path):
+        """Model emits text after JSON — should still parse the object."""
+        client = self._make_client(tmp_path)
+        raw = '{"entities": []}\n\nHope that helps!'
+        result = client._parse_json_response(raw)
+        assert result == {"entities": []}
+
+    def test_no_json_at_all_raises_with_details(self, tmp_path):
+        """No JSON anywhere — error includes original parse details."""
+        from llm_client import LLMExtractionError
+        client = self._make_client(tmp_path)
+        raw = 'This is just plain text with no JSON at all.'
+        try:
+            client._parse_json_response(raw)
+            assert False, "Should have raised"
+        except LLMExtractionError as e:
+            assert "Initial parse error" in str(e)
+            assert "no valid JSON object found" in str(e)
+
+    def test_invalid_json_after_preamble_raises_with_details(self, tmp_path):
+        """Malformed JSON after preamble — error includes candidate error."""
+        from llm_client import LLMExtractionError
+        client = self._make_client(tmp_path)
+        raw = 'Here is the result:\n{"entities": [INVALID]}'
+        try:
+            client._parse_json_response(raw)
+            assert False, "Should have raised"
+        except LLMExtractionError as e:
+            assert "Initial parse error" in str(e)
+
+
+# ---------------------------------------------------------------------------
 # Malformed confidence repair (#290)
 # ---------------------------------------------------------------------------
 

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -513,11 +513,36 @@ class LLMClient:
 
         try:
             return json.loads(text)
-        except json.JSONDecodeError as e:
-            raise LLMExtractionError(
-                f"Failed to parse JSON from LLM response: {e}\n"
-                f"Raw response (first 500 chars): {raw_text[:500]}"
-            )
+        except json.JSONDecodeError:
+            pass
+
+        # Fallback: model may have emitted reasoning text before/after JSON.
+        # Find the first top-level JSON object in the response.
+        brace_start = text.find("{")
+        if brace_start != -1:
+            depth = 0
+            for i in range(brace_start, len(text)):
+                if text[i] == "{":
+                    depth += 1
+                elif text[i] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        candidate = text[brace_start:i + 1]
+                        # Apply confidence fix to candidate too
+                        candidate = re.sub(
+                            r'"confidence":\s*(\d+)-(\d+(?:\.\d+)?)',
+                            self._fix_malformed_confidence,
+                            candidate,
+                        )
+                        try:
+                            return json.loads(candidate)
+                        except json.JSONDecodeError:
+                            break
+
+        raise LLMExtractionError(
+            f"Failed to parse JSON from LLM response: no valid JSON object found.\n"
+            f"Raw response (first 500 chars): {raw_text[:500]}"
+        )
 
     @staticmethod
     def _fix_malformed_confidence(match: re.Match) -> str:

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -513,34 +513,33 @@ class LLMClient:
 
         try:
             return json.loads(text)
-        except json.JSONDecodeError:
-            pass
+        except json.JSONDecodeError as initial_err:
+            initial_error = initial_err
 
         # Fallback: model may have emitted reasoning text before/after JSON.
-        # Find the first top-level JSON object in the response.
-        brace_start = text.find("{")
-        if brace_start != -1:
-            depth = 0
-            for i in range(brace_start, len(text)):
-                if text[i] == "{":
-                    depth += 1
-                elif text[i] == "}":
-                    depth -= 1
-                    if depth == 0:
-                        candidate = text[brace_start:i + 1]
-                        # Apply confidence fix to candidate too
-                        candidate = re.sub(
-                            r'"confidence":\s*(\d+)-(\d+(?:\.\d+)?)',
-                            self._fix_malformed_confidence,
-                            candidate,
-                        )
-                        try:
-                            return json.loads(candidate)
-                        except json.JSONDecodeError:
-                            break
+        # Use json.JSONDecoder().raw_decode which correctly handles braces
+        # inside string literals and continues scanning on failure.
+        decoder = json.JSONDecoder()
+        search_start = 0
+        last_candidate_err = None
+        while search_start < len(text):
+            brace_pos = text.find("{", search_start)
+            if brace_pos == -1:
+                break
+            try:
+                obj, end_idx = decoder.raw_decode(text, brace_pos)
+                return obj
+            except json.JSONDecodeError as e:
+                last_candidate_err = e
+                # Skip past this position and try the next '{'
+                search_start = brace_pos + 1
 
+        detail = f"Initial parse error: {initial_error}"
+        if last_candidate_err and last_candidate_err is not initial_error:
+            detail += f"\nFallback candidate error: {last_candidate_err}"
         raise LLMExtractionError(
             f"Failed to parse JSON from LLM response: no valid JSON object found.\n"
+            f"{detail}\n"
             f"Raw response (first 500 chars): {raw_text[:500]}"
         )
 


### PR DESCRIPTION
## Summary

Corrects an overclaim in `docs/openvino-b70-findings.md` that stated `enable_thinking=False` produces "clean JSON" output. In practice, the model suppresses structured `<think>` reasoning blocks but may still emit brief inline reasoning text before JSON (normal model verbosity, not the thinking mechanism).

Also includes the corresponding code fix: a fallback JSON extractor in `tools/llm_client.py` that finds the first balanced-brace JSON object when direct `json.loads()` fails due to inline preamble text.

## Changes

### docs/openvino-b70-findings.md

- Phase 2 "Methodology Fixes Applied" section: replaced "model outputs clean JSON" with accurate description of behavior
- Key Takeaways section: replaced "produces clean JSON output" with explanation of what's suppressed and how inline reasoning is handled

### tools/llm_client.py

- `_parse_json_response()`: added fallback path that scans for the first top-level `{...}` JSON object when initial `json.loads()` fails
- Handles qwen3-8b emitting conversational preamble (e.g. "Okay, let's analyze this turn...") before the actual JSON response
- All 37 existing tests pass
