### PR TITLE
docs: add documentation coverage for PRs #296-#307

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A structured knowledge extraction and state-tracking engine for AI-driven narrat
 - A **structured state layer** that extracts entities, relationships, and events from narrative text and maintains them as a schema-defined, evolving knowledge base (validated when `jsonschema` is installed or when running `tools/validate.py`)
 - A **player-side assistant** that independently tracks canonical world state, not relying on the DM's narration alone
 - A **schema-first extraction pipeline** using LLMs (local or cloud) to convert unstructured narrative into structured, provenance-tracked data
-- **Provider-agnostic** — runs on local models (Ollama, llama-server, OpenVINO) or cloud APIs (Gemini, OpenAI) with a config change; supports automatic fallback to a secondary provider when the primary is unavailable
+- **Provider-agnostic** — runs on local models (Ollama, llama-server, OpenVINO) or cloud APIs (Gemini, OpenAI) with a config change; supports automatic fallback to a secondary provider when the primary exhausts retries
 
 ## What This Is Not
 
@@ -152,9 +152,9 @@ tools/
   analyze_next_move.py           # Generate next-move analysis and prompt candidates
   validate.py                    # Validate JSON files against schemas
   semantic_extraction.py         # LLM-based entity/relationship/event extraction
-  catalog_merger.py              # Merge extracted data into framework catalogs
+  catalog_merger.py              # Merge extracted data into framework catalogs (includes context-aware entity selection)
   llm_client.py                  # Provider-agnostic LLM client wrapper (with fallback provider support)
-  build_context.py               # Build focused per-turn entity context (context-aware selection)
+  build_context.py               # Build focused per-turn entity context
   extract_structured_data.py     # Extract inline game markers and temporal events
   generate_wiki_pages.py         # Generate markdown wiki pages from V2 entity files
   migrate_catalogs_v2.py         # One-time V1→V2 catalog layout migration

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A structured knowledge extraction and state-tracking engine for AI-driven narrat
 - A **structured state layer** that extracts entities, relationships, and events from narrative text and maintains them as a schema-defined, evolving knowledge base (validated when `jsonschema` is installed or when running `tools/validate.py`)
 - A **player-side assistant** that independently tracks canonical world state, not relying on the DM's narration alone
 - A **schema-first extraction pipeline** using LLMs (local or cloud) to convert unstructured narrative into structured, provenance-tracked data
-- **Provider-agnostic** — runs on local models (Ollama) or cloud APIs (Gemini, OpenAI) with a config change
+- **Provider-agnostic** — runs on local models (Ollama, llama-server, OpenVINO) or cloud APIs (Gemini, OpenAI) with a config change; supports automatic fallback to a secondary provider when the primary is unavailable
 
 ## What This Is Not
 
@@ -35,7 +35,7 @@ LLMs lose coherence over long interactions. Chat history is not memory. When a c
 Given a sequence of DM outputs and player prompts, the system:
 
 1. **Preserves** the exact transcript as an immutable source of truth
-2. **Extracts** entities, relationships, events, and temporal markers via a four-agent LLM pipeline
+2. **Extracts** entities, relationships, events, and temporal markers via a five-agent LLM pipeline
 3. **Maintains** a schema-defined knowledge base of characters, locations, factions, items, relationships, and events — plot threads are tracked separately and currently maintained manually or with Copilot assistance rather than by the automated extraction pipeline
 4. **Tracks** player objectives, evidence classification, and DM behavior patterns
 5. **Analyzes** the current situation and generates candidate next-player prompts
@@ -60,7 +60,7 @@ docs/
   idea-discussion.md
 
 config/
-  llm.json                     # LLM provider settings (model, endpoint)
+  llm.json                     # LLM provider settings (model, endpoint, fallback provider)
 
 schemas/
   turn.schema.json
@@ -153,14 +153,18 @@ tools/
   validate.py                    # Validate JSON files against schemas
   semantic_extraction.py         # LLM-based entity/relationship/event extraction
   catalog_merger.py              # Merge extracted data into framework catalogs
-  llm_client.py                  # Provider-agnostic LLM client wrapper
-  build_context.py               # Build focused per-turn entity context
+  llm_client.py                  # Provider-agnostic LLM client wrapper (with fallback provider support)
+  build_context.py               # Build focused per-turn entity context (context-aware selection)
   extract_structured_data.py     # Extract inline game markers and temporal events
   generate_wiki_pages.py         # Generate markdown wiki pages from V2 entity files
   migrate_catalogs_v2.py         # One-time V1→V2 catalog layout migration
   synthesis.py                   # Data foundation for wiki synthesis: event grouping, phase segmentation, relationship arc summarization
   narrative_synthesis.py         # LLM-powered narrative wiki page generation (LLM calls and page assembly)
+  dedup_audit.py                 # LLM-assisted post-extraction dedup (identify, score, merge/flag duplicates)
   export_book_skeleton.py        # Generate book/fiction outline (placeholder)
+
+server/
+  ov_serve.py                    # OpenVINO GenAI REST server (OpenAI-compatible endpoint)
 
 examples/
   demo-session/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -238,7 +238,9 @@ All data structures are defined in `schemas/`. See each schema file for field de
 | `tools/catalog_merger.py` | Merge extracted entities into framework catalog files |
 | `tools/generate_story_summary.py` | Generate high-level story arc summary from extracted data (LLM or data-only mode) |
 | `tools/build_scene_graph.py` | Build cross-type spatial/temporal index from entity catalogs (#257) |
-| `tools/llm_client.py` | Provider-agnostic LLM client (OpenAI, Ollama, Google Gemini, etc.) |
+| `tools/llm_client.py` | Provider-agnostic LLM client (OpenAI, Ollama, Google Gemini, etc.) with automatic fallback provider support (#301) |
+| `tools/dedup_audit.py` | LLM-assisted post-extraction dedup: identifies duplicate entities via name similarity heuristics, scores with LLM, auto-merges or flags for review (#306) |
+| `server/ov_serve.py` | OpenVINO GenAI REST server — OpenAI-compatible `/v1/chat/completions` endpoint using `ContinuousBatchingPipeline` with prefix caching and dynamic batching (#299) |
 | `tools/start_extraction_detached.ps1` | Launch semantic extraction in a detached process with log/PID files; supports `-Framework`/`-PlayerLabel` passthrough and safe argument quoting for values with spaces |
 | `tools/watch_extraction_detached.ps1` | Show status and tail logs for detached extraction runs |
 | `tools/stop_extraction_detached.ps1` | Stop detached extraction runs by PID file |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -97,13 +97,21 @@ Goals:
 
 **NPU investigation (#65):** AMD XDNA1 (Phoenix) NPU cannot run LLM inference — AMD only supports LLMs on Strix Point (XDNA2) and newer. The Radeon 780M iGPU (~10-15 tok/s) is too slow to be useful. A dedicated GPU server (e.g., used RTX 3090 in a separate machine) is the viable path to exceed RTX 4070 performance.
 
-Remaining work:
-- Fallback provider chain in `tools/llm_client.py` (local → cloud)
-- CLI `--provider` override for per-run provider selection
-- Batch processing mode for unattended overnight extraction (**partially implemented** via detached helper scripts: `tools/start_extraction_detached.ps1`, `tools/watch_extraction_detached.ps1`, `tools/stop_extraction_detached.ps1`; launcher now safely quotes spaced arguments and supports framework/player-label passthrough)
+Completed:
+- **Fallback provider chain** (#301): When the primary LLM exhausts all `retry_attempts`, the client automatically routes to a fallback provider configured via the `"fallback"` block in `config/llm.json`. `LLMTruncationError` and `QuotaExhaustedError` bypass the fallback and propagate immediately.
+- **OpenVINO GenAI REST server** (#299): `server/ov_serve.py` provides an OpenAI-compatible `/v1/chat/completions` endpoint using `ContinuousBatchingPipeline` with prefix caching, dynamic batching, and thinking suppression for Intel Arc GPUs.
+- **Context-aware entity selection** (#296): Multi-tier entity context selection for discovery prompts — mentioned entities, co-located entities, one-hop relationships, then recency backfill — replacing recency-only ordering.
+- **Entity type classification guidance** (#305): The entity discovery template includes a compact type classification guide with positive examples and explicit NEVER-use rules, plus a post-discovery programmatic filter that rejects misclassified entities.
+- **Alias conflict rejection guard** (#307): `_filter_pc_aliases()` and `_filter_entity_aliases()` cross-reference aliases against all entity names in the catalog, rejecting any alias that matches another entity's primary name.
+- **LLM-assisted dedup audit** (#306): `tools/dedup_audit.py` identifies duplicate entities via name similarity heuristics, scores candidate pairs with an LLM call, auto-merges high-confidence duplicates (≥0.9) or flags medium-confidence pairs for human review.
+- **Thinking suppression + fallback JSON parser** (#300): Robust output parsing strips `<think>` blocks, handles markdown code fences, and scans for valid JSON objects when initial parse fails.
+- Batch processing mode for unattended overnight extraction (**implemented** via detached helper scripts: `tools/start_extraction_detached.ps1`, `tools/watch_extraction_detached.ps1`, `tools/stop_extraction_detached.ps1`; launcher safely quotes spaced arguments and supports framework/player-label passthrough)
 - Provider setup documentation in `docs/usage.md`
-- Quality validation of `qwen2.5:7b` as a faster alternative to 14B
 - **Segmented extraction** (#141, #197): Long sessions are extracted in configurable segments to stay within model context limits. Each segment starts with a clean entity catalog; a reconciliation pass merges the results. The bootstrap default now auto-enables `--segment-size 100` when session size exceeds 150 turns (pass `--segment-size 0` to disable).
+
+Remaining work:
+- CLI `--provider` override for per-run provider selection
+- Quality validation of `qwen2.5:7b` as a faster alternative to 14B
 
 Design implications for earlier phases:
 - Keep context loading modular (catalog-first) so smaller local models can handle targeted tasks

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -346,21 +346,23 @@ pip install openvino openvino-genai optimum[openvino] fastapi uvicorn
 optimum-cli export openvino --model Qwen/Qwen3-8B --weight-format int4_sym \
     --trust-remote-code ./models/qwen3-8b-int4-ov
 
-# Start the server (any OpenAI-compatible wrapper around ContinuousBatchingPipeline)
-python ov_serve.py --model ./models/qwen3-8b-int4-ov --port 8000
+# Start the server using the included ov_serve.py (#299)
+python server/ov_serve.py --model ./models/qwen3-8b-int4-ov --port 8000
 ```
 
-The server wrapper should handle:
+The included `server/ov_serve.py` provides:
 
-- **Thinking suppression** — pass `enable_thinking=False` (a Python `bool`) in
-  the chat template's `extra_context` dict when calling
-  `tokenizer.apply_chat_template(..., extra_context={'enable_thinking': False})`.
-  This prevents qwen3 models from wasting ~80% of output tokens on `<think>`
+- **OpenAI-compatible API** — `/v1/chat/completions`, `/v1/models`, `/health` endpoints
+- **Thinking suppression** — passes `enable_thinking=False` in
+  `apply_chat_template(..., extra_context={'enable_thinking': False})`,
+  preventing qwen3 models from wasting ~80% of output tokens on `<think>`
   blocks. Unlike llama-server's `--reasoning-format none`, OpenVINO controls
   this at the tokenizer level.
-- **Continuous batching** — queue concurrent requests and process them in
-  batches for higher aggregate throughput.
-- **Robust output parsing** — strip any residual `<think>` blocks and
+- **Continuous batching** — queues concurrent requests and processes them in
+  batches via `ContinuousBatchingPipeline` for higher aggregate throughput.
+- **Prefix caching** — reuses KV cache for shared prompt prefixes across
+  requests in the same batch.
+- **Robust output parsing** — strips any residual `<think>` blocks and
   markdown fences before returning content.
 
 Configure `config/llm.json` on the client machine:
@@ -405,6 +407,21 @@ This dramatically slows extraction and increases truncation risk.
   template's `extra_context` parameter when calling `apply_chat_template()`.
   The extraction pipeline's JSON parser also strips any residual `<think>`
   blocks as a safety net.
+
+#### Fallback JSON Parser (#300)
+
+The LLM client includes a multi-tier JSON parser that handles non-standard
+model output gracefully:
+
+1. **Direct parse** — attempt `json.loads()` on the raw response content
+2. **Think-block stripping** — remove `<think>...</think>` blocks and retry
+3. **Fence extraction** — extract content from `` ```json ... ``` `` fences
+4. **Object scanning** — scan for the first valid `{...}` JSON object in the
+   output (handles cases where reasoning text precedes the JSON)
+
+This eliminates the need for `response_format` enforcement on thinking-capable
+models and recovers valid JSON from outputs that include reasoning preambles
+or markdown formatting.
 
 #### Server Restart After Interrupted Extraction
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -362,8 +362,8 @@ The included `server/ov_serve.py` provides:
   batches via `ContinuousBatchingPipeline` for higher aggregate throughput.
 - **Prefix caching** — reuses KV cache for shared prompt prefixes across
   requests in the same batch.
-- **Robust output parsing** — strips any residual `<think>` blocks and
-  markdown fences before returning content.
+- **Robust output parsing** — strips any residual `<think>` blocks before
+  returning content (fence stripping is handled client-side by `llm_client.py`).
 
 Configure `config/llm.json` on the client machine:
 
@@ -410,14 +410,16 @@ This dramatically slows extraction and increases truncation risk.
 
 #### Fallback JSON Parser (#300)
 
-The LLM client includes a multi-tier JSON parser that handles non-standard
-model output gracefully:
+The LLM client includes a robust JSON parser (`_parse_json_response`) that
+handles non-standard model output gracefully:
 
-1. **Direct parse** — attempt `json.loads()` on the raw response content
-2. **Think-block stripping** — remove `<think>...</think>` blocks and retry
-3. **Fence extraction** — extract content from `` ```json ... ``` `` fences
-4. **Object scanning** — scan for the first valid `{...}` JSON object in the
-   output (handles cases where reasoning text precedes the JSON)
+1. **Normalize** — strip `<think>...</think>` blocks, extract content from
+   markdown code fences, and fix malformed confidence values (e.g.
+   `0-1.0` → `1.0`)
+2. **Parse** — attempt `json.loads()` on the cleaned text
+3. **Fallback scan** — on parse failure, use `JSONDecoder.raw_decode` to
+   find the first valid `{...}` object in the output (handles cases where
+   reasoning text or other preamble precedes the JSON)
 
 This eliminates the need for `response_format` enforcement on thinking-capable
 models and recovers valid JSON from outputs that include reasoning preambles


### PR DESCRIPTION
## Summary

Add documentation coverage for seven recently merged PRs (#296, #299, #300, #301, #305, #306, #307) across all four documentation files.

## Changes

### README.md
- Fix "four-agent" to "five-agent" LLM pipeline (temporal extraction is Phase 5)
- Add llama-server and OpenVINO to provider list in "What This Is"
- Add `fallback` mention to `config/llm.json` description
- Add `dedup_audit.py` and `server/ov_serve.py` to repository structure
- Annotate `llm_client.py` (fallback support) and `build_context.py` (context-aware selection)

### docs/architecture.md
- Add `tools/dedup_audit.py` to Tool Scripts table (#306)
- Add `server/ov_serve.py` to Tool Scripts table (#299)
- Update `tools/llm_client.py` description to mention fallback provider (#301)

### docs/roadmap.md
- Restructure Phase 3 into Completed / Remaining work sections
- Move fallback provider chain from "remaining" to "completed" (#301)
- Add all seven features to the Completed list with PR references

### docs/usage.md
- Update OpenVINO server setup to reference the project's own `server/ov_serve.py` (#299)
- Document prefix caching and dynamic batching features
- Add "Fallback JSON Parser (#300)" subsection documenting the 4-tier parse strategy
