### PR TITLE
feat: multi-GPU endpoint support for ov_serve.py and LLMClient

### DIFF
--- a/config/llm.json
+++ b/config/llm.json
@@ -1,6 +1,10 @@
 {
   "provider": "openai",
   "base_url": "http://192.168.10.169:8000/v1",
+  "base_urls": [
+    "http://192.168.10.169:8000/v1",
+    "http://192.168.10.169:8001/v1"
+  ],
   "model": "qwen3-8b-int4-ov",
   "api_key_env": "",
   "temperature": 0.3,

--- a/config/llm.json
+++ b/config/llm.json
@@ -1,9 +1,9 @@
 {
   "provider": "openai",
-  "base_url": "http://192.168.10.169:8000/v1",
+  "base_url": "http://localhost:8000/v1",
   "base_urls": [
-    "http://192.168.10.169:8000/v1",
-    "http://192.168.10.169:8001/v1"
+    "http://localhost:8000/v1",
+    "http://localhost:8001/v1"
   ],
   "model": "qwen3-8b-int4-ov",
   "api_key_env": "",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,6 +135,7 @@ An automated pipeline that uses an LLM to extract structured data from transcrip
 
 - **Five-agent pipeline**: Entity Discovery → Entity Detail → Relationship Mapper → Event Extractor → Temporal Signal Extractor
 - **Intra-turn parallelism** (#282): When `parallel_workers > 1` in `config/llm.json`, entity detail, PC detail, relationship mapping, and event extraction run concurrently via `ThreadPoolExecutor` after discovery completes. Results are merged sequentially (entities → relationships → events) to maintain catalog consistency. The inter-call delay is applied once per turn instead of between each call. With `parallel_workers: 1` (default), the pipeline uses the original sequential execution path.
+- **Multi-endpoint dispatch**: When `base_urls` (list) is configured in `config/llm.json`, `LLMClient` creates one `OpenAI` client per endpoint and distributes requests via thread-safe round-robin. This enables multi-GPU setups where each `ov_serve.py` instance targets a different GPU (e.g., `--device GPU.0` on port 8000, `--device GPU.1` on port 8001). With `parallel_workers > 1`, concurrent intra-turn requests are spread across all endpoints. Falls back to the single `base_url` when the list is absent.
 - Prompt templates in `templates/extraction/` define each agent's behavior
 - `tools/semantic_extraction.py` orchestrates the pipeline
 - `tools/catalog_merger.py` merges agent outputs into `framework/catalogs/`; includes per-pair relationship consolidation, `_dedup_relationships()` safety net (#183), and `cleanup_dangling_relationships()` to remove refs to non-existent entities (#184)
@@ -243,7 +244,7 @@ All data structures are defined in `schemas/`. See each schema file for field de
 | `tools/llm_client.py` | Provider-agnostic LLM client (OpenAI, Ollama, Google Gemini, etc.) with automatic fallback provider support (#301) |
 | `tools/dedup_audit.py` | LLM-assisted post-extraction dedup: identifies duplicate entities via name similarity heuristics, scores with LLM, auto-merges or flags for review (#306) |
 | `tools/discovery_baseline.py` | Discovery output measurement harness: runs entity discovery against a live LLM, reports token consumption, entity counts, and categorization (active/passive/spurious) (#310) |
-| `server/ov_serve.py` | OpenVINO GenAI REST server — OpenAI-compatible `/v1/chat/completions` endpoint using `ContinuousBatchingPipeline` with prefix caching and dynamic batching (#299) |
+| `server/ov_serve.py` | OpenVINO GenAI REST server — OpenAI-compatible `/v1/chat/completions` endpoint using `ContinuousBatchingPipeline` with prefix caching and dynamic batching. Supports `--device` flag for multi-GPU targeting (e.g., `GPU.0`, `GPU.1`) (#299) |
 | `tools/start_extraction_detached.ps1` | Launch semantic extraction in a detached process with log/PID files; supports `-Framework`/`-PlayerLabel` passthrough and safe argument quoting for values with spaces |
 | `tools/watch_extraction_detached.ps1` | Show status and tail logs for detached extraction runs |
 | `tools/stop_extraction_detached.ps1` | Stop detached extraction runs by PID file |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -429,10 +429,11 @@ dispatch across both endpoints:
     "http://<server-ip>:8000/v1",
     "http://<server-ip>:8001/v1"
   ],
-  "parallel_workers": 4,
-  ...
+  "parallel_workers": 4
 }
 ```
+
+> Other keys (model, temperature, etc.) omitted for brevity — see examples above.
 
 - `base_url` is kept for backward compatibility and used by Ollama paths;
   `base_urls` takes precedence for the OpenAI client pool.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -403,6 +403,44 @@ Key settings for OpenVINO servers:
 - **`temperature: 0.3`** — Avoid 0.0 with qwen3 models (can cause empty
   responses or infinite thinking loops).
 
+#### Multi-GPU Setup
+
+For systems with multiple GPUs, run one `ov_serve.py` instance per GPU on
+different ports, each pinned to a specific device:
+
+```bash
+# GPU 0 on port 8000
+python server/ov_serve.py --model-dir ./models/qwen3-8b-int4-ov \
+    --port 8000 --host 0.0.0.0 --device GPU.0
+
+# GPU 1 on port 8001
+python server/ov_serve.py --model-dir ./models/qwen3-8b-int4-ov \
+    --port 8001 --host 0.0.0.0 --device GPU.1
+```
+
+Configure `config/llm.json` with `base_urls` (list) to enable round-robin
+dispatch across both endpoints:
+
+```json
+{
+  "provider": "openai",
+  "base_url": "http://<server-ip>:8000/v1",
+  "base_urls": [
+    "http://<server-ip>:8000/v1",
+    "http://<server-ip>:8001/v1"
+  ],
+  "parallel_workers": 4,
+  ...
+}
+```
+
+- `base_url` is kept for backward compatibility and used by Ollama paths;
+  `base_urls` takes precedence for the OpenAI client pool.
+- With `parallel_workers: 4` and 2 endpoints, each GPU receives ~2 concurrent
+  requests on average, activating the server-side dynamic batching for higher
+  aggregate throughput.
+- Each GPU maintains its own prefix cache independently.
+
 #### Thinking Suppression
 
 Qwen3 models generate `<think>...</think>` blocks by default, which consume

--- a/server/ov_serve.py
+++ b/server/ov_serve.py
@@ -43,6 +43,7 @@ REQUEST_TIMEOUT_S = 600  # Batch generation timeout (seconds); 0 = no timeout
 _pipeline_degraded = False  # Set True if reload fails; surfaced via /health
 EXTRA_STOP_TOKEN_IDS: set = set()  # Additional stop token IDs beyond EOS
 TIMEOUT_KEEP_ALIVE = 120  # HTTP keep-alive timeout in seconds
+DEVICE = "GPU"  # OpenVINO device target (GPU, GPU.0, GPU.1, CPU, etc.)
 
 # --- Request/Response Models ---
 
@@ -183,7 +184,7 @@ async def _reload_pipeline():
         pipeline = await loop.run_in_executor(
             None,
             lambda: ov_genai.ContinuousBatchingPipeline(
-                MODEL_DIR, sched_cfg, 'GPU', {'CACHE_DIR': CACHE_DIR}
+                MODEL_DIR, sched_cfg, DEVICE, {'CACHE_DIR': CACHE_DIR}
             ),
         )
         tokenizer = pipeline.get_tokenizer()
@@ -206,12 +207,12 @@ async def lifespan(app: FastAPI):
     sched_cfg.enable_prefix_caching = True
 
     pipeline = ov_genai.ContinuousBatchingPipeline(
-        MODEL_DIR, sched_cfg, 'GPU', {'CACHE_DIR': CACHE_DIR}
+        MODEL_DIR, sched_cfg, DEVICE, {'CACHE_DIR': CACHE_DIR}
     )
     tokenizer = pipeline.get_tokenizer()
 
     elapsed = time.perf_counter() - start
-    print(f"Model loaded in {elapsed:.1f}s (prefix caching enabled, batch_wait={BATCH_WAIT_MS}ms, max_batch={MAX_BATCH_SIZE}, request_timeout={REQUEST_TIMEOUT_S}s)")
+    print(f"Model loaded in {elapsed:.1f}s (device={DEVICE}, prefix caching enabled, batch_wait={BATCH_WAIT_MS}ms, max_batch={MAX_BATCH_SIZE}, request_timeout={REQUEST_TIMEOUT_S}s)")
 
     # Start batch worker
     batch_queue = asyncio.Queue()
@@ -364,13 +365,15 @@ def build_parser():
                         help="Comma-separated extra stop token IDs (beyond EOS)")
     parser.add_argument("--timeout-keep-alive", type=int, default=TIMEOUT_KEEP_ALIVE,
                         help="HTTP keep-alive timeout in seconds (default: 120)")
+    parser.add_argument("--device", type=str, default=DEVICE,
+                        help="OpenVINO device target (default: GPU). Use GPU.0, GPU.1 for multi-GPU")
     return parser
 
 
 def main(argv=None):
     """Parse CLI args, configure globals, and start the server."""
     global MODEL_DIR, CACHE_DIR, MODEL_NAME, BATCH_WAIT_MS, MAX_BATCH_SIZE
-    global CACHE_SIZE_GB, REQUEST_TIMEOUT_S, TIMEOUT_KEEP_ALIVE, EXTRA_STOP_TOKEN_IDS
+    global CACHE_SIZE_GB, REQUEST_TIMEOUT_S, TIMEOUT_KEEP_ALIVE, DEVICE, EXTRA_STOP_TOKEN_IDS
 
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -383,6 +386,7 @@ def main(argv=None):
     CACHE_SIZE_GB = args.cache_size_gb
     REQUEST_TIMEOUT_S = args.request_timeout
     TIMEOUT_KEEP_ALIVE = args.timeout_keep_alive
+    DEVICE = args.device
     if args.stop_token_ids:
         EXTRA_STOP_TOKEN_IDS = {int(x.strip()) for x in args.stop_token_ids.split(",")}
 

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -11,6 +11,7 @@ import os
 import random
 import re
 import sys
+import threading
 import time
 
 
@@ -126,12 +127,26 @@ class LLMClient:
         # Disable SDK-level retries — we handle retries ourselves to avoid
         # the SDK's max_retries (default 2) multiplying with our retry_attempts,
         # which caused up to 9 attempts per call and wasted quota (#215).
-        self.client = OpenAI(
-            base_url=self.config.get("base_url", "https://api.openai.com/v1"),
-            api_key=api_key or "not-needed",
-            timeout=self.config.get("timeout_seconds", 60),
-            max_retries=0,
-        )
+        #
+        # Multi-endpoint support: when "base_urls" (list) is configured,
+        # create one OpenAI client per endpoint and round-robin across them.
+        # Falls back to single "base_url" when the list is absent.
+        base_urls = self.config.get("base_urls")
+        if not base_urls:
+            base_urls = [self.config.get("base_url", "https://api.openai.com/v1")]
+        self._clients = [
+            OpenAI(
+                base_url=url,
+                api_key=api_key or "not-needed",
+                timeout=self.config.get("timeout_seconds", 60),
+                max_retries=0,
+            )
+            for url in base_urls
+        ]
+        self._client_index = 0
+        self._client_lock = threading.Lock()
+        # Keep self.client as primary for backward compatibility (Ollama paths, etc.)
+        self.client = self._clients[0]
         self.model = self.config.get("model", "gpt-4o")
         self.temperature = self.config.get("temperature", 0.0)
         self.max_tokens = self.config.get("max_tokens", 4096)
@@ -172,6 +187,22 @@ class LLMClient:
         # would trip rate limits / quota thresholds (#282 review).
         if self.parallel_workers > 1 and self._is_cloud_provider:
             self.parallel_workers = 1
+
+        if len(self._clients) > 1:
+            print(
+                f"  Multi-endpoint: {len(self._clients)} endpoints configured, "
+                f"round-robin dispatch enabled",
+                file=sys.stderr,
+            )
+
+    def _next_client(self):
+        """Return the next OpenAI client in round-robin order (thread-safe)."""
+        if len(self._clients) == 1:
+            return self._clients[0]
+        with self._client_lock:
+            client = self._clients[self._client_index]
+            self._client_index = (self._client_index + 1) % len(self._clients)
+            return client
 
     @property
     def _is_ollama(self) -> bool:
@@ -503,7 +534,7 @@ class LLMClient:
                         if extra_body:
                             kwargs["extra_body"] = extra_body
 
-                    response = self.client.chat.completions.create(**kwargs)
+                    response = self._next_client().chat.completions.create(**kwargs)
                     raw_text = response.choices[0].message.content
                     finish_reason = getattr(response.choices[0], "finish_reason", None)
 
@@ -712,7 +743,7 @@ class LLMClient:
                         if extra_body_raw:
                             kwargs["extra_body"] = extra_body_raw
 
-                    response = self.client.chat.completions.create(**kwargs)
+                    response = self._next_client().chat.completions.create(**kwargs)
                     raw_text = response.choices[0].message.content
 
                     if not raw_text:

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -132,8 +132,20 @@ class LLMClient:
         # create one OpenAI client per endpoint and round-robin across them.
         # Falls back to single "base_url" when the list is absent.
         base_urls = self.config.get("base_urls")
-        if not base_urls:
+        if base_urls:
+            if not isinstance(base_urls, list) or not all(
+                isinstance(u, str) for u in base_urls
+            ):
+                raise LLMExtractionError(
+                    "'base_urls' in llm.json must be a list of URL strings."
+                )
+            if not base_urls:
+                raise LLMExtractionError(
+                    "'base_urls' in llm.json must not be empty."
+                )
+        else:
             base_urls = [self.config.get("base_url", "https://api.openai.com/v1")]
+        self._base_urls = base_urls
         self._clients = [
             OpenAI(
                 base_url=url,
@@ -173,6 +185,10 @@ class LLMClient:
             # Build a merged config for the fallback client
             fb_config = dict(self.config)
             fb_config.pop("fallback", None)  # prevent recursion
+            # Clear primary base_urls so fallback uses its own base_url
+            # unless the fallback block explicitly provides base_urls.
+            if "base_urls" not in fallback_cfg:
+                fb_config.pop("base_urls", None)
             fb_config.update(fallback_cfg)
             try:
                 self._fallback_client = LLMClient.__new__(LLMClient)
@@ -352,17 +368,26 @@ class LLMClient:
 
     @property
     def _is_cloud_provider(self) -> bool:
-        """True when the configured provider appears to be a cloud API."""
+        """True when the configured provider appears to be a cloud API.
+
+        Checks all endpoints in the client pool (base_urls) when configured,
+        falling back to base_url. Returns True only if ALL endpoints appear
+        to be cloud (non-local) URLs.
+        """
         if self._is_ollama:
             return False
-        base_url = self.config.get("base_url", "")
-        return not any(local in base_url for local in [
+        urls = getattr(self, '_base_urls', None) or [self.config.get("base_url", "")]
+        local_patterns = [
             "localhost", "127.0.0.1", "0.0.0.0", "[::1]",
             "192.168.", "10.", "172.16.", "172.17.", "172.18.",
             "172.19.", "172.20.", "172.21.", "172.22.", "172.23.",
             "172.24.", "172.25.", "172.26.", "172.27.", "172.28.",
             "172.29.", "172.30.", "172.31.",
-        ])
+        ]
+        return not any(
+            any(local in url for local in local_patterns)
+            for url in urls
+        )
 
     @staticmethod
     def _classify_error(e: Exception) -> tuple[int | None, float | None]:


### PR DESCRIPTION
## Summary

Adds multi-GPU support so each `ov_serve.py` instance can target a specific GPU, and the extraction pipeline distributes requests across multiple endpoints via round-robin.

## Changes

### `server/ov_serve.py`
- Added `--device` CLI argument (default: `GPU`). Use `GPU.0`, `GPU.1`, etc. to pin each server instance to a specific GPU in multi-GPU systems.
- Both pipeline creation sites (lifespan startup and watchdog reload) use the configurable `DEVICE` global instead of hardcoded `'GPU'`.
- Startup log now includes the device name.

### `tools/llm_client.py`
- Added `base_urls` (list) support: when configured, creates one `OpenAI` client per endpoint and distributes requests via thread-safe round-robin (`_next_client()`).
- Falls back to single `base_url` when `base_urls` is absent — fully backward compatible.
- Logs multi-endpoint mode on startup.

### `config/llm.json`
- Added `base_urls` list with ports 8000 (GPU.0) and 8001 (GPU.1).
- `parallel_workers` already set to 4 (enables intra-turn parallelism).

### Documentation
- `docs/architecture.md`: Added multi-endpoint dispatch description and `--device` flag to `ov_serve.py` tool table entry.
- `docs/usage.md`: Added "Multi-GPU Setup" section with server startup commands, config example, and operational notes.

## Testing

All 1570 existing tests pass. The multi-endpoint path is exercised when `base_urls` has >1 entry; single-endpoint behavior is unchanged.
