### PR TITLE
feat: heartbeat wrapper eliminates polling waste for extraction (#328)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -248,6 +248,7 @@ All data structures are defined in `schemas/`. See each schema file for field de
 | `tools/start_extraction_detached.ps1` | Launch semantic extraction in a detached process with log/PID files; supports `-Framework`/`-PlayerLabel` passthrough and safe argument quoting for values with spaces |
 | `tools/watch_extraction_detached.ps1` | Show status and tail logs for detached extraction runs |
 | `tools/stop_extraction_detached.ps1` | Stop detached extraction runs by PID file |
+| `tools/run_with_heartbeat.py` / `.ps1` / `.sh` | Heartbeat wrapper — keeps terminal alive during long commands for idle-detection-based completion notification |
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1105,6 +1105,50 @@ During extraction (batch, segmented, or single-turn), the pipeline writes a per-
 - `timestamp` — UTC wall-clock time
 - `discovery_ok`, `detail_ok`, `pc_ok`, `relationships_ok`, `events_ok` — per-phase success flags
 - `*_error` — error message when a phase failed (null on success)
+
+---
+
+## Heartbeat Wrapper for Long-Running Extraction
+
+### Problem
+
+When an AI agent session launches a long extraction batch (15–25 minutes) via `run_in_terminal mode=async`, VS Code's idle detection considers the terminal "finished" as soon as output stops for >1 second. The agent then resorts to hundreds of polling calls to detect completion, wasting context window budget.
+
+### Solution
+
+The heartbeat wrapper scripts print a `.` character every 500ms to keep the terminal "alive" until the wrapped command finishes. When the command exits, the heartbeat stops, the terminal goes idle (>1000ms silence), and the agent receives an automatic completion notification. This turns O(n) polling into exactly 1 async call.
+
+### Usage
+
+**Python (cross-platform, recommended):**
+```bash
+python tools/run_with_heartbeat.py "python tools/bootstrap_session.py --session sessions/session-001 --all"
+```
+
+**Bash (Linux/macOS/WSL):**
+```bash
+./tools/run_with_heartbeat.sh python tools/bootstrap_session.py --session sessions/session-001 --all
+```
+
+**PowerShell (Windows):**
+```powershell
+.\tools\run_with_heartbeat.ps1 -Command "python tools/bootstrap_session.py --session sessions/session-001 --all"
+```
+
+### With `run_in_terminal mode=async`
+
+In a Copilot agent session, wrap the extraction command:
+
+```
+run_in_terminal mode=async:
+  python tools/run_with_heartbeat.py "python tools/bootstrap_session.py --session sessions/session-001 --all"
+```
+
+The agent will receive automatic notification when extraction completes, with no polling required.
+
+### Exit Code Propagation
+
+All wrapper variants propagate the wrapped command's exit code. If the extraction fails with exit code 1, the wrapper also exits with code 1.
 - `new_entities`, `new_events` — counts of entities/events added by this turn
 - `discovery_proposals` — array of all entities proposed by the model for this turn, each with `name`, `is_new`, `proposed_id`, `existing_id`, and `confidence`
 - `discovery_filtered` — array of entities rejected during filtering, each with `name`, `id`, and `reason` (`below_confidence_threshold` or `concept_prefix`)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1105,50 +1105,6 @@ During extraction (batch, segmented, or single-turn), the pipeline writes a per-
 - `timestamp` — UTC wall-clock time
 - `discovery_ok`, `detail_ok`, `pc_ok`, `relationships_ok`, `events_ok` — per-phase success flags
 - `*_error` — error message when a phase failed (null on success)
-
----
-
-## Heartbeat Wrapper for Long-Running Extraction
-
-### Problem
-
-When an AI agent session launches a long extraction batch (15–25 minutes) via `run_in_terminal mode=async`, VS Code's idle detection considers the terminal "finished" as soon as output stops for >1 second. The agent then resorts to hundreds of polling calls to detect completion, wasting context window budget.
-
-### Solution
-
-The heartbeat wrapper scripts print a `.` character every 500ms to keep the terminal "alive" until the wrapped command finishes. When the command exits, the heartbeat stops, the terminal goes idle (>1000ms silence), and the agent receives an automatic completion notification. This turns O(n) polling into exactly 1 async call.
-
-### Usage
-
-**Python (cross-platform, recommended):**
-```bash
-python tools/run_with_heartbeat.py "python tools/bootstrap_session.py --session sessions/session-001 --all"
-```
-
-**Bash (Linux/macOS/WSL):**
-```bash
-./tools/run_with_heartbeat.sh python tools/bootstrap_session.py --session sessions/session-001 --all
-```
-
-**PowerShell (Windows):**
-```powershell
-.\tools\run_with_heartbeat.ps1 -Command "python tools/bootstrap_session.py --session sessions/session-001 --all"
-```
-
-### With `run_in_terminal mode=async`
-
-In a Copilot agent session, wrap the extraction command:
-
-```
-run_in_terminal mode=async:
-  python tools/run_with_heartbeat.py "python tools/bootstrap_session.py --session sessions/session-001 --all"
-```
-
-The agent will receive automatic notification when extraction completes, with no polling required.
-
-### Exit Code Propagation
-
-All wrapper variants propagate the wrapped command's exit code. If the extraction fails with exit code 1, the wrapper also exits with code 1.
 - `new_entities`, `new_events` — counts of entities/events added by this turn
 - `discovery_proposals` — array of all entities proposed by the model for this turn, each with `name`, `is_new`, `proposed_id`, `existing_id`, and `confidence`
 - `discovery_filtered` — array of entities rejected during filtering, each with `name`, `id`, and `reason` (`below_confidence_threshold` or `concept_prefix`)
@@ -1529,3 +1485,53 @@ Both catalogs and events are saved to disk after recovery.
 ## Example Session
 
 See `examples/demo-session/` for a complete worked example with 6 turns, 3 entities, 2 plot threads, and annotated analysis.
+
+---
+
+## Heartbeat Wrapper for Long-Running Extraction
+
+### Problem
+
+When an AI agent session launches a long extraction batch (15–25 minutes) via `run_in_terminal mode=async`, VS Code's idle detection considers the terminal "finished" as soon as output stops for >1 second. The agent then resorts to hundreds of polling calls to detect completion, wasting context window budget.
+
+### Solution
+
+The heartbeat wrapper scripts print a `.` character every 500ms to stderr to keep the terminal "alive" until the wrapped command finishes. Dots go to stderr so they don't corrupt structured stdout output (VS Code idle detection watches all terminal output, not just stdout). When the command exits, the heartbeat stops, the terminal goes idle (>1000ms silence), and the agent receives an automatic completion notification. This turns O(n) polling into exactly 1 async call.
+
+### Usage
+
+**Python (cross-platform, recommended):**
+```bash
+python tools/run_with_heartbeat.py python tools/bootstrap_session.py --session sessions/session-001 --all
+```
+
+**Bash (Linux/macOS/WSL):**
+```bash
+# Ensure executable permission on fresh clones:
+chmod +x tools/run_with_heartbeat.sh
+
+./tools/run_with_heartbeat.sh python tools/bootstrap_session.py --session sessions/session-001 --all
+
+# Or invoke directly with bash (no chmod needed):
+bash tools/run_with_heartbeat.sh python tools/bootstrap_session.py --session sessions/session-001 --all
+```
+
+**PowerShell (Windows):**
+```powershell
+.\tools\run_with_heartbeat.ps1 -Command "python tools/bootstrap_session.py --session sessions/session-001 --all"
+```
+
+### With `run_in_terminal mode=async`
+
+In a Copilot agent session, wrap the extraction command:
+
+```
+run_in_terminal mode=async:
+  python tools/run_with_heartbeat.py python tools/bootstrap_session.py --session sessions/session-001 --all
+```
+
+The agent will receive automatic notification when extraction completes, with no polling required.
+
+### Exit Code Propagation
+
+All wrapper variants propagate the wrapped command's exit code. If the extraction fails with exit code 1, the wrapper also exits with code 1.

--- a/tools/run_with_heartbeat.ps1
+++ b/tools/run_with_heartbeat.ps1
@@ -3,8 +3,8 @@
     Heartbeat wrapper for long-running commands.
 
 .DESCRIPTION
-    Executes a command and prints a '.' every 500ms to keep terminal idle
-    detection alive. When the command finishes, heartbeat stops and the
+    Executes a command and prints a '.' to stderr every 500ms to keep terminal
+    idle detection alive. When the command finishes, heartbeat stops and the
     terminal goes idle, triggering automatic completion notification.
 
 .PARAMETER Command
@@ -30,7 +30,7 @@ $job = Start-Job -ScriptBlock {
 # Print heartbeat while job is running
 try {
     while ($job.State -eq 'Running') {
-        Write-Host -NoNewline "."
+        [Console]::Error.Write(".")
         Start-Sleep -Milliseconds 500
     }
 }
@@ -44,7 +44,7 @@ finally {
 # Collect output and display it
 $output = Receive-Job -Job $job
 if ($output) {
-    Write-Host ""
+    [Console]::Error.WriteLine("")
     $output | ForEach-Object { Write-Host $_ }
 }
 

--- a/tools/run_with_heartbeat.ps1
+++ b/tools/run_with_heartbeat.ps1
@@ -1,0 +1,66 @@
+<#
+.SYNOPSIS
+    Heartbeat wrapper for long-running commands.
+
+.DESCRIPTION
+    Executes a command and prints a '.' every 500ms to keep terminal idle
+    detection alive. When the command finishes, heartbeat stops and the
+    terminal goes idle, triggering automatic completion notification.
+
+.PARAMETER Command
+    The command string to execute.
+
+.EXAMPLE
+    .\run_with_heartbeat.ps1 -Command "python bootstrap_session.py --all"
+    .\run_with_heartbeat.ps1 -Command "ssh arclight 'cd /path && python extract.py'"
+#>
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Command
+)
+
+$ErrorActionPreference = "Stop"
+
+# Start the command as a job
+$job = Start-Job -ScriptBlock {
+    param($cmd)
+    Invoke-Expression $cmd
+} -ArgumentList $Command
+
+# Print heartbeat while job is running
+try {
+    while ($job.State -eq 'Running') {
+        Write-Host -NoNewline "."
+        Start-Sleep -Milliseconds 500
+    }
+}
+finally {
+    # Ensure job is cleaned up on Ctrl+C
+    if ($job.State -eq 'Running') {
+        Stop-Job -Job $job
+    }
+}
+
+# Collect output and display it
+$output = Receive-Job -Job $job
+if ($output) {
+    Write-Host ""
+    $output | ForEach-Object { Write-Host $_ }
+}
+
+# Get exit code from job
+$exitCode = 0
+if ($job.State -eq 'Failed') {
+    $exitCode = 1
+    $jobError = $job.ChildJobs[0].JobStateInfo.Reason
+    if ($jobError) {
+        Write-Host ""
+        Write-Host "Error: $jobError" -ForegroundColor Red
+    }
+}
+
+Remove-Job -Job $job -Force
+
+Write-Host ""
+Write-Host "Command exited with code: $exitCode"
+exit $exitCode

--- a/tools/run_with_heartbeat.ps1
+++ b/tools/run_with_heartbeat.ps1
@@ -34,6 +34,7 @@ $procArgs = @{
 }
 if ($arguments) { $procArgs.ArgumentList = $arguments }
 $proc = Start-Process @procArgs
+$null = $proc.Handle   # Pin native handle so ExitCode is available after exit
 
 # Heartbeat while process is running
 try {

--- a/tools/run_with_heartbeat.ps1
+++ b/tools/run_with_heartbeat.ps1
@@ -21,46 +21,36 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-# Start the command as a job
-$job = Start-Job -ScriptBlock {
-    param($cmd)
-    Invoke-Expression $cmd
-} -ArgumentList $Command
+# Parse command and arguments
+$parts = $Command -split ' ', 2
+$exe = $parts[0]
+$arguments = if ($parts.Length -gt 1) { $parts[1] } else { $null }
 
-# Print heartbeat while job is running
+# Start process directly (not via job/Invoke-Expression)
+$procArgs = @{
+    FilePath    = $exe
+    NoNewWindow = $true
+    PassThru    = $true
+}
+if ($arguments) { $procArgs.ArgumentList = $arguments }
+$proc = Start-Process @procArgs
+
+# Heartbeat while process is running
 try {
-    while ($job.State -eq 'Running') {
+    while (-not $proc.HasExited) {
         [Console]::Error.Write(".")
         Start-Sleep -Milliseconds 500
     }
 }
 finally {
-    # Ensure job is cleaned up on Ctrl+C
-    if ($job.State -eq 'Running') {
-        Stop-Job -Job $job
+    if (-not $proc.HasExited) {
+        Stop-Process -Id $proc.Id -Force
     }
 }
 
-# Collect output and display it
-$output = Receive-Job -Job $job
-if ($output) {
-    [Console]::Error.WriteLine("")
-    $output | ForEach-Object { Write-Host $_ }
-}
+$proc.WaitForExit()
+$exitCode = $proc.ExitCode
 
-# Get exit code from job
-$exitCode = 0
-if ($job.State -eq 'Failed') {
-    $exitCode = 1
-    $jobError = $job.ChildJobs[0].JobStateInfo.Reason
-    if ($jobError) {
-        Write-Host ""
-        Write-Host "Error: $jobError" -ForegroundColor Red
-    }
-}
-
-Remove-Job -Job $job -Force
-
-Write-Host ""
-Write-Host "Command exited with code: $exitCode"
+[Console]::Error.WriteLine("")
+[Console]::Error.WriteLine("Command exited with code: $exitCode")
 exit $exitCode

--- a/tools/run_with_heartbeat.py
+++ b/tools/run_with_heartbeat.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Heartbeat wrapper for long-running commands.
+
+Prints '.' every 500ms to keep terminal idle detection alive.
+When the wrapped command finishes, heartbeat stops and the terminal
+goes idle, triggering automatic completion notification.
+
+Usage:
+    python run_with_heartbeat.py <command>
+    python run_with_heartbeat.py "python bootstrap_session.py --all"
+    python run_with_heartbeat.py "ssh arclight 'cd /path && python extract.py'"
+"""
+
+import subprocess
+import sys
+import time
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python run_with_heartbeat.py <command>", file=sys.stderr)
+        sys.exit(1)
+
+    command = " ".join(sys.argv[1:])
+
+    # Launch command as subprocess via shell
+    proc = subprocess.Popen(
+        command,
+        shell=True,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+
+    # Print heartbeat while process is running
+    try:
+        while proc.poll() is None:
+            sys.stdout.write(".")
+            sys.stdout.flush()
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        proc.terminate()
+        proc.wait()
+        print("\nInterrupted.")
+        sys.exit(130)
+
+    exit_code = proc.returncode
+    print(f"\nCommand exited with code: {exit_code}")
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/run_with_heartbeat.py
+++ b/tools/run_with_heartbeat.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """Heartbeat wrapper for long-running commands.
 
-Prints '.' every 500ms to keep terminal idle detection alive.
+Prints '.' to stderr every 500ms to keep terminal idle detection alive.
 When the wrapped command finishes, heartbeat stops and the terminal
 goes idle, triggering automatic completion notification.
 
 Usage:
-    python run_with_heartbeat.py <command>
-    python run_with_heartbeat.py "python bootstrap_session.py --all"
-    python run_with_heartbeat.py "ssh arclight 'cd /path && python extract.py'"
+    python run_with_heartbeat.py <command> [args...]
+    python run_with_heartbeat.py python bootstrap_session.py --all
+    python run_with_heartbeat.py ssh arclight "cd /path && python extract.py"
 """
 
 import subprocess
@@ -18,15 +18,12 @@ import time
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: python run_with_heartbeat.py <command>", file=sys.stderr)
+        print("Usage: python run_with_heartbeat.py <command> [args...]", file=sys.stderr)
         sys.exit(1)
 
-    command = " ".join(sys.argv[1:])
-
-    # Launch command as subprocess via shell
+    # Launch command as subprocess directly (no shell)
     proc = subprocess.Popen(
-        command,
-        shell=True,
+        sys.argv[1:],
         stdout=sys.stdout,
         stderr=sys.stderr,
     )
@@ -34,17 +31,17 @@ def main():
     # Print heartbeat while process is running
     try:
         while proc.poll() is None:
-            sys.stdout.write(".")
-            sys.stdout.flush()
+            sys.stderr.write(".")
+            sys.stderr.flush()
             time.sleep(0.5)
     except KeyboardInterrupt:
         proc.terminate()
         proc.wait()
-        print("\nInterrupted.")
+        print("\nInterrupted.", file=sys.stderr)
         sys.exit(130)
 
     exit_code = proc.returncode
-    print(f"\nCommand exited with code: {exit_code}")
+    print(f"\nCommand exited with code: {exit_code}", file=sys.stderr)
     sys.exit(exit_code)
 
 

--- a/tools/run_with_heartbeat.sh
+++ b/tools/run_with_heartbeat.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Heartbeat wrapper for long-running commands.
+#
+# Prints '.' every 500ms to keep terminal idle detection alive.
+# When the wrapped command finishes, heartbeat stops and the terminal
+# goes idle, triggering automatic completion notification.
+#
+# Usage:
+#   ./run_with_heartbeat.sh python bootstrap_session.py --all
+#   ./run_with_heartbeat.sh ssh arclight "cd /path && python extract.py"
+
+set -e
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <command> [args...]" >&2
+    exit 1
+fi
+
+# Launch command in background
+"$@" &
+PID=$!
+
+# Kill child on Ctrl+C
+trap 'kill $PID 2>/dev/null; wait $PID 2>/dev/null; exit 130' INT TERM
+
+# Print heartbeat while child is running
+while kill -0 "$PID" 2>/dev/null; do
+    printf "."
+    sleep 0.5
+done
+
+# Collect exit code
+wait $PID
+EXIT_CODE=$?
+
+echo ""
+echo "Command exited with code: $EXIT_CODE"
+exit $EXIT_CODE

--- a/tools/run_with_heartbeat.sh
+++ b/tools/run_with_heartbeat.sh
@@ -1,15 +1,13 @@
 #!/usr/bin/env bash
 # Heartbeat wrapper for long-running commands.
 #
-# Prints '.' every 500ms to keep terminal idle detection alive.
+# Prints '.' to stderr every 500ms to keep terminal idle detection alive.
 # When the wrapped command finishes, heartbeat stops and the terminal
 # goes idle, triggering automatic completion notification.
 #
 # Usage:
 #   ./run_with_heartbeat.sh python bootstrap_session.py --all
 #   ./run_with_heartbeat.sh ssh arclight "cd /path && python extract.py"
-
-set -e
 
 if [ $# -eq 0 ]; then
     echo "Usage: $0 <command> [args...]" >&2
@@ -25,7 +23,7 @@ trap 'kill $PID 2>/dev/null; wait $PID 2>/dev/null; exit 130' INT TERM
 
 # Print heartbeat while child is running
 while kill -0 "$PID" 2>/dev/null; do
-    printf "."
+    printf "." >&2
     sleep 0.5
 done
 
@@ -33,6 +31,6 @@ done
 wait $PID
 EXIT_CODE=$?
 
-echo ""
-echo "Command exited with code: $EXIT_CODE"
+echo "" >&2
+echo "Command exited with code: $EXIT_CODE" >&2
 exit $EXIT_CODE


### PR DESCRIPTION
## Summary

Adds heartbeat wrapper scripts that print a `.` every 500ms while a wrapped command runs, keeping VS Code terminal idle detection alive. This eliminates the need for O(n) polling calls when an agent session launches long-running extraction batches.

## Problem

When a Copilot agent launches extraction via `run_in_terminal mode=async`, VS Code considers the terminal idle after ~1s of no output. The agent then resorts to hundreds of `wc -l` / `tail` polling calls to detect completion, wasting context window budget.

## Solution

**Before:** 200+ polling calls over 15-25 minutes of extraction.
**After:** Exactly 1 async call. Agent gets automatic completion notification when heartbeat stops.

## Files Added

- `tools/run_with_heartbeat.py` — Cross-platform Python wrapper (recommended)
- `tools/run_with_heartbeat.sh` — Bash wrapper for Linux/macOS/WSL
- `tools/run_with_heartbeat.ps1` — PowerShell wrapper for Windows

## Usage

```bash
python tools/run_with_heartbeat.py "python tools/bootstrap_session.py --session sessions/session-001 --all"
```

## Documentation

Added "Heartbeat Wrapper for Long-Running Extraction" section to `docs/usage.md`.

## Testing

- Verified heartbeat dots appear during execution (ping test)
- Verified exit code propagation (exit 42 test)
- Full test suite: 1570 passed, no regressions

Closes #328
