### PR TITLE
fix: correct token heuristic and add context budget pre-flight check

### DIFF
--- a/tests/test_bounded_entity_context.py
+++ b/tests/test_bounded_entity_context.py
@@ -33,8 +33,8 @@ def _make_catalogs(entities):
 
 class TestEstimateTokens:
     def test_basic(self):
-        assert _estimate_tokens("abcd") == 1
-        assert _estimate_tokens("a" * 100) == 25
+        assert _estimate_tokens("abc") == 1
+        assert _estimate_tokens("a" * 100) == 33
 
     def test_empty(self):
         assert _estimate_tokens("") == 1  # min 1
@@ -96,11 +96,12 @@ class TestBoundedFormatRecentPrioritization:
                                 aliases=["D", "Dormy"],
                                 last_updated_turn="turn-010")]
         catalogs = _make_catalogs(recent + dormant)
-        # Budget of 20 tokens is below unbounded size (31 tokens), so
-        # the fast-path won't apply and tiering kicks in.
+        # Budget is enough for one full line + one brief line but below the
+        # unbounded output with both entities in full detail, so tiering
+        # kicks in and the dormant entity gets degraded to brief.
         result = format_known_entities_bounded(
             catalogs, current_turn=100,
-            entity_context_budget=20,
+            entity_context_budget=27,
             recency_window=10)
         # Recent entity should have full detail
         assert "Active hero" in result

--- a/tests/test_preflight_budget.py
+++ b/tests/test_preflight_budget.py
@@ -3,13 +3,23 @@
 Tests the WARNING/NOTICE messages emitted to stderr when estimated
 input + output approaches or exceeds the context window.
 """
+import contextlib
 import io
 import json
 import sys
 import os
 import unittest
+from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'tools'))
+
+# Mock openai so tests don't depend on optional LLM dependency
+if "openai" not in sys.modules:
+    _mock_openai = MagicMock()
+    _mock_openai.OpenAI = MagicMock
+    sys.modules["openai"] = _mock_openai
+
+from llm_client import LLMClient
 
 
 def _make_llm_client(context_length=32768, max_tokens=4096):
@@ -30,7 +40,6 @@ def _make_llm_client(context_length=32768, max_tokens=4096):
     try:
         with os.fdopen(fd, 'w') as f:
             json.dump(config, f)
-        from llm_client import LLMClient
         client = LLMClient(path)
     finally:
         os.unlink(path)
@@ -41,14 +50,11 @@ def _capture_preflight(client, sys_prompt, user_prompt, max_tokens=None):
     """Call extract_json and capture stderr. Expects the LLM call to fail
     (no server) — we only care about the pre-flight output."""
     stderr = io.StringIO()
-    old_stderr = sys.stderr
-    sys.stderr = stderr
-    try:
-        client.extract_json(sys_prompt, user_prompt, max_tokens=max_tokens)
-    except Exception:
-        pass  # Expected — no server running on port 59999
-    finally:
-        sys.stderr = old_stderr
+    with contextlib.redirect_stderr(stderr):
+        try:
+            client.extract_json(sys_prompt, user_prompt, max_tokens=max_tokens)
+        except Exception:
+            pass  # Expected — no server running on port 59999
     return stderr.getvalue()
 
 

--- a/tests/test_preflight_budget.py
+++ b/tests/test_preflight_budget.py
@@ -1,0 +1,102 @@
+"""Unit tests for the context budget pre-flight check in LLMClient.extract_json.
+
+Tests the WARNING/NOTICE messages emitted to stderr when estimated
+input + output approaches or exceeds the context window.
+"""
+import io
+import json
+import sys
+import os
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'tools'))
+
+
+def _make_llm_client(context_length=32768, max_tokens=4096):
+    """Construct a real LLMClient from a temp config file."""
+    import tempfile
+    config = {
+        "provider": "openai",
+        "base_url": "http://localhost:59999/v1",
+        "model": "test-model",
+        "api_key_env": "",
+        "temperature": 0.3,
+        "max_tokens": max_tokens,
+        "context_length": context_length,
+        "retry_attempts": 1,
+        "timeout_seconds": 1,
+    }
+    fd, path = tempfile.mkstemp(suffix=".json")
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(config, f)
+        from llm_client import LLMClient
+        client = LLMClient(path)
+    finally:
+        os.unlink(path)
+    return client
+
+
+def _capture_preflight(client, sys_prompt, user_prompt, max_tokens=None):
+    """Call extract_json and capture stderr. Expects the LLM call to fail
+    (no server) — we only care about the pre-flight output."""
+    stderr = io.StringIO()
+    old_stderr = sys.stderr
+    sys.stderr = stderr
+    try:
+        client.extract_json(sys_prompt, user_prompt, max_tokens=max_tokens)
+    except Exception:
+        pass  # Expected — no server running on port 59999
+    finally:
+        sys.stderr = old_stderr
+    return stderr.getvalue()
+
+
+class TestPreFlightBudgetCheck(unittest.TestCase):
+
+    def test_no_warning_small_prompt(self):
+        """Small prompt should produce no WARNING or NOTICE."""
+        client = _make_llm_client(context_length=32768, max_tokens=4096)
+        output = _capture_preflight(client, "Short system.", "Short user.", max_tokens=100)
+        self.assertNotIn("WARNING", output)
+        self.assertNotIn("NOTICE", output)
+
+    def test_warning_on_overflow(self):
+        """Prompt that exceeds context window should emit WARNING."""
+        client = _make_llm_client(context_length=32768, max_tokens=6144)
+        # ~33,333 tokens at //3, + 6144 output = ~39k > 32k
+        big_prompt = "x" * 100000
+        output = _capture_preflight(client, "sys", big_prompt, max_tokens=6144)
+        self.assertIn("WARNING", output)
+        self.assertIn("exceeds context window", output)
+
+    def test_notice_on_tight_fit(self):
+        """Prompt that barely fits should emit NOTICE."""
+        client = _make_llm_client(context_length=32768, max_tokens=4096)
+        # Target: input ~27.3k tokens, output 4096 → ~31.4k, headroom ~1.3k < 5% of 32k (1638)
+        tight_prompt = "y" * 82000
+        output = _capture_preflight(client, "s", tight_prompt, max_tokens=4096)
+        self.assertIn("NOTICE", output)
+        self.assertIn("Tight context budget", output)
+
+    def test_no_check_without_context_length(self):
+        """When context_length is None, no check is performed."""
+        client = _make_llm_client(context_length=32768, max_tokens=4096)
+        client.context_length = None  # Override after construction
+        big_prompt = "z" * 100000
+        output = _capture_preflight(client, "sys", big_prompt, max_tokens=6144)
+        self.assertNotIn("WARNING", output)
+        self.assertNotIn("NOTICE", output)
+
+    def test_no_warning_at_comfortable_margin(self):
+        """Prompt with >5% headroom should produce no warning."""
+        client = _make_llm_client(context_length=32768, max_tokens=4096)
+        # ~20k tokens input + 4096 output = ~24k, headroom ~8.7k > 5% (1638)
+        prompt = "a" * 60000
+        output = _capture_preflight(client, "sys", prompt, max_tokens=4096)
+        self.assertNotIn("WARNING", output)
+        self.assertNotIn("NOTICE", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -360,8 +360,13 @@ def format_known_entities(catalogs: dict) -> str:
 
 
 def _estimate_tokens(text: str) -> int:
-    """Rough token estimate: ~4 characters per token."""
-    return max(1, len(text) // 4)
+    """Rough token estimate: ~3 characters per token.
+
+    BPE tokenizers (Qwen, Llama, GPT) average 2.5–3.5 characters per
+    token depending on content.  Using 3 as the divisor is conservative
+    enough to avoid under-counting while keeping the estimate cheap.
+    """
+    return max(1, len(text) // 3)
 
 
 def _format_entity_full(entity: dict) -> str:
@@ -984,6 +989,8 @@ def merge_entity(catalogs: dict, entity: dict) -> None:
             break
 
     # Guard: repair empty first_seen_turn before merge (#241)
+    # Primary stamping is now done in _coerce_entity_fields (programmatic
+    # layer), but keep this as a safety net for direct merge_entity callers.
     fst = entity.get("first_seen_turn")
     if not fst or (isinstance(fst, str) and not re.match(r"^turn-[0-9]{3,}$", fst)):
         fallback = entity.get("last_updated_turn", "")

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -430,8 +430,8 @@ class LLMClient:
 
         # --- Input budget pre-flight check ---
         # Estimate whether input + requested output can fit in the context
-        # window.  Uses a conservative 3 chars/token heuristic.  Warns on
-        # tight fits; raises on clear overflows so callers can skip or trim.
+        # window.  Uses a conservative 3 chars/token heuristic.  Emits
+        # WARNING on overflow and NOTICE on tight fits (< 5% headroom).
         effective_max = max_tokens if max_tokens is not None else self.max_tokens
         if self.context_length:
             input_chars = len(system_prompt) + len(user_prompt)

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -428,10 +428,36 @@ class LLMClient:
             {"role": "user", "content": user_prompt},
         ]
 
+        # --- Input budget pre-flight check ---
+        # Estimate whether input + requested output can fit in the context
+        # window.  Uses a conservative 3 chars/token heuristic.  Warns on
+        # tight fits; raises on clear overflows so callers can skip or trim.
+        effective_max = max_tokens if max_tokens is not None else self.max_tokens
+        if self.context_length:
+            input_chars = len(system_prompt) + len(user_prompt)
+            estimated_input = max(1, input_chars // 3)
+            # ~50 tokens for chat-template framing (role markers, <think> block)
+            estimated_total = estimated_input + effective_max + 50
+            headroom = self.context_length - estimated_total
+            if headroom < 0:
+                print(
+                    f"  WARNING: Input ({estimated_input} tok) + output "
+                    f"({effective_max} tok) exceeds context window "
+                    f"({self.context_length} tok) by ~{-headroom} tokens. "
+                    f"Output will likely be truncated.",
+                    file=sys.stderr,
+                )
+            elif headroom < self.context_length * 0.05:
+                print(
+                    f"  NOTICE: Tight context budget — input ~{estimated_input} "
+                    f"tok + output {effective_max} tok, only ~{headroom} tok "
+                    f"headroom in {self.context_length} tok window.",
+                    file=sys.stderr,
+                )
+
         last_error = None
         for attempt in range(self.retry_attempts):
             try:
-                effective_max = max_tokens if max_tokens is not None else self.max_tokens
                 effective_temp = temperature if temperature is not None else self.temperature
 
                 # Ollama streaming path — uses native /api/chat with

--- a/tools/narrative_synthesis.py
+++ b/tools/narrative_synthesis.py
@@ -447,8 +447,8 @@ def generate_item_summary(llm_client, item_input: dict) -> str:
 
 
 def _estimate_tokens(prompt: str, response: str) -> int:
-    """Rough token estimate (~4 chars per token)."""
-    return (len(prompt) + len(response)) // 4
+    """Rough token estimate (~3 chars per token)."""
+    return (len(prompt) + len(response)) // 3
 
 
 def _parse_biography_response(raw_response: str, fallback_name: str) -> tuple[str, str]:


### PR DESCRIPTION
## Summary

Fixes the token estimation heuristic and adds a pre-flight context budget check to catch prompt overflows before they reach the LLM.

## Token Heuristic Fix

The `_estimate_tokens()` function used `len(text) // 4` (4 chars/token), which underestimates actual BPE tokenizer output by ~25%. Changed to `len(text) // 3` to better match Qwen3/Llama/GPT tokenizers (2.5-3.5 chars/token average).

**Impact example (char-player detail extraction, turn-210):**

| Metric | Old (`//4`) | New (`//3`) |
|--------|------------|------------|
| PC prior context (69k chars) | ~17,302 tok | ~23,070 tok |
| Total input | ~19,777 tok | ~24,715 tok |
| Headroom (32k - input - 6,144 output) | 6,847 tok | **1,859 tok** |

The old heuristic reported comfortable headroom when the actual margin was dangerously tight.

## Pre-flight Budget Check

Added a check in `LLMClient.extract_json()` that estimates `input + output` against `context_length` before sending the request:

- **WARNING** when estimated total exceeds context window (output will be truncated)
- **NOTICE** when headroom is < 5% of context window (tight but may work)
- No output when there's comfortable margin
- No check when `context_length` is not configured

## Files Changed

- `tools/catalog_merger.py` — `_estimate_tokens()` divisor 4 → 3
- `tools/narrative_synthesis.py` — `_estimate_tokens()` divisor 4 → 3
- `tools/llm_client.py` — pre-flight budget check in `extract_json()`
- `tests/test_bounded_entity_context.py` — updated budget value for new heuristic
- `tests/test_preflight_budget.py` — 5 new tests for pre-flight check

## Test Results

1522 passed (1517 existing + 5 new), 0 failed.

Closes #309
