### PR TITLE
fix: prevent re-extraction from regressing last_updated_turn

### DIFF
--- a/tests/test_catalog_merger_v2.py
+++ b/tests/test_catalog_merger_v2.py
@@ -929,3 +929,37 @@ class TestMergeRelationshipsDedup:
         rels = catalogs["characters.json"][0]["relationships"]
         assert len(rels) == 1
         assert rels[0]["current_relationship"] == "close friend"
+
+
+class TestLastUpdatedTurnRegression:
+    """Re-extraction of an earlier turn must not regress last_updated_turn (#314)."""
+
+    def test_reextraction_does_not_regress_last_updated_turn(self):
+        """Merging an update from an earlier turn keeps the later last_updated_turn."""
+        catalogs = {
+            "characters.json": [
+                _make_v2_entity("char-hero", "Hero",
+                                first_seen_turn="turn-100",
+                                last_updated_turn="turn-289"),
+            ]
+        }
+        update = _make_v2_entity("char-hero", "Hero",
+                                 first_seen_turn="turn-100",
+                                 last_updated_turn="turn-210")
+        merge_entity(catalogs, update)
+        assert catalogs["characters.json"][0]["last_updated_turn"] == "turn-289"
+
+    def test_forward_update_advances_last_updated_turn(self):
+        """Normal forward extraction still advances last_updated_turn."""
+        catalogs = {
+            "characters.json": [
+                _make_v2_entity("char-hero", "Hero",
+                                first_seen_turn="turn-100",
+                                last_updated_turn="turn-200"),
+            ]
+        }
+        update = _make_v2_entity("char-hero", "Hero",
+                                 first_seen_turn="turn-100",
+                                 last_updated_turn="turn-250")
+        merge_entity(catalogs, update)
+        assert catalogs["characters.json"][0]["last_updated_turn"] == "turn-250"

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -1123,9 +1123,13 @@ def _update_existing_entity(current: dict, update: dict, *, known_entity_names: 
                                  "source_turn": alias_turn}
             current["name"] = update["name"]
 
-    # Update last_updated_turn
+    # Update last_updated_turn — keep the latest (max) to prevent
+    # re-extraction of earlier turns from regressing the value (#314).
     if update.get("last_updated_turn"):
-        current["last_updated_turn"] = update["last_updated_turn"]
+        existing_num = _parse_turn_number(current.get("last_updated_turn"))
+        update_num = _parse_turn_number(update["last_updated_turn"])
+        if not existing_num or (update_num and update_num >= existing_num):
+            current["last_updated_turn"] = update["last_updated_turn"]
 
     # Update notes
     if update.get("notes"):


### PR DESCRIPTION
## Summary

`_update_existing_entity()` unconditionally overwrites `last_updated_turn` with the incoming value. When re-extracting an earlier turn, entities that already have a later `last_updated_turn` get regressed, creating `first_seen_turn > last_updated_turn`.

## Fix

Use `_parse_turn_number()` to compare existing vs incoming values, only advancing `last_updated_turn` forward (or setting it when previously empty).

## Testing

- 2 new tests: regression prevention + forward advance
- 1524 total tests pass (no regressions)

Closes #314
