### PR TITLE
fix: update Playwright bridge selectors for VS Code 1.100

### DIFF
--- a/crew/bridge/README.md
+++ b/crew/bridge/README.md
@@ -28,7 +28,9 @@ await bridge.close();
 
 ## Running the Smoke Test
 
-The smoke test requires VS Code and GitHub Copilot to be installed locally:
+The smoke test requires VS Code and GitHub Copilot to be installed locally.
+
+> **Important:** Close all VS Code windows before running the smoke test. The bridge launches its own VS Code instance and an existing window can interfere with Electron discovery.
 
 ```bash
 BRIDGE_SMOKE=1 npx playwright test tests/smoke.test.ts
@@ -40,6 +42,23 @@ On Windows (PowerShell):
 $env:BRIDGE_SMOKE = "1"
 npx playwright test tests/smoke.test.ts
 ```
+
+## Running the Diagnostic Test
+
+The diagnostic test captures screenshots, accessibility trees, CSS selector probes, and raw HTML from the chat panel DOM. Use it to debug selector breakage after VS Code updates.
+
+```bash
+BRIDGE_DIAGNOSTIC=1 npx playwright test tests/diagnostic.test.ts
+```
+
+On Windows (PowerShell):
+
+```powershell
+$env:BRIDGE_DIAGNOSTIC = "1"
+npx playwright test tests/diagnostic.test.ts
+```
+
+Diagnostic output is saved to `test-results/diagnostic/` by default.
 
 ## Selectors
 

--- a/crew/bridge/src/page-objects/chat-panel.ts
+++ b/crew/bridge/src/page-objects/chat-panel.ts
@@ -227,15 +227,15 @@ export class ChatPanel {
    * Get the text content of the chat panel area (for stability comparison).
    */
   private async getChatPanelText(): Promise<string> {
-    return this.page.evaluate(() => {
-      const sendBtn = document.querySelector('button[aria-label^="Send"]');
+    return this.page.evaluate((sendBtnSel) => {
+      const sendBtn = document.querySelector(sendBtnSel);
       if (!sendBtn) return '';
       let container: Element | null = sendBtn;
       for (let i = 0; i < 6 && container?.parentElement; i++) {
         container = container.parentElement;
       }
       return (container as HTMLElement)?.innerText ?? '';
-    });
+    }, SELECTORS.sendButton);
   }
 
   /**
@@ -358,8 +358,8 @@ export class ChatPanel {
     );
 
     // 4. CSS class census — all unique classes in the chat panel area
-    const classCensus = await this.page.evaluate(() => {
-      const sendBtn = document.querySelector('button[aria-label^="Send"]');
+    const classCensus = await this.page.evaluate((sendBtnSel) => {
+      const sendBtn = document.querySelector(sendBtnSel);
       if (!sendBtn) return { error: 'Send button not found' };
 
       // Walk up ~8 levels to find a reasonable ancestor encompassing the chat area
@@ -382,7 +382,7 @@ export class ChatPanel {
       };
       walk(container);
       return classMap;
-    });
+    }, SELECTORS.sendButton);
 
     fs.writeFileSync(
       path.join(outputDir, 'css-class-census.json'),
@@ -390,8 +390,8 @@ export class ChatPanel {
     );
 
     // 5. Raw HTML of the chat area (truncated to 500KB)
-    const chatHtml = await this.page.evaluate(() => {
-      const sendBtn = document.querySelector('button[aria-label^="Send"]');
+    const chatHtml = await this.page.evaluate((sendBtnSel) => {
+      const sendBtn = document.querySelector(sendBtnSel);
       if (!sendBtn) return '<no-send-button-found />';
 
       let container: Element | null = sendBtn;
@@ -402,7 +402,7 @@ export class ChatPanel {
       return html.length > 500_000
         ? html.substring(0, 500_000) + '\n<!-- TRUNCATED -->'
         : html;
-    });
+    }, SELECTORS.sendButton);
 
     fs.writeFileSync(path.join(outputDir, 'chat-panel.html'), chatHtml);
 

--- a/crew/bridge/src/page-objects/chat-panel.ts
+++ b/crew/bridge/src/page-objects/chat-panel.ts
@@ -1,8 +1,8 @@
-import type { Page } from 'playwright';
+import type { Page, Locator } from 'playwright';
 import { SELECTORS } from '../selectors';
 
 const DEFAULT_RESPONSE_TIMEOUT = 120_000; // 2 minutes
-const STABILITY_PERIOD = 2_000; // 2 seconds of no DOM changes = streaming done
+const STABILITY_PERIOD = 3_000; // 3 seconds of no DOM changes = streaming done
 
 /** Returns the platform-appropriate modifier key (Meta on macOS, Control elsewhere). */
 function platformModifier(): string {
@@ -14,22 +14,39 @@ export class ChatPanel {
 
   /**
    * Open the Chat panel via keyboard shortcut.
-   * Tries Control+Alt+i (Meta+Alt+i on macOS) first, then falls back to Command Palette.
+   * Tries Control+Alt+i (Meta+Alt+i on macOS) first, then the Toggle Chat
+   * sparkle button, then falls back to the Command Palette.
    */
   async open(): Promise<void> {
+    // The Send button uniquely identifies an open, ready chat panel
+    const chatVisibleSelector =
+      `${SELECTORS.chatInput}, ${SELECTORS.sendButton}`;
+
     // Try the keyboard shortcut for opening Chat
     await this.page.keyboard.press(`${platformModifier()}+Alt+i`);
 
     // Wait for the chat panel or input to appear
     try {
-      await this.page.waitForSelector(
-        `${SELECTORS.chatInput}, ${SELECTORS.chatInputFallback}, ${SELECTORS.chatPanelFallback}`,
-        { timeout: 5_000 }
-      );
+      await this.page.waitForSelector(chatVisibleSelector, { timeout: 5_000 });
+      return;
     } catch {
-      // Fallback: use the Command Palette
-      await this.openViaCommandPalette();
+      // Keyboard shortcut didn't work
     }
+
+    // Fallback: click the Toggle Chat sparkle button in the title bar (VS Code >= 1.100)
+    try {
+      const sparkle = this.page.locator(SELECTORS.toggleChatButton).first();
+      if (await sparkle.isVisible({ timeout: 2_000 })) {
+        await sparkle.click();
+        await this.page.waitForSelector(chatVisibleSelector, { timeout: 5_000 });
+        return;
+      }
+    } catch {
+      // Sparkle button didn't work
+    }
+
+    // Last resort: use the Command Palette
+    await this.openViaCommandPalette();
   }
 
   private async openViaCommandPalette(): Promise<void> {
@@ -41,8 +58,45 @@ export class ChatPanel {
     await this.page.keyboard.press('Enter');
 
     await this.page.waitForSelector(
-      `${SELECTORS.chatInput}, ${SELECTORS.chatInputFallback}, ${SELECTORS.chatPanelFallback}`,
+      `${SELECTORS.chatInput}, ${SELECTORS.sendButton}`,
       { timeout: 10_000 }
+    );
+  }
+
+  /**
+   * Find the chat input textbox, trying multiple selector strategies.
+   * Returns the best-matching Locator for the chat input.
+   */
+  private async findChatInput(): Promise<Locator> {
+    // Strategy 1: ARIA-based — Monaco editor textarea with known aria-label
+    const primary = this.page.locator(SELECTORS.chatInput);
+    const primaryCount = await primary.count();
+
+    if (primaryCount === 1) {
+      return primary;
+    }
+
+    if (primaryCount > 1) {
+      // Multiple Monaco editors (files open) — the chat input is in the
+      // secondary sidebar which comes last in DOM order.
+      return primary.last();
+    }
+
+    // Strategy 2: CSS class-based fallback
+    const fallback = this.page.locator(SELECTORS.chatInputFallback);
+    if (await fallback.count() > 0) {
+      return fallback.first();
+    }
+
+    // Strategy 3: Any textbox without an aria-label (very broad)
+    const anyTextbox = this.page.locator('[role="textbox"]:not([aria-label])');
+    if (await anyTextbox.count() > 0) {
+      return anyTextbox.last();
+    }
+
+    throw new Error(
+      'Could not find chat input textbox. Is the Chat panel open? ' +
+      'Run the diagnostic test for details.'
     );
   }
 
@@ -50,9 +104,7 @@ export class ChatPanel {
    * Select an agent by typing @agentName in the chat input.
    */
   async selectAgent(name: string): Promise<void> {
-    const input = this.page.locator(
-      `${SELECTORS.chatInput}, ${SELECTORS.chatInputFallback}`
-    ).first();
+    const input = await this.findChatInput();
     await input.waitFor({ timeout: 5_000 });
 
     // Clear existing content and type the agent mention
@@ -65,9 +117,7 @@ export class ChatPanel {
    * Send a prompt to the chat.
    */
   async sendPrompt(text: string): Promise<void> {
-    const input = this.page.locator(
-      `${SELECTORS.chatInput}, ${SELECTORS.chatInputFallback}`
-    ).first();
+    const input = await this.findChatInput();
     await input.waitFor({ timeout: 5_000 });
     await input.focus();
 
@@ -79,101 +129,137 @@ export class ChatPanel {
 
   /**
    * Wait for the streaming response to complete.
-   * Detection strategy: watch for the loading indicator to disappear,
-   * then confirm stability (no new DOM mutations for STABILITY_PERIOD ms).
+   *
+   * Strategy (count-based, uses verified selectors):
+   * 1. Count .interactive-item-container elements before (caller should have
+   *    counted before sending — here we just wait for a new one to appear)
+   * 2. Wait for .codicon-loading inside the last container to disappear
+   * 3. Final stability wait
    */
   async waitForResponse(timeout: number = DEFAULT_RESPONSE_TIMEOUT): Promise<void> {
-    const startTime = Date.now();
+    const deadline = Date.now() + timeout;
 
-    // Count existing responses before waiting so we detect a NEW one
-    const countBefore = await this.page.locator(SELECTORS.responseContainer).count();
+    // Phase 1: Wait for a new response container to appear
+    // We detect this by waiting for .interactive-response (the assistant's reply)
+    // to have the .chat-most-recent-response class, indicating VS Code has attached it.
+    await this.page.waitForTimeout(1_000);
 
-    // Wait for a new response container to appear (count increases)
-    await this.page.waitForFunction(
-      ([selector, prevCount]: [string, number]) =>
-        document.querySelectorAll(selector).length > prevCount,
-      [SELECTORS.responseContainer, countBefore] as [string, number],
-      { timeout: Math.min(timeout, 30_000) },
-    );
+    // Phase 2: Wait for streaming indicator to appear then disappear
+    const streamingSelector = `${SELECTORS.responseInProgress}, ${SELECTORS.stopButton}`;
+    let indicatorFound = false;
 
-    // Wait for the loading indicator to disappear
     try {
-      await this.page.waitForSelector(SELECTORS.responseInProgress, {
+      await this.page.waitForSelector(streamingSelector, {
         state: 'attached',
-        timeout: 10_000,
+        timeout: Math.min(30_000, Math.max(deadline - Date.now(), 5_000)),
       });
+      indicatorFound = true;
     } catch {
-      // Loading indicator may have already appeared and disappeared
+      // Fast response — indicator may have appeared and disappeared already
+      console.warn('Streaming indicator not detected — using content stability fallback.');
     }
 
-    // Now wait for it to detach (streaming complete)
-    const remaining = timeout - (Date.now() - startTime);
-    if (remaining <= 0) {
-      throw new Error(`Response timed out after ${timeout}ms`);
+    if (indicatorFound) {
+      const remaining = Math.max(deadline - Date.now(), 5_000);
+      try {
+        await this.page.waitForSelector(streamingSelector, {
+          state: 'detached',
+          timeout: remaining,
+        });
+      } catch {
+        console.warn('Streaming indicator detach timed out — proceeding.');
+      }
+    } else {
+      // Fallback: poll the accessibility tree for content stability
+      await this.waitForContentStability(deadline);
     }
 
-    await this.page.waitForSelector(SELECTORS.responseInProgress, {
-      state: 'detached',
-      timeout: remaining,
-    });
-
-    // Stability check: wait for no DOM mutations in the response area
-    await this.waitForStability();
+    // Phase 3: Final stability wait
+    await this.page.waitForTimeout(STABILITY_PERIOD);
   }
 
-  private async waitForStability(): Promise<void> {
-    await this.page.evaluate(([stabilityMs, selector]: [number, string]) => {
-      return new Promise<void>((resolve) => {
-        const target = document.querySelector(selector);
-        if (!target) {
-          resolve();
-          return;
-        }
+  /**
+   * Fallback response detection: poll the chat panel's text content until it
+   * stops changing, indicating the response has finished streaming.
+   */
+  private async waitForContentStability(deadline: number): Promise<void> {
+    const POLL_INTERVAL = 2_000;
+    const REQUIRED_STABLE = 3;
+    let lastText = '';
+    let stableCount = 0;
 
-        let timer: ReturnType<typeof setTimeout>;
-        const observer = new MutationObserver(() => {
-          clearTimeout(timer);
-          timer = setTimeout(() => {
-            observer.disconnect();
-            resolve();
-          }, stabilityMs);
-        });
+    while (Date.now() < deadline) {
+      const text = await this.getChatPanelText();
 
-        observer.observe(target, {
-          childList: true,
-          subtree: true,
-          characterData: true,
-        });
+      if (text === lastText) {
+        stableCount++;
+        if (stableCount >= REQUIRED_STABLE) return;
+      } else {
+        stableCount = 0;
+        lastText = text;
+      }
 
-        // Start the initial timer
-        timer = setTimeout(() => {
-          observer.disconnect();
-          resolve();
-        }, stabilityMs);
-      });
-    }, [STABILITY_PERIOD, SELECTORS.lastResponse] as [number, string]);
+      await this.page.waitForTimeout(POLL_INTERVAL);
+    }
+
+    console.warn('Content stability check timed out — proceeding anyway.');
+  }
+
+  /**
+   * Get the text content of the chat panel area (for stability comparison).
+   */
+  private async getChatPanelText(): Promise<string> {
+    return this.page.evaluate(() => {
+      const sendBtn = document.querySelector('button[aria-label^="Send"]');
+      if (!sendBtn) return '';
+      let container: Element | null = sendBtn;
+      for (let i = 0; i < 6 && container?.parentElement; i++) {
+        container = container.parentElement;
+      }
+      return (container as HTMLElement)?.innerText ?? '';
+    });
   }
 
   /**
    * Extract the text content of the last response in the chat.
+   *
+   * Uses verified selectors: find the last .interactive-item-container,
+   * then extract .rendered-markdown text inside it.
    */
   async getLastResponse(): Promise<string> {
-    const responseEl = this.page.locator(SELECTORS.lastResponse).locator(SELECTORS.responseBody).last();
+    // Get the last interactive-item-container (should be the response)
+    const containers = this.page.locator(SELECTORS.responseContainer);
+    const count = await containers.count();
 
-    try {
-      await responseEl.waitFor({ timeout: 5_000 });
-    } catch {
+    if (count === 0) {
       throw new Error(
-        'No response found in chat panel. The model may not have responded.'
+        'No response containers found in chat panel. ' +
+        'Is the Chat panel open? Run the diagnostic test for details.'
       );
     }
 
-    const text = await responseEl.textContent();
-    if (!text || text.trim().length === 0) {
-      throw new Error('Response element found but contains no text.');
+    // Walk backwards to find the last container with rendered markdown
+    for (let i = count - 1; i >= 0; i--) {
+      const container = containers.nth(i);
+      const markdown = container.locator(SELECTORS.responseBody);
+      const mdCount = await markdown.count();
+
+      if (mdCount > 0) {
+        const text = await markdown.last().textContent();
+        if (text?.trim()) return text.trim();
+      }
     }
 
-    return text.trim();
+    // Fallback: try getting text from the last container directly
+    const lastContainer = containers.last();
+    const text = await lastContainer.textContent();
+    if (text?.trim()) return text.trim();
+
+    throw new Error(
+      'No response text found in chat panel. ' +
+      'Run the diagnostic test to verify selectors: ' +
+      'BRIDGE_DIAGNOSTIC=1 npx playwright test tests/diagnostic.test.ts'
+    );
   }
 
   /**
@@ -183,5 +269,125 @@ export class ChatPanel {
     await this.sendPrompt(text);
     await this.waitForResponse(timeout);
     return this.getLastResponse();
+  }
+
+  /**
+   * Capture diagnostic information about the chat panel DOM.
+   * Saves screenshots, accessibility tree, CSS selector probe results,
+   * and raw HTML to the specified output directory.
+   */
+  async captureDiagnostics(outputDir: string): Promise<void> {
+    const fs = await import('fs');
+    const path = await import('path');
+    fs.mkdirSync(outputDir, { recursive: true });
+
+    // 1. Screenshot
+    await this.page.screenshot({
+      path: path.join(outputDir, 'screenshot.png'),
+      fullPage: true,
+    });
+
+    // 2. Accessibility tree (may not be available in all Playwright versions)
+    try {
+      const a11y = await (this.page as any).accessibility?.snapshot({ interestingOnly: false });
+      if (a11y) {
+        fs.writeFileSync(
+          path.join(outputDir, 'accessibility-tree.json'),
+          JSON.stringify(a11y, null, 2),
+        );
+      }
+    } catch {
+      console.warn('page.accessibility.snapshot() not available — skipping a11y tree capture.');
+    }
+
+    // 3. Selector probe — test which CSS selectors match DOM elements
+    const diagnosticProbeSelectors = [
+      '.interactive-item-container',
+      '.interactive-response',
+      '.interactive-request',
+      '.rendered-markdown',
+      '.chat-markdown-part.rendered-markdown',
+      '.codicon-loading',
+      '.interactive-session',
+      '.chat-editor-overflow',
+    ];
+
+    const selectorResults = await this.page.evaluate((candidates) => {
+      const results: Record<string, { count: number; samples: string[] }> = {};
+      for (const sel of candidates) {
+        try {
+          const els = document.querySelectorAll(sel);
+          results[sel] = {
+            count: els.length,
+            samples: Array.from(els).slice(0, 3).map(el => {
+              const tag = el.tagName.toLowerCase();
+              const cls = el.className && typeof el.className === 'string'
+                ? '.' + el.className.split(/\s+/).join('.') : '';
+              const text = (el.textContent ?? '').substring(0, 100);
+              return `<${tag}${cls}> ${text}`;
+            }),
+          };
+        } catch (e: any) {
+          results[sel] = { count: -1, samples: [e.message ?? 'error'] };
+        }
+      }
+      return results;
+    }, diagnosticProbeSelectors);
+
+    fs.writeFileSync(
+      path.join(outputDir, 'selector-probe.json'),
+      JSON.stringify(selectorResults, null, 2),
+    );
+
+    // 4. CSS class census — all unique classes in the chat panel area
+    const classCensus = await this.page.evaluate(() => {
+      const sendBtn = document.querySelector('button[aria-label^="Send"]');
+      if (!sendBtn) return { error: 'Send button not found' };
+
+      // Walk up ~8 levels to find a reasonable ancestor encompassing the chat area
+      let container: Element | null = sendBtn;
+      for (let i = 0; i < 8 && container?.parentElement; i++) {
+        container = container.parentElement;
+      }
+      if (!container) return { error: 'Could not find container' };
+
+      const classMap: Record<string, number> = {};
+      const walk = (el: Element) => {
+        if (el.classList) {
+          el.classList.forEach(cls => {
+            classMap[cls] = (classMap[cls] || 0) + 1;
+          });
+        }
+        for (const child of Array.from(el.children)) {
+          walk(child);
+        }
+      };
+      walk(container);
+      return classMap;
+    });
+
+    fs.writeFileSync(
+      path.join(outputDir, 'css-class-census.json'),
+      JSON.stringify(classCensus, null, 2),
+    );
+
+    // 5. Raw HTML of the chat area (truncated to 500KB)
+    const chatHtml = await this.page.evaluate(() => {
+      const sendBtn = document.querySelector('button[aria-label^="Send"]');
+      if (!sendBtn) return '<no-send-button-found />';
+
+      let container: Element | null = sendBtn;
+      for (let i = 0; i < 8 && container?.parentElement; i++) {
+        container = container.parentElement;
+      }
+      const html = container?.outerHTML ?? '<no-container />';
+      return html.length > 500_000
+        ? html.substring(0, 500_000) + '\n<!-- TRUNCATED -->'
+        : html;
+    });
+
+    fs.writeFileSync(path.join(outputDir, 'chat-panel.html'), chatHtml);
+
+    console.log(`Diagnostics saved to ${outputDir}`);
   }
 }

--- a/crew/bridge/src/page-objects/chat-panel.ts
+++ b/crew/bridge/src/page-objects/chat-panel.ts
@@ -139,10 +139,23 @@ export class ChatPanel {
   async waitForResponse(timeout: number = DEFAULT_RESPONSE_TIMEOUT): Promise<void> {
     const deadline = Date.now() + timeout;
 
-    // Phase 1: Wait for a new response container to appear
-    // We detect this by waiting for .interactive-response (the assistant's reply)
-    // to have the .chat-most-recent-response class, indicating VS Code has attached it.
-    await this.page.waitForTimeout(1_000);
+    // Phase 1: Wait for a new response container to appear.
+    // Count existing containers, then wait for the count to increase —
+    // this guarantees a response actually arrived before checking streaming.
+    const initialCount = await this.page.locator(SELECTORS.responseContainer).count();
+    try {
+      await this.page.waitForFunction(
+        (args: { selector: string; prev: number }) =>
+          document.querySelectorAll(args.selector).length > args.prev,
+        { selector: SELECTORS.responseContainer, prev: initialCount },
+        { timeout: Math.min(30_000, Math.max(deadline - Date.now(), 5_000)) },
+      );
+    } catch {
+      throw new Error(
+        `Timed out waiting for a new response container (had ${initialCount}). ` +
+        'The assistant may not have started replying.',
+      );
+    }
 
     // Phase 2: Wait for streaming indicator to appear then disappear
     const streamingSelector = `${SELECTORS.responseInProgress}, ${SELECTORS.stopButton}`;
@@ -167,7 +180,10 @@ export class ChatPanel {
           timeout: remaining,
         });
       } catch {
-        console.warn('Streaming indicator detach timed out — proceeding.');
+        throw new Error(
+          'Timed out waiting for streaming to finish (indicator never detached). ' +
+          `Elapsed: ${Date.now() - (deadline - timeout)}ms, timeout: ${timeout}ms`,
+        );
       }
     } else {
       // Fallback: poll the accessibility tree for content stability
@@ -202,7 +218,9 @@ export class ChatPanel {
       await this.page.waitForTimeout(POLL_INTERVAL);
     }
 
-    console.warn('Content stability check timed out — proceeding anyway.');
+    throw new Error(
+      'Content stability check timed out — response may be incomplete.',
+    );
   }
 
   /**

--- a/crew/bridge/src/page-objects/vscode-app.ts
+++ b/crew/bridge/src/page-objects/vscode-app.ts
@@ -1,5 +1,6 @@
 import { _electron as electron, type ElectronApplication, type Page } from 'playwright';
 import * as path from 'path';
+import * as os from 'os';
 import { SELECTORS } from '../selectors';
 
 export interface VSCodeLaunchOptions {
@@ -7,13 +8,13 @@ export interface VSCodeLaunchOptions {
   executablePath?: string;
   /** Workspace folder to open on launch. */
   workspacePath?: string;
-  /** Temporary user data directory for clean state. If not set, VS Code uses its default profile. */
+  /** User data directory. A temp dir avoids single-instance conflicts with a running VS Code. */
   userDataDir?: string;
-  /** Extensions to keep enabled (all others are disabled). Defaults to ['GitHub.copilot', 'GitHub.copilot-chat']. */
-  enabledExtensions?: string[];
+  /** Extensions directory. Defaults to ~/.vscode/extensions (the system install location). */
+  extensionsDir?: string;
+  /** Extension IDs to explicitly disable. All other extensions remain enabled. */
+  disabledExtensions?: string[];
 }
-
-const DEFAULT_ENABLED_EXTENSIONS = ['GitHub.copilot', 'GitHub.copilot-chat'];
 
 /**
  * Resolves the VS Code executable path.
@@ -39,22 +40,25 @@ export class VSCodeApp {
 
   async launch(options: VSCodeLaunchOptions = {}): Promise<Page> {
     const execPath = resolveExecutablePath(options.executablePath);
-    const enabledExtensions = options.enabledExtensions ?? DEFAULT_ENABLED_EXTENSIONS;
 
     const args: string[] = [
       '--disable-gpu-sandbox',
       '--no-sandbox',
     ];
 
-    // Disable all extensions, then selectively enable
-    args.push('--disable-extensions');
-    for (const ext of enabledExtensions) {
-      args.push(`--enable-extension=${ext}`);
+    // Selectively disable specific extensions (all others remain enabled)
+    for (const ext of options.disabledExtensions ?? []) {
+      args.push(`--disable-extension=${ext}`);
     }
 
     if (options.userDataDir) {
       args.push(`--user-data-dir=${options.userDataDir}`);
     }
+
+    // Point to the system's extensions dir so installed extensions (e.g. Copilot) are available.
+    // Auth tokens live in the OS credential store, so they work with any user-data-dir.
+    const extDir = options.extensionsDir ?? path.join(process.env.USERPROFILE ?? os.homedir(), '.vscode', 'extensions');
+    args.push(`--extensions-dir=${extDir}`);
 
     if (options.workspacePath) {
       args.push(options.workspacePath);
@@ -68,14 +72,80 @@ export class VSCodeApp {
 
     this.page = await this.app.firstWindow();
 
-    // Wait for VS Code to be fully loaded
-    await this.page.waitForSelector(SELECTORS.titleBar, { timeout: 30_000 });
+    // Wait for VS Code to be fully loaded (try primary selector, then fallback)
+    try {
+      await this.page.waitForSelector(SELECTORS.titleBar, { timeout: 30_000 });
+    } catch {
+      await this.page.waitForSelector(SELECTORS.titleBarFallback, { timeout: 10_000 });
+    }
 
-    // Log VS Code version from the title bar
-    const titleText = await this.page.textContent(SELECTORS.titleBar);
-    console.log(`VS Code launched: ${titleText}`);
+    // Log VS Code window title from the title bar
+    const titleText =
+      await this.page.textContent(SELECTORS.titleBar).catch(() => null) ??
+      await this.page.textContent(SELECTORS.titleBarFallback).catch(() => null);
+    console.log(`VS Code launched: ${titleText?.trim()}`);
+
+    // Dismiss onboarding wizard if present (clean user-data-dir triggers this)
+    await this.dismissOnboarding();
 
     return this.page;
+  }
+
+  /**
+   * Dismiss the VS Code onboarding wizard (sign-in + theme picker steps).
+   * This appears on first launch with a fresh user-data-dir.
+   */
+  private async dismissOnboarding(): Promise<void> {
+    if (!this.page) return;
+    const page = this.page;
+
+    // Step 1: Skip sign-in if the dialog is showing
+    try {
+      const skipBtn = page.locator(SELECTORS.onboardingSkipSignIn);
+      if (await skipBtn.isVisible({ timeout: 2_000 })) {
+        await skipBtn.click();
+        console.log('Dismissed onboarding sign-in dialog');
+        await page.waitForTimeout(1_000);
+      }
+    } catch {
+      // No sign-in dialog — already past this step or not a fresh profile
+    }
+
+    // Step 2: Click through remaining onboarding steps (theme picker, etc.)
+    for (let i = 0; i < 5; i++) {
+      try {
+        // Look for the X close button on the onboarding dialog
+        const closeBtn = page.locator('.onboarding-a-close, .dialog-shadow .codicon-close');
+        if (await closeBtn.first().isVisible({ timeout: 1_000 })) {
+          await closeBtn.first().click();
+          console.log('Closed onboarding dialog via X button');
+          await page.waitForTimeout(500);
+          break;
+        }
+      } catch {
+        // No close button found
+      }
+
+      try {
+        // Fall back to clicking Continue/Next buttons to step through
+        const continueBtn = page.locator('button:has-text("Continue"), button:has-text("Next")').last();
+        if (await continueBtn.isVisible({ timeout: 1_000 })) {
+          await continueBtn.click();
+          console.log('Clicked onboarding Continue/Next');
+          await page.waitForTimeout(500);
+        } else {
+          break;
+        }
+      } catch {
+        break;
+      }
+    }
+
+    // Press Escape a couple of times to dismiss any remaining overlays
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
   }
 
   getPage(): Page {

--- a/crew/bridge/src/page-objects/vscode-app.ts
+++ b/crew/bridge/src/page-objects/vscode-app.ts
@@ -115,7 +115,7 @@ export class VSCodeApp {
     for (let i = 0; i < 5; i++) {
       try {
         // Look for the X close button on the onboarding dialog
-        const closeBtn = page.locator('.onboarding-a-close, .dialog-shadow .codicon-close');
+        const closeBtn = page.locator(SELECTORS.onboardingClose);
         if (await closeBtn.first().isVisible({ timeout: 1_000 })) {
           await closeBtn.first().click();
           console.log('Closed onboarding dialog via X button');
@@ -128,7 +128,7 @@ export class VSCodeApp {
 
       try {
         // Fall back to clicking Continue/Next buttons to step through
-        const continueBtn = page.locator('button:has-text("Continue"), button:has-text("Next")').last();
+        const continueBtn = page.locator(SELECTORS.onboardingContinue).last();
         if (await continueBtn.isVisible({ timeout: 1_000 })) {
           await continueBtn.click();
           console.log('Clicked onboarding Continue/Next');

--- a/crew/bridge/src/selectors.ts
+++ b/crew/bridge/src/selectors.ts
@@ -1,54 +1,96 @@
 /**
  * Centralized selector registry for VS Code Chat panel automation.
  *
- * Each selector is annotated with the VS Code version it was tested against.
- * Prefer ARIA roles and data attributes over CSS classes for stability.
+ * Selectors marked [VERIFIED] were confirmed against VS Code 1.100.x DOM snapshot.
+ * Selectors marked [UNVERIFIED] need validation via the diagnostic test.
+ *
+ * KEY FIX (2025-05): .chat-editor-overflow is the chat INPUT overflow container,
+ * NOT the response area. Response containers use .interactive-item-container /
+ * .interactive-response. The old selectors were looking in the wrong place.
  */
 
-// VS Code version: 1.100.x
+// VS Code version: 1.100.x (tested 2025-05)
 export const SELECTORS = {
-  /** The chat input textarea where prompts are typed. */
-  chatInput: '[role="textbox"][aria-label*="Chat Input"]',
+  /**
+   * [VERIFIED] Chat input textbox — Monaco editor textarea.
+   * The Monaco textarea's aria-label starts with "The editor is not accessible".
+   * NOTE: Also matches file editor textareas; use last() to get the chat one
+   * (secondary sidebar comes last in DOM order).
+   */
+  chatInput: '[role="textbox"][aria-label^="The editor is not accessible"]',
 
-  /** The chat input textarea (fallback — class-based). */
+  /**
+   * Chat input fallback — CSS class-based (may break on VS Code updates).
+   */
   chatInputFallback: '.interactive-input-editor .monaco-editor textarea',
 
-  /** The send button for submitting a chat prompt. */
-  sendButton: '[aria-label="Send"]',
+  /**
+   * [VERIFIED] Send button.
+   * Full label: "Send [Alt] Send to New Chat (Ctrl+Shift+Enter)".
+   * Disabled when input is empty.
+   */
+  sendButton: 'button[aria-label^="Send"]',
 
-  /** The send button (fallback — title-based). */
-  sendButtonFallback: '[title="Send"]',
+  /** [VERIFIED] Broader Send button match. */
+  sendButtonFallback: 'button[aria-label*="Send"]',
 
-  /** Container for individual chat response messages. */
+  /**
+   * [VERIFIED] Container for individual chat messages (request + response).
+   * Each turn has two: .interactive-request and .interactive-response.
+   */
   responseContainer: '.interactive-item-container',
 
-  /** The last response element in the chat panel. */
+  /** [VERIFIED] Last message container in the chat panel. */
   lastResponse: '.interactive-item-container:last-child',
 
-  /** Response body content within a response container. */
-  responseBody: '.interactive-response .rendered-markdown',
+  /** [VERIFIED] Response body — rendered markdown content inside a container. */
+  responseBody: '.rendered-markdown',
 
-  /** Loading/streaming indicator shown while the model is generating. */
+  /** [VERIFIED] Loading spinner icon — appears during streaming. */
   streamingIndicator: '.codicon-loading',
 
-  /** Progress indicator on the response (alternative detection). */
+  /** [VERIFIED] Stop/Cancel button — appears during streaming. */
+  stopButton: 'button[aria-label*="Stop"], button[aria-label*="Cancel"]',
+
+  /** [VERIFIED] Loading spinner scoped to last response — streaming in progress. */
   responseInProgress: '.interactive-item-container:last-child .codicon-loading',
 
-  /** The chat panel view container. */
-  chatPanel: '[id="workbench.panel.chat"]',
+  /** [VERIFIED] Chat panel view container. */
+  chatPanel: '.interactive-session',
 
-  /** The chat panel (fallback — view-based). */
+  /** [VERIFIED] Chat panel fallback — session container. */
   chatPanelFallback: '.interactive-session',
 
-  /** Agent picker / model picker dropdown trigger. */
-  agentPicker: '.chat-input-toolbars .codicon-chevron-down',
+  /** [VERIFIED] Toggle Chat sparkle button in title bar Command Center. */
+  toggleChatButton: '[aria-label="Toggle Chat"]',
 
-  /** Agent picker menu items. */
+  /**
+   * [VERIFIED] Agent picker button.
+   * Full label: "Set Agent (Ctrl+.) - Agent".
+   */
+  agentPicker: 'button[aria-label*="Set Agent"]',
+
+  /** Agent picker dropdown list items. */
   agentPickerItem: '.monaco-list-row',
 
-  /** Command palette input. */
+  /** [VERIFIED] Command palette input. */
   commandPaletteInput: '.quick-input-widget input[type="text"]',
 
-  /** The title bar — used to verify VS Code has loaded. */
-  titleBar: '.titlebar-text',
+  /** [VERIFIED] Title bar — confirms VS Code has loaded. */
+  titleBar: '.window-title',
+
+  /** Title bar fallback — part container. */
+  titleBarFallback: '#workbench\\.parts\\.titlebar',
+
+  /** Onboarding "Continue without Signing In" button. */
+  onboardingSkipSignIn: 'text="Continue without Signing In"',
+
+  /** Onboarding close button (X). */
+  onboardingClose: '.dialog-shadow .codicon-close, .onboarding-a-close',
+
+  /** Onboarding Continue/Next buttons. */
+  onboardingContinue: 'button:has-text("Continue"), button:has-text("Next")',
+
+  /** Onboarding dialog container. */
+  onboardingContainer: '.onboarding-a-dialog',
 } as const;

--- a/crew/bridge/tests/diagnostic.test.ts
+++ b/crew/bridge/tests/diagnostic.test.ts
@@ -2,8 +2,8 @@ import { test } from '@playwright/test';
 import { VSCodeApp } from '../src/page-objects/vscode-app';
 import { ChatPanel } from '../src/page-objects/chat-panel';
 import * as path from 'path';
-import * as child_process from 'child_process';
 import * as fs from 'fs';
+import { isVSCodeRunning } from './helpers';
 
 /**
  * Diagnostic test for discovering VS Code chat response DOM structure.
@@ -25,24 +25,6 @@ import * as fs from 'fs';
 
 const SKIP_REASON =
   'Set BRIDGE_DIAGNOSTIC=1 to run the DOM diagnostic test.';
-
-function isVSCodeRunning(): boolean {
-  try {
-    if (process.platform === 'win32') {
-      const out = child_process.execSync(
-        'tasklist /FI "IMAGENAME eq Code.exe" /NH',
-        { encoding: 'utf8' },
-      );
-      return out.includes('Code.exe');
-    }
-    const out = child_process.execSync('pgrep -x code || pgrep -x "Electron"', {
-      encoding: 'utf8',
-    });
-    return out.trim().length > 0;
-  } catch {
-    return false;
-  }
-}
 
 test.describe('DOM Diagnostic', () => {
   test('capture chat response DOM after sending a prompt', async () => {

--- a/crew/bridge/tests/diagnostic.test.ts
+++ b/crew/bridge/tests/diagnostic.test.ts
@@ -1,0 +1,161 @@
+import { test } from '@playwright/test';
+import { VSCodeApp } from '../src/page-objects/vscode-app';
+import { ChatPanel } from '../src/page-objects/chat-panel';
+import * as path from 'path';
+import * as child_process from 'child_process';
+import * as fs from 'fs';
+
+/**
+ * Diagnostic test for discovering VS Code chat response DOM structure.
+ *
+ * This test sends a simple prompt and captures:
+ *   - Screenshots (before & after)
+ *   - Full accessibility tree
+ *   - CSS selector probe results (which candidate selectors match)
+ *   - CSS class census (all classes in the chat panel area)
+ *   - Raw HTML of the chat panel
+ *
+ * Run:
+ *   1. Close all VS Code windows
+ *   2. cd crew/bridge
+ *      npm install && npm run build
+ *      BRIDGE_DIAGNOSTIC=1 npx playwright test tests/diagnostic.test.ts
+ *   3. Inspect test-results/diagnostic/after/selector-probe.json
+ */
+
+const SKIP_REASON =
+  'Set BRIDGE_DIAGNOSTIC=1 to run the DOM diagnostic test.';
+
+function isVSCodeRunning(): boolean {
+  try {
+    if (process.platform === 'win32') {
+      const out = child_process.execSync(
+        'tasklist /FI "IMAGENAME eq Code.exe" /NH',
+        { encoding: 'utf8' },
+      );
+      return out.includes('Code.exe');
+    }
+    const out = child_process.execSync('pgrep -x code || pgrep -x "Electron"', {
+      encoding: 'utf8',
+    });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+test.describe('DOM Diagnostic', () => {
+  test('capture chat response DOM after sending a prompt', async () => {
+    test.skip(
+      !['1', 'true'].includes(process.env.BRIDGE_DIAGNOSTIC ?? ''),
+      SKIP_REASON,
+    );
+    test.skip(
+      isVSCodeRunning(),
+      'Close all VS Code windows before running (single-instance lock).',
+    );
+    test.setTimeout(300_000); // 5 minutes
+
+    const vscode = new VSCodeApp();
+    const workspacePath = path.resolve(__dirname, '..', '..', '..');
+    const page = await vscode.launch({ workspacePath });
+
+    try {
+      const chat = new ChatPanel(page);
+      await chat.open();
+      await page.waitForTimeout(3_000);
+
+      const outputDir = path.resolve(
+        __dirname, '..', 'test-results', 'diagnostic',
+      );
+      fs.mkdirSync(outputDir, { recursive: true });
+
+      // Capture BEFORE state
+      console.log('Capturing pre-send diagnostics...');
+      await chat.captureDiagnostics(path.join(outputDir, 'before'));
+
+      // Select agent and send prompt
+      console.log('Selecting agent and sending prompt...');
+      await chat.selectAgent('developer');
+      await chat.sendPrompt('What is 2+2? Reply with just the number.');
+
+      // Wait for response — generous fixed wait since we're discovering selectors
+      console.log('Prompt sent, waiting 60s for response to complete...');
+      await page.waitForTimeout(60_000);
+
+      // Capture AFTER state
+      console.log('Capturing post-response diagnostics...');
+      await chat.captureDiagnostics(path.join(outputDir, 'after'));
+
+      console.log('\n=== DIAGNOSTIC COMPLETE ===');
+      console.log(`Output: ${outputDir}`);
+      console.log('Key files to inspect:');
+      console.log(
+        '  after/selector-probe.json  — which CSS selectors matched response elements',
+      );
+      console.log(
+        '  after/css-class-census.json — all CSS classes in the chat panel area',
+      );
+      console.log(
+        '  after/chat-panel.html       — raw HTML of the chat area',
+      );
+      console.log('  after/screenshot.png        — visual state');
+      console.log(
+        '  after/accessibility-tree.json — full ARIA tree',
+      );
+
+      // Compare before/after to highlight new CSS classes
+      try {
+        const beforeClasses = JSON.parse(
+          fs.readFileSync(
+            path.join(outputDir, 'before', 'css-class-census.json'),
+            'utf8',
+          ),
+        );
+        const afterClasses = JSON.parse(
+          fs.readFileSync(
+            path.join(outputDir, 'after', 'css-class-census.json'),
+            'utf8',
+          ),
+        );
+        const newClasses = Object.keys(afterClasses).filter(
+          cls => !(cls in beforeClasses),
+        );
+        if (newClasses.length > 0) {
+          console.log(
+            `\nNew CSS classes after response: ${newClasses.join(', ')}`,
+          );
+        }
+      } catch {
+        console.log('Could not compare before/after class census.');
+      }
+
+      // Log selector probe results
+      try {
+        const probeResults = JSON.parse(
+          fs.readFileSync(
+            path.join(outputDir, 'after', 'selector-probe.json'),
+            'utf8',
+          ),
+        );
+        console.log('\nSelector probe results (count > 0):');
+        for (const [sel, info] of Object.entries(probeResults)) {
+          const { count, samples } = info as {
+            count: number;
+            samples: string[];
+          };
+          if (count > 0) {
+            console.log(`  ${sel}: ${count} matches`);
+            for (const s of samples) {
+              console.log(`    → ${s}`);
+            }
+          }
+        }
+      } catch {
+        console.log('Could not read selector probe results.');
+      }
+    } finally {
+      await vscode.close();
+    }
+  });
+});

--- a/crew/bridge/tests/helpers.ts
+++ b/crew/bridge/tests/helpers.ts
@@ -1,0 +1,27 @@
+import * as child_process from 'child_process';
+
+/** Check if VS Code is already running (would block Electron launch). */
+export function isVSCodeRunning(): boolean {
+  try {
+    if (process.platform === 'win32') {
+      const out = child_process.execSync(
+        'tasklist /FI "IMAGENAME eq Code.exe" /NH',
+        { encoding: 'utf8' },
+      );
+      return out.includes('Code.exe');
+    }
+    if (process.platform === 'darwin') {
+      // macOS: the process name is "Electron" launched from Code.app
+      const out = child_process.execSync(
+        'pgrep -af "Visual Studio Code|Code Helper"',
+        { encoding: 'utf8' },
+      );
+      return out.trim().length > 0;
+    }
+    // Linux: process name is "code" (lowercase)
+    const out = child_process.execSync('pgrep -x code', { encoding: 'utf8' });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/crew/bridge/tests/smoke.test.ts
+++ b/crew/bridge/tests/smoke.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { createBridge, type VSCodeBridge } from '../src/index';
 import * as path from 'path';
-import * as child_process from 'child_process';
+import { isVSCodeRunning } from './helpers';
 
 /**
  * Smoke test for the VS Code agent bridge.
@@ -22,21 +22,6 @@ import * as child_process from 'child_process';
 
 const SKIP_REASON =
   'Requires VS Code + GitHub Copilot installed. Set BRIDGE_SMOKE=1 to run.';
-
-/** Check if VS Code is already running (would block Electron launch). */
-function isVSCodeRunning(): boolean {
-  try {
-    if (process.platform === 'win32') {
-      const out = child_process.execSync('tasklist /FI "IMAGENAME eq Code.exe" /NH', { encoding: 'utf8' });
-      return out.includes('Code.exe');
-    }
-    // macOS/Linux
-    const out = child_process.execSync('pgrep -x code || pgrep -x "Electron"', { encoding: 'utf8' });
-    return out.trim().length > 0;
-  } catch {
-    return false;
-  }
-}
 
 test.describe('VS Code Bridge Smoke Test', () => {
   let bridge: VSCodeBridge;

--- a/crew/bridge/tests/smoke.test.ts
+++ b/crew/bridge/tests/smoke.test.ts
@@ -1,52 +1,61 @@
 import { test, expect } from '@playwright/test';
 import { createBridge, type VSCodeBridge } from '../src/index';
 import * as path from 'path';
-import * as os from 'os';
-import * as fs from 'fs';
+import * as child_process from 'child_process';
 
 /**
  * Smoke test for the VS Code agent bridge.
  *
+ * Uses the system's default VS Code profile (which has Copilot authenticated).
+ * Requires NO other VS Code instance to be running — VS Code's single-instance
+ * lock prevents Playwright from attaching to a second instance with the same
+ * user-data-dir.
+ *
  * SKIPPED by default — requires VS Code and GitHub Copilot to be installed.
  *
  * To run manually:
- *   cd crew/bridge
- *   npm install
- *   npm run build
- *   BRIDGE_SMOKE=1 npx playwright test tests/smoke.test.ts
+ *   1. Close all VS Code windows
+ *   2. cd crew/bridge
+ *      npm install && npm run build
+ *      BRIDGE_SMOKE=1 npx playwright test tests/smoke.test.ts
  */
 
 const SKIP_REASON =
   'Requires VS Code + GitHub Copilot installed. Set BRIDGE_SMOKE=1 to run.';
 
+/** Check if VS Code is already running (would block Electron launch). */
+function isVSCodeRunning(): boolean {
+  try {
+    if (process.platform === 'win32') {
+      const out = child_process.execSync('tasklist /FI "IMAGENAME eq Code.exe" /NH', { encoding: 'utf8' });
+      return out.includes('Code.exe');
+    }
+    // macOS/Linux
+    const out = child_process.execSync('pgrep -x code || pgrep -x "Electron"', { encoding: 'utf8' });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
 test.describe('VS Code Bridge Smoke Test', () => {
   let bridge: VSCodeBridge;
-  let tmpDir: string;
-
-  test.beforeAll(async () => {
-    // Create a temp user data dir for clean state
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nse-bridge-test-'));
-  });
 
   test.afterAll(async () => {
     if (bridge) {
       await bridge.close();
     }
-    // Clean up temp dir
-    if (tmpDir && fs.existsSync(tmpDir)) {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
   });
 
   test('launch VS Code, send prompt, read response', async () => {
     test.skip(!['1', 'true'].includes(process.env.BRIDGE_SMOKE ?? ''), SKIP_REASON);
+    test.skip(isVSCodeRunning(), 'Close all VS Code windows before running the smoke test (single-instance lock).');
 
     // Use the repo root as the workspace
     const workspacePath = path.resolve(__dirname, '..', '..', '..');
 
     bridge = await createBridge({
       workspacePath,
-      userDataDir: tmpDir,
       defaultTimeout: 180_000, // 3 minutes for CI-like environments
     });
 


### PR DESCRIPTION
## Summary

Updates all Playwright bridge DOM selectors to match the verified VS Code 1.100 DOM structure. The original selectors from PR #335 were outdated — confirmed via diagnostic test that captured the actual DOM.

## Changes

### Selector updates (`selectors.ts`)
- `titleBar`: `.titlebar-text` → `.window-title` (verified)
- `chatInput`: ARIA-based fallback chain for the chat textbox (verified)
- `responseContainer`: confirmed `.interactive-item-container` (verified via diagnostic)
- `responseInProgress`: scoped `.codicon-loading` to last response container
- `agentPicker`: `.chat-input-toolbars .codicon-chevron-down` → `button[aria-label*="Set Agent"]` (verified)
- `chatPanel`: `.interactive-session` (verified)
- Removed broken `.chat-editor-overflow` from response selectors (it's the Monaco editor overflow, not chat)

### Chat panel rewrite (`chat-panel.ts`)
- Multi-strategy chat input finding with fallback chain
- Response detection uses verified `.interactive-item-container` count + `.codicon-loading` indicator
- Simplified `getLastResponse()` to walk `.interactive-item-container` elements

### Smoke test fixes (`smoke.test.ts`)
- Removed clean `userDataDir` — Copilot requires existing auth state
- Added `isVSCodeRunning()` skip gate (single-instance lock prevents parallel launches)
- Fixed EPERM cleanup error on Windows

### New diagnostic test (`diagnostic.test.ts`)
- Captures screenshots, accessibility tree, CSS class census, and selector probe results
- Essential for future selector debugging when VS Code updates

## Verification

Smoke test passes end-to-end:
```
VS Code launched: narrative-state-engine
Response received: 4
1 passed (42.8s)
```
