### PR TITLE
feat: Playwright-based VS Code agent bridge prototype

### DIFF
--- a/crew/bridge/.gitignore
+++ b/crew/bridge/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+test-results/
+playwright-report/

--- a/crew/bridge/README.md
+++ b/crew/bridge/README.md
@@ -13,7 +13,8 @@ npm run build
 ## Usage
 
 ```typescript
-import { createBridge } from '@nse/vscode-bridge';
+// Local import — this package is not published to npm
+import { createBridge } from '../bridge/src/index';
 
 const bridge = await createBridge({
   workspacePath: '/path/to/project',

--- a/crew/bridge/README.md
+++ b/crew/bridge/README.md
@@ -1,0 +1,56 @@
+# @nse/vscode-bridge
+
+Playwright-based automation bridge for VS Code's Chat panel. Enables programmatic interaction with Copilot agents (e.g., `@developer`) for CrewAI integration.
+
+## Setup
+
+```bash
+cd crew/bridge
+npm install
+npm run build
+```
+
+## Usage
+
+```typescript
+import { createBridge } from '@nse/vscode-bridge';
+
+const bridge = await createBridge({
+  workspacePath: '/path/to/project',
+});
+
+const response = await bridge.sendPrompt('developer', 'Explain this codebase');
+console.log(response);
+
+await bridge.close();
+```
+
+## Running the Smoke Test
+
+The smoke test requires VS Code and GitHub Copilot to be installed locally:
+
+```bash
+BRIDGE_SMOKE=1 npx playwright test tests/smoke.test.ts
+```
+
+On Windows (PowerShell):
+
+```powershell
+$env:BRIDGE_SMOKE = "1"
+npx playwright test tests/smoke.test.ts
+```
+
+## Selectors
+
+All DOM selectors are centralized in `src/selectors.ts` with VS Code version annotations. When VS Code updates break automation, update selectors there.
+
+## Architecture
+
+```
+src/
+├── index.ts              # High-level createBridge() API
+├── selectors.ts          # Centralized DOM selector registry
+└── page-objects/
+    ├── vscode-app.ts     # VS Code Electron lifecycle management
+    └── chat-panel.ts     # Chat panel interaction (open, send, read)
+```

--- a/crew/bridge/package-lock.json
+++ b/crew/bridge/package-lock.json
@@ -1,0 +1,111 @@
+{
+  "name": "@nse/vscode-bridge",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@nse/vscode-bridge",
+      "version": "0.1.0",
+      "dependencies": {
+        "playwright": "^1.50.0"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.50.0",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
+      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/crew/bridge/package.json
+++ b/crew/bridge/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@nse/vscode-bridge",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "test": "npx playwright test",
+    "test:smoke": "npx playwright test tests/smoke.test.ts"
+  },
+  "dependencies": {
+    "playwright": "^1.50.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0",
+    "typescript": "^5.5.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/crew/bridge/playwright.config.ts
+++ b/crew/bridge/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 300_000, // 5 minutes — VS Code launch + response can be slow
+  retries: 0,
+  use: {
+    trace: 'on-first-retry',
+  },
+});

--- a/crew/bridge/playwright.config.ts
+++ b/crew/bridge/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './tests',
   timeout: 300_000, // 5 minutes — VS Code launch + response can be slow
-  retries: 0,
+  retries: 1,
   use: {
     trace: 'on-first-retry',
   },

--- a/crew/bridge/src/index.ts
+++ b/crew/bridge/src/index.ts
@@ -1,0 +1,55 @@
+import { VSCodeApp, type VSCodeLaunchOptions } from './page-objects/vscode-app';
+import { ChatPanel } from './page-objects/chat-panel';
+
+export { VSCodeApp, type VSCodeLaunchOptions } from './page-objects/vscode-app';
+export { ChatPanel } from './page-objects/chat-panel';
+export { SELECTORS } from './selectors';
+
+export interface BridgeOptions extends VSCodeLaunchOptions {
+  /** Default timeout for waiting on responses, in milliseconds. */
+  defaultTimeout?: number;
+}
+
+export interface VSCodeBridge {
+  /** Send a prompt to the specified agent and return the full response text. */
+  sendPrompt(agent: string, prompt: string): Promise<string>;
+  /** Close VS Code and clean up. */
+  close(): Promise<void>;
+}
+
+/**
+ * Create a VS Code automation bridge.
+ *
+ * Launches VS Code, opens the Chat panel, and returns an interface
+ * for sending prompts to agents and reading responses.
+ *
+ * @example
+ * ```ts
+ * const bridge = await createBridge({ workspacePath: '/path/to/project' });
+ * const response = await bridge.sendPrompt('developer', 'What is 2+2?');
+ * console.log(response);
+ * await bridge.close();
+ * ```
+ */
+export async function createBridge(options?: BridgeOptions): Promise<VSCodeBridge> {
+  const vscode = new VSCodeApp();
+  const page = await vscode.launch(options);
+  const chat = new ChatPanel(page);
+
+  // Open the chat panel once during setup
+  await chat.open();
+
+  const defaultTimeout = options?.defaultTimeout ?? 120_000;
+
+  return {
+    async sendPrompt(agent: string, prompt: string): Promise<string> {
+      await chat.selectAgent(agent);
+      const response = await chat.sendAndRead(prompt, defaultTimeout);
+      return response;
+    },
+
+    async close(): Promise<void> {
+      await vscode.close();
+    },
+  };
+}

--- a/crew/bridge/src/page-objects/chat-panel.ts
+++ b/crew/bridge/src/page-objects/chat-panel.ts
@@ -1,0 +1,176 @@
+import type { Page } from 'playwright';
+import { SELECTORS } from '../selectors';
+
+const DEFAULT_RESPONSE_TIMEOUT = 120_000; // 2 minutes
+const STABILITY_PERIOD = 2_000; // 2 seconds of no DOM changes = streaming done
+
+export class ChatPanel {
+  constructor(private page: Page) {}
+
+  /**
+   * Open the Chat panel via keyboard shortcut.
+   * Tries Ctrl+Shift+I first, then falls back to Command Palette.
+   */
+  async open(): Promise<void> {
+    // Try the keyboard shortcut for opening Chat
+    await this.page.keyboard.press('Control+Alt+i');
+
+    // Wait for the chat panel or input to appear
+    try {
+      await this.page.waitForSelector(
+        `${SELECTORS.chatInput}, ${SELECTORS.chatInputFallback}, ${SELECTORS.chatPanelFallback}`,
+        { timeout: 5_000 }
+      );
+    } catch {
+      // Fallback: use the Command Palette
+      await this.openViaCommandPalette();
+    }
+  }
+
+  private async openViaCommandPalette(): Promise<void> {
+    await this.page.keyboard.press('Control+Shift+p');
+    await this.page.waitForSelector(SELECTORS.commandPaletteInput, { timeout: 5_000 });
+
+    const input = this.page.locator(SELECTORS.commandPaletteInput);
+    await input.fill('Chat: Open Chat');
+    await this.page.keyboard.press('Enter');
+
+    await this.page.waitForSelector(
+      `${SELECTORS.chatInput}, ${SELECTORS.chatInputFallback}, ${SELECTORS.chatPanelFallback}`,
+      { timeout: 10_000 }
+    );
+  }
+
+  /**
+   * Select an agent by typing @agentName in the chat input.
+   */
+  async selectAgent(name: string): Promise<void> {
+    const input = this.page.locator(
+      `${SELECTORS.chatInput}, ${SELECTORS.chatInputFallback}`
+    ).first();
+    await input.waitFor({ timeout: 5_000 });
+
+    // Clear existing content and type the agent mention
+    await input.focus();
+    await this.page.keyboard.press('Control+a');
+    await input.pressSequentially(`@${name} `, { delay: 50 });
+  }
+
+  /**
+   * Send a prompt to the chat.
+   */
+  async sendPrompt(text: string): Promise<void> {
+    const input = this.page.locator(
+      `${SELECTORS.chatInput}, ${SELECTORS.chatInputFallback}`
+    ).first();
+    await input.waitFor({ timeout: 5_000 });
+    await input.focus();
+
+    await input.pressSequentially(text, { delay: 20 });
+
+    // Submit with Enter
+    await this.page.keyboard.press('Enter');
+  }
+
+  /**
+   * Wait for the streaming response to complete.
+   * Detection strategy: watch for the loading indicator to disappear,
+   * then confirm stability (no new DOM mutations for STABILITY_PERIOD ms).
+   */
+  async waitForResponse(timeout: number = DEFAULT_RESPONSE_TIMEOUT): Promise<void> {
+    const startTime = Date.now();
+
+    // First, wait for a response container to appear (indicates processing started)
+    await this.page.waitForSelector(SELECTORS.lastResponse, {
+      timeout: Math.min(timeout, 30_000),
+    });
+
+    // Wait for the loading indicator to disappear
+    try {
+      await this.page.waitForSelector(SELECTORS.responseInProgress, {
+        state: 'attached',
+        timeout: 10_000,
+      });
+    } catch {
+      // Loading indicator may have already appeared and disappeared
+    }
+
+    // Now wait for it to detach (streaming complete)
+    const remaining = timeout - (Date.now() - startTime);
+    if (remaining <= 0) {
+      throw new Error(`Response timed out after ${timeout}ms`);
+    }
+
+    await this.page.waitForSelector(SELECTORS.responseInProgress, {
+      state: 'detached',
+      timeout: remaining,
+    });
+
+    // Stability check: wait for no DOM mutations in the response area
+    await this.waitForStability();
+  }
+
+  private async waitForStability(): Promise<void> {
+    await this.page.evaluate((stabilityMs: number) => {
+      return new Promise<void>((resolve) => {
+        const target = document.querySelector('.interactive-item-container:last-child');
+        if (!target) {
+          resolve();
+          return;
+        }
+
+        let timer: ReturnType<typeof setTimeout>;
+        const observer = new MutationObserver(() => {
+          clearTimeout(timer);
+          timer = setTimeout(() => {
+            observer.disconnect();
+            resolve();
+          }, stabilityMs);
+        });
+
+        observer.observe(target, {
+          childList: true,
+          subtree: true,
+          characterData: true,
+        });
+
+        // Start the initial timer
+        timer = setTimeout(() => {
+          observer.disconnect();
+          resolve();
+        }, stabilityMs);
+      });
+    }, STABILITY_PERIOD);
+  }
+
+  /**
+   * Extract the text content of the last response in the chat.
+   */
+  async getLastResponse(): Promise<string> {
+    const responseEl = this.page.locator(SELECTORS.lastResponse).locator(SELECTORS.responseBody).last();
+
+    try {
+      await responseEl.waitFor({ timeout: 5_000 });
+    } catch {
+      throw new Error(
+        'No response found in chat panel. The model may not have responded.'
+      );
+    }
+
+    const text = await responseEl.textContent();
+    if (!text || text.trim().length === 0) {
+      throw new Error('Response element found but contains no text.');
+    }
+
+    return text.trim();
+  }
+
+  /**
+   * Convenience method: send a prompt and wait for the full response.
+   */
+  async sendAndRead(text: string, timeout?: number): Promise<string> {
+    await this.sendPrompt(text);
+    await this.waitForResponse(timeout);
+    return this.getLastResponse();
+  }
+}

--- a/crew/bridge/src/page-objects/chat-panel.ts
+++ b/crew/bridge/src/page-objects/chat-panel.ts
@@ -4,16 +4,21 @@ import { SELECTORS } from '../selectors';
 const DEFAULT_RESPONSE_TIMEOUT = 120_000; // 2 minutes
 const STABILITY_PERIOD = 2_000; // 2 seconds of no DOM changes = streaming done
 
+/** Returns the platform-appropriate modifier key (Meta on macOS, Control elsewhere). */
+function platformModifier(): string {
+  return process.platform === 'darwin' ? 'Meta' : 'Control';
+}
+
 export class ChatPanel {
   constructor(private page: Page) {}
 
   /**
    * Open the Chat panel via keyboard shortcut.
-   * Tries Ctrl+Shift+I first, then falls back to Command Palette.
+   * Tries Control+Alt+i (Meta+Alt+i on macOS) first, then falls back to Command Palette.
    */
   async open(): Promise<void> {
     // Try the keyboard shortcut for opening Chat
-    await this.page.keyboard.press('Control+Alt+i');
+    await this.page.keyboard.press(`${platformModifier()}+Alt+i`);
 
     // Wait for the chat panel or input to appear
     try {
@@ -28,7 +33,7 @@ export class ChatPanel {
   }
 
   private async openViaCommandPalette(): Promise<void> {
-    await this.page.keyboard.press('Control+Shift+p');
+    await this.page.keyboard.press(`${platformModifier()}+Shift+p`);
     await this.page.waitForSelector(SELECTORS.commandPaletteInput, { timeout: 5_000 });
 
     const input = this.page.locator(SELECTORS.commandPaletteInput);
@@ -52,7 +57,7 @@ export class ChatPanel {
 
     // Clear existing content and type the agent mention
     await input.focus();
-    await this.page.keyboard.press('Control+a');
+    await this.page.keyboard.press(`${platformModifier()}+a`);
     await input.pressSequentially(`@${name} `, { delay: 50 });
   }
 
@@ -80,10 +85,16 @@ export class ChatPanel {
   async waitForResponse(timeout: number = DEFAULT_RESPONSE_TIMEOUT): Promise<void> {
     const startTime = Date.now();
 
-    // First, wait for a response container to appear (indicates processing started)
-    await this.page.waitForSelector(SELECTORS.lastResponse, {
-      timeout: Math.min(timeout, 30_000),
-    });
+    // Count existing responses before waiting so we detect a NEW one
+    const countBefore = await this.page.locator(SELECTORS.responseContainer).count();
+
+    // Wait for a new response container to appear (count increases)
+    await this.page.waitForFunction(
+      ([selector, prevCount]: [string, number]) =>
+        document.querySelectorAll(selector).length > prevCount,
+      [SELECTORS.responseContainer, countBefore] as [string, number],
+      { timeout: Math.min(timeout, 30_000) },
+    );
 
     // Wait for the loading indicator to disappear
     try {
@@ -111,9 +122,9 @@ export class ChatPanel {
   }
 
   private async waitForStability(): Promise<void> {
-    await this.page.evaluate((stabilityMs: number) => {
+    await this.page.evaluate(([stabilityMs, selector]: [number, string]) => {
       return new Promise<void>((resolve) => {
-        const target = document.querySelector('.interactive-item-container:last-child');
+        const target = document.querySelector(selector);
         if (!target) {
           resolve();
           return;
@@ -140,7 +151,7 @@ export class ChatPanel {
           resolve();
         }, stabilityMs);
       });
-    }, STABILITY_PERIOD);
+    }, [STABILITY_PERIOD, SELECTORS.lastResponse] as [number, string]);
   }
 
   /**

--- a/crew/bridge/src/page-objects/vscode-app.ts
+++ b/crew/bridge/src/page-objects/vscode-app.ts
@@ -7,7 +7,7 @@ export interface VSCodeLaunchOptions {
   executablePath?: string;
   /** Workspace folder to open on launch. */
   workspacePath?: string;
-  /** Temporary user data directory for clean state. If not set, uses a temp dir. */
+  /** Temporary user data directory for clean state. If not set, VS Code uses its default profile. */
   userDataDir?: string;
   /** Extensions to keep enabled (all others are disabled). Defaults to ['GitHub.copilot', 'GitHub.copilot-chat']. */
   enabledExtensions?: string[];
@@ -29,7 +29,7 @@ function resolveExecutablePath(provided?: string): string {
     }
   }
 
-  // Fallback: assume 'code' is on PATH and resolve to electron
+  // Fallback: assume 'code' is on PATH
   return 'code';
 }
 

--- a/crew/bridge/src/page-objects/vscode-app.ts
+++ b/crew/bridge/src/page-objects/vscode-app.ts
@@ -1,0 +1,102 @@
+import { _electron as electron, type ElectronApplication, type Page } from 'playwright';
+import * as path from 'path';
+import { SELECTORS } from '../selectors';
+
+export interface VSCodeLaunchOptions {
+  /** Path to the VS Code executable. Defaults to system 'code' resolved via PATH. */
+  executablePath?: string;
+  /** Workspace folder to open on launch. */
+  workspacePath?: string;
+  /** Temporary user data directory for clean state. If not set, uses a temp dir. */
+  userDataDir?: string;
+  /** Extensions to keep enabled (all others are disabled). Defaults to ['GitHub.copilot', 'GitHub.copilot-chat']. */
+  enabledExtensions?: string[];
+}
+
+const DEFAULT_ENABLED_EXTENSIONS = ['GitHub.copilot', 'GitHub.copilot-chat'];
+
+/**
+ * Resolves the VS Code executable path.
+ * On Windows, the typical path is under Program Files or the user's local app data.
+ */
+function resolveExecutablePath(provided?: string): string {
+  if (provided) return provided;
+
+  if (process.platform === 'win32') {
+    const localAppData = process.env.LOCALAPPDATA;
+    if (localAppData) {
+      return path.join(localAppData, 'Programs', 'Microsoft VS Code', 'Code.exe');
+    }
+  }
+
+  // Fallback: assume 'code' is on PATH and resolve to electron
+  return 'code';
+}
+
+export class VSCodeApp {
+  private app: ElectronApplication | null = null;
+  private page: Page | null = null;
+
+  async launch(options: VSCodeLaunchOptions = {}): Promise<Page> {
+    const execPath = resolveExecutablePath(options.executablePath);
+    const enabledExtensions = options.enabledExtensions ?? DEFAULT_ENABLED_EXTENSIONS;
+
+    const args: string[] = [
+      '--disable-gpu-sandbox',
+      '--no-sandbox',
+    ];
+
+    // Disable all extensions, then selectively enable
+    args.push('--disable-extensions');
+    for (const ext of enabledExtensions) {
+      args.push(`--enable-extension=${ext}`);
+    }
+
+    if (options.userDataDir) {
+      args.push(`--user-data-dir=${options.userDataDir}`);
+    }
+
+    if (options.workspacePath) {
+      args.push(options.workspacePath);
+    }
+
+    this.app = await electron.launch({
+      executablePath: execPath,
+      args,
+      timeout: 60_000,
+    });
+
+    this.page = await this.app.firstWindow();
+
+    // Wait for VS Code to be fully loaded
+    await this.page.waitForSelector(SELECTORS.titleBar, { timeout: 30_000 });
+
+    // Log VS Code version from the title bar
+    const titleText = await this.page.textContent(SELECTORS.titleBar);
+    console.log(`VS Code launched: ${titleText}`);
+
+    return this.page;
+  }
+
+  getPage(): Page {
+    if (!this.page) {
+      throw new Error('VS Code is not launched. Call launch() first.');
+    }
+    return this.page;
+  }
+
+  getApp(): ElectronApplication {
+    if (!this.app) {
+      throw new Error('VS Code is not launched. Call launch() first.');
+    }
+    return this.app;
+  }
+
+  async close(): Promise<void> {
+    if (this.app) {
+      await this.app.close();
+      this.app = null;
+      this.page = null;
+    }
+  }
+}

--- a/crew/bridge/src/selectors.ts
+++ b/crew/bridge/src/selectors.ts
@@ -1,0 +1,54 @@
+/**
+ * Centralized selector registry for VS Code Chat panel automation.
+ *
+ * Each selector is annotated with the VS Code version it was tested against.
+ * Prefer ARIA roles and data attributes over CSS classes for stability.
+ */
+
+// VS Code version: 1.100.x
+export const SELECTORS = {
+  /** The chat input textarea where prompts are typed. */
+  chatInput: '[role="textbox"][aria-label*="Chat Input"]',
+
+  /** The chat input textarea (fallback — class-based). */
+  chatInputFallback: '.interactive-input-editor .monaco-editor textarea',
+
+  /** The send button for submitting a chat prompt. */
+  sendButton: '[aria-label="Send"]',
+
+  /** The send button (fallback — title-based). */
+  sendButtonFallback: '[title="Send"]',
+
+  /** Container for individual chat response messages. */
+  responseContainer: '.interactive-item-container',
+
+  /** The last response element in the chat panel. */
+  lastResponse: '.interactive-item-container:last-child',
+
+  /** Response body content within a response container. */
+  responseBody: '.interactive-response .rendered-markdown',
+
+  /** Loading/streaming indicator shown while the model is generating. */
+  streamingIndicator: '.codicon-loading',
+
+  /** Progress indicator on the response (alternative detection). */
+  responseInProgress: '.interactive-item-container:last-child .codicon-loading',
+
+  /** The chat panel view container. */
+  chatPanel: '[id="workbench.panel.chat"]',
+
+  /** The chat panel (fallback — view-based). */
+  chatPanelFallback: '.interactive-session',
+
+  /** Agent picker / model picker dropdown trigger. */
+  agentPicker: '.chat-input-toolbars .codicon-chevron-down',
+
+  /** Agent picker menu items. */
+  agentPickerItem: '.monaco-list-row',
+
+  /** Command palette input. */
+  commandPaletteInput: '.quick-input-widget input[type="text"]',
+
+  /** The title bar — used to verify VS Code has loaded. */
+  titleBar: '.titlebar-text',
+} as const;

--- a/crew/bridge/tests/smoke.test.ts
+++ b/crew/bridge/tests/smoke.test.ts
@@ -39,7 +39,7 @@ test.describe('VS Code Bridge Smoke Test', () => {
   });
 
   test('launch VS Code, send prompt, read response', async () => {
-    test.skip(!process.env.BRIDGE_SMOKE, SKIP_REASON);
+    test.skip(!['1', 'true'].includes(process.env.BRIDGE_SMOKE ?? ''), SKIP_REASON);
 
     // Use the repo root as the workspace
     const workspacePath = path.resolve(__dirname, '..', '..', '..');

--- a/crew/bridge/tests/smoke.test.ts
+++ b/crew/bridge/tests/smoke.test.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import { createBridge, type VSCodeBridge } from '../src/index';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+/**
+ * Smoke test for the VS Code agent bridge.
+ *
+ * SKIPPED by default — requires VS Code and GitHub Copilot to be installed.
+ *
+ * To run manually:
+ *   cd crew/bridge
+ *   npm install
+ *   npm run build
+ *   BRIDGE_SMOKE=1 npx playwright test tests/smoke.test.ts
+ */
+
+const SKIP_REASON =
+  'Requires VS Code + GitHub Copilot installed. Set BRIDGE_SMOKE=1 to run.';
+
+test.describe('VS Code Bridge Smoke Test', () => {
+  let bridge: VSCodeBridge;
+  let tmpDir: string;
+
+  test.beforeAll(async () => {
+    // Create a temp user data dir for clean state
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nse-bridge-test-'));
+  });
+
+  test.afterAll(async () => {
+    if (bridge) {
+      await bridge.close();
+    }
+    // Clean up temp dir
+    if (tmpDir && fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('launch VS Code, send prompt, read response', async () => {
+    test.skip(!process.env.BRIDGE_SMOKE, SKIP_REASON);
+
+    // Use the repo root as the workspace
+    const workspacePath = path.resolve(__dirname, '..', '..', '..');
+
+    bridge = await createBridge({
+      workspacePath,
+      userDataDir: tmpDir,
+      defaultTimeout: 180_000, // 3 minutes for CI-like environments
+    });
+
+    const response = await bridge.sendPrompt('developer', 'What is 2+2?');
+
+    console.log('Response received:', response);
+
+    expect(response).toBeTruthy();
+    expect(response.length).toBeGreaterThan(0);
+  });
+});

--- a/crew/bridge/tsconfig.json
+++ b/crew/bridge/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
## Summary

Adds a Playwright-based automation bridge for VS Code's Chat panel under `crew/bridge/`. This enables programmatic interaction with Copilot agents (e.g., `@developer`) for CrewAI integration.

## What's included

### TypeScript project (`crew/bridge/`)

- **`src/selectors.ts`** — Centralized DOM selector registry with VS Code version annotations. Uses ARIA roles and data attributes where available for stability.
- **`src/page-objects/vscode-app.ts`** — VS Code Electron lifecycle management: launch with configurable executable path, workspace, user data dir, and extension filtering.
- **`src/page-objects/chat-panel.ts`** — Chat panel interaction: open via keyboard shortcut or command palette, agent selection via `@mention`, prompt submission, streaming response detection (loading indicator + DOM mutation stability), and response text extraction.
- **`src/index.ts`** — High-level `createBridge()` API exposing `sendPrompt(agent, prompt)` and `close()`.
- **`tests/smoke.test.ts`** — End-to-end smoke test (skipped by default; requires VS Code + Copilot). Run with `BRIDGE_SMOKE=1 npx playwright test`.
- **`playwright.config.ts`** — Playwright test configuration with extended timeouts for VS Code launch.

### Build verification

- TypeScript compiles cleanly (`npm run build`)
- Python test suite: 1483 passed, no regressions
- Smoke test skipped by default (needs local VS Code + Copilot)

## Smoke test instructions

```powershell
cd crew/bridge
npm install
npm run build
$env:BRIDGE_SMOKE = "1"
npx playwright test tests/smoke.test.ts
```
