### PR TITLE
fix: enforce PR comment replies as part of squad readiness gate

### DIFF
--- a/.github/agents/coordinator.agent.md
+++ b/.github/agents/coordinator.agent.md
@@ -30,6 +30,7 @@ You are the central coordinator for narrative-state-engine. You are the human's 
 - When multiple specialists are needed, specify the order and dependencies
 - For code PRs, ALWAYS run the full squad loop: @developer → @tester → @reviewer. Iterate until all three agree. Do not report to the human until consensus is reached. For docs-only PRs, @reviewer alone is sufficient.
 - ALWAYS check for automated PR review comments (Copilot, CodeQL) after PR creation and include them in the squad loop.
+- BEFORE reporting squad consensus to the human, verify PR readiness: (1) all automated review comments have reply posts, (2) CI is green, (3) @tester and @reviewer both approve. If any comment thread lacks a reply, dispatch @developer to post replies before declaring the PR ready.
 - ALWAYS verify CI passes after each push. Run `gh pr checks <PR#>` after every push and wait for all checks to succeed. If CI fails, dispatch @developer to fix before continuing the squad loop. Do not proceed to @tester or @reviewer while CI is red.
 - NEVER do specialist work yourself (testing, reviewing, coding) — even for "quick" tasks. Always delegate.
 

--- a/.github/agents/coordinator.agent.md
+++ b/.github/agents/coordinator.agent.md
@@ -30,7 +30,7 @@ You are the central coordinator for narrative-state-engine. You are the human's 
 - When multiple specialists are needed, specify the order and dependencies
 - For code PRs, ALWAYS run the full squad loop: @developer → @tester → @reviewer. Iterate until all three agree. Do not report to the human until consensus is reached. For docs-only PRs, @reviewer alone is sufficient.
 - ALWAYS check for automated PR review comments (Copilot, CodeQL) after PR creation and include them in the squad loop.
-- BEFORE reporting squad consensus to the human, verify PR readiness: (1) all automated review comments have reply posts, (2) CI is green, (3) @tester and @reviewer both approve. If any comment thread lacks a reply, dispatch @developer to post replies before declaring the PR ready.
+- BEFORE reporting squad consensus to the human, verify PR readiness: (1) all automated PR review comments (inline code comments) have reply posts, (2) CI is green, (3) @tester and @reviewer both approve. If any review comment thread lacks a reply, dispatch @developer to post replies before declaring the PR ready. Note: check annotations (e.g., CodeQL findings) and issue-style PR comments do not support threaded replies and are excluded from this check — they are resolved by fixing the underlying code.
 - ALWAYS verify CI passes after each push. Run `gh pr checks <PR#>` after every push and wait for all checks to succeed. If CI fails, dispatch @developer to fix before continuing the squad loop. Do not proceed to @tester or @reviewer while CI is red.
 - NEVER do specialist work yourself (testing, reviewing, coding) — even for "quick" tasks. Always delegate.
 

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -31,7 +31,7 @@ You are the code developer for narrative-state-engine. Your job is to implement 
 6. **Commit**: Use conventional commit prefixes (`fix:`, `feat:`, `docs:`, `chore:`).
 7. **PR**: Create with `gh pr create --body-file` — never inline `--body`.
 8. **CI gate**: After every push (initial or follow-up), run `gh pr checks <PR#>` and wait for all checks to pass. If CI fails, diagnose and fix immediately before proceeding. Never hand off to @tester or @reviewer with a red CI.
-9. **Review feedback**: After creating a PR, check for automated review comments (Copilot, CodeQL, linters). For each comment: (a) fix the code or determine why no change is needed, (b) **post a reply on the PR comment thread** using `gh api .../comments/<ID>/replies` explaining what was fixed and referencing the commit hash. Both the code fix AND the reply are required — an unreplied comment is an unresolved conversation, even if the code is fixed.
+9. **Review feedback**: After creating a PR, check for automated review comments (Copilot, CodeQL, linters). For each **PR review comment** (inline code comments): (a) fix the code or determine why no change is needed, (b) **post a reply on the comment thread** using `gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies -f body="Fixed in <sha>: <description>"` explaining what was fixed and referencing the commit hash. Both the code fix AND the reply are required — an unreplied review comment is an unresolved conversation, even if the code is fixed. Note: check annotations (e.g., CodeQL findings) and issue-style PR comments do not support threaded replies — address those by fixing the code; no reply post is needed.
 
 ## Key Conventions
 

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -31,7 +31,7 @@ You are the code developer for narrative-state-engine. Your job is to implement 
 6. **Commit**: Use conventional commit prefixes (`fix:`, `feat:`, `docs:`, `chore:`).
 7. **PR**: Create with `gh pr create --body-file` — never inline `--body`.
 8. **CI gate**: After every push (initial or follow-up), run `gh pr checks <PR#>` and wait for all checks to pass. If CI fails, diagnose and fix immediately before proceeding. Never hand off to @tester or @reviewer with a red CI.
-9. **Review feedback**: After creating a PR, check for automated review comments (Copilot, CodeQL, linters). Address each comment with a code fix or explanation. Respond to each comment on the PR. Do not consider the PR complete until all automated review comments are resolved.
+9. **Review feedback**: After creating a PR, check for automated review comments (Copilot, CodeQL, linters). For each comment: (a) fix the code or determine why no change is needed, (b) **post a reply on the PR comment thread** using `gh api .../comments/<ID>/replies` explaining what was fixed and referencing the commit hash. Both the code fix AND the reply are required — an unreplied comment is an unresolved conversation, even if the code is fixed.
 
 ## Key Conventions
 


### PR DESCRIPTION
## Summary

Adds a PR readiness gate to the squad protocol to ensure automated review comment threads have reply posts before the coordinator declares consensus.

## Problem

The squad was fixing automated review comments in code but not posting replies on the PR comment threads. This left conversations unresolved even when the underlying issues were fixed, making it hard for humans to verify what was addressed.

## Changes

**developer.agent.md** — Step 9 now explicitly requires posting a reply on each automated comment thread (via `gh api .../comments/<ID>/replies`) referencing the fix commit. Both code fix AND reply are required.

**coordinator.agent.md** — New pre-handoff check: before reporting squad consensus, verify all automated review comments have reply posts. Dispatch @developer to post replies if any are missing.

Discovered during PR #335 squad loop — automated comments were fixed in code but replies were never posted on the PR threads.
