### PR TITLE
docs: add explicit never-push-to-main rule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -109,6 +109,14 @@ Run `python tools/validate.py` to check compliance before committing.
 
 ## Development Workflow
 
+### Never Push Directly to Main
+
+- **All changes must go through a pull request.** Do not commit or push directly to `main`.
+- Always create a feature/fix branch first, commit there, push the branch, and open a PR.
+- This applies to all changes — code, docs, config, schemas, templates — no exceptions.
+- If you are on `main`, create a branch before making any commits: `git checkout -b <branch-name>`.
+- After the PR is merged, do not push additional commits to `main` directly.
+
 ### Branch Naming
 
 - Use `fix/` prefix for bug fixes, `feat/` for new features, and `docs/` for documentation-only changes.


### PR DESCRIPTION
## Summary

Add an explicit "Never Push Directly to Main" section to `.github/copilot-instructions.md` as the first rule under Development Workflow.

This ensures every Copilot agent session creates a branch and opens a PR rather than committing directly to `main`. The rule was previously implied by the PR workflow instructions but not stated as a hard prohibition — agents would occasionally skip branching.

### Changes

- Added "Never Push Directly to Main" subsection before "Branch Naming"
- Five bullet points covering: PR requirement, branch-first workflow, universal scope, recovery if on main, post-merge discipline
