### PR TITLE
feat: add Python CrewAI tool for VS Code agent bridge

### DIFF
--- a/crew/bridge/package.json
+++ b/crew/bridge/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "build": "tsc",
+    "serve": "node dist/server.js",
+    "start:server": "tsc && node dist/server.js",
     "test": "npx playwright test",
     "test:smoke": "npx playwright test tests/smoke.test.ts"
   },

--- a/crew/bridge/src/chat-metrics.ts
+++ b/crew/bridge/src/chat-metrics.ts
@@ -1,0 +1,55 @@
+/**
+ * Chat metrics tracking for the VS Code automation bridge.
+ *
+ * Tracks turn count, character/token estimates per session.
+ */
+
+export interface ChatMetrics {
+  turnCount: number;
+  totalCharsSent: number;
+  totalCharsReceived: number;
+  /** Estimated tokens sent (chars / 4). */
+  estimatedTokensSent: number;
+  /** Estimated tokens received (chars / 4). */
+  estimatedTokensReceived: number;
+  /** ISO 8601 timestamp of when the session started. */
+  sessionStartedAt: string;
+}
+
+export class ChatMetricsTracker {
+  private turnCount = 0;
+  private totalCharsSent = 0;
+  private totalCharsReceived = 0;
+  private sessionStartedAt: string;
+
+  constructor() {
+    this.sessionStartedAt = new Date().toISOString();
+  }
+
+  recordSend(chars: number): void {
+    this.turnCount++;
+    this.totalCharsSent += chars;
+  }
+
+  recordReceive(chars: number): void {
+    this.totalCharsReceived += chars;
+  }
+
+  reset(): void {
+    this.turnCount = 0;
+    this.totalCharsSent = 0;
+    this.totalCharsReceived = 0;
+    this.sessionStartedAt = new Date().toISOString();
+  }
+
+  getMetrics(): ChatMetrics {
+    return {
+      turnCount: this.turnCount,
+      totalCharsSent: this.totalCharsSent,
+      totalCharsReceived: this.totalCharsReceived,
+      estimatedTokensSent: Math.ceil(this.totalCharsSent / 4),
+      estimatedTokensReceived: Math.ceil(this.totalCharsReceived / 4),
+      sessionStartedAt: this.sessionStartedAt,
+    };
+  }
+}

--- a/crew/bridge/src/index.ts
+++ b/crew/bridge/src/index.ts
@@ -1,9 +1,11 @@
 import { VSCodeApp, type VSCodeLaunchOptions } from './page-objects/vscode-app';
 import { ChatPanel } from './page-objects/chat-panel';
+import { ChatMetricsTracker, type ChatMetrics } from './chat-metrics';
 
 export { VSCodeApp, type VSCodeLaunchOptions } from './page-objects/vscode-app';
 export { ChatPanel } from './page-objects/chat-panel';
 export { SELECTORS } from './selectors';
+export { ChatMetricsTracker, type ChatMetrics } from './chat-metrics';
 
 export interface BridgeOptions extends VSCodeLaunchOptions {
   /** Default timeout for waiting on responses, in milliseconds. */
@@ -13,6 +15,8 @@ export interface BridgeOptions extends VSCodeLaunchOptions {
 export interface VSCodeBridge {
   /** Send a prompt to the specified agent and return the full response text. */
   sendPrompt(agent: string, prompt: string): Promise<string>;
+  /** Start a new chat session, resetting conversation context. */
+  newChat(): Promise<void>;
   /** Close VS Code and clean up. */
   close(): Promise<void>;
 }
@@ -32,6 +36,32 @@ export interface VSCodeBridge {
  * ```
  */
 export async function createBridge(options?: BridgeOptions): Promise<VSCodeBridge> {
+  const { bridge } = await buildBridge(options);
+  return bridge;
+}
+
+/**
+ * Create a VS Code automation bridge with access to chat metrics.
+ *
+ * Returns both the bridge and a metrics accessor function, used by
+ * the HTTP server to expose /chat/metrics.
+ */
+export function createBridgeWithMetrics(options?: BridgeOptions): {
+  bridge: Promise<VSCodeBridge>;
+  getMetrics: () => ChatMetrics;
+} {
+  const metrics = new ChatMetricsTracker();
+  return {
+    bridge: buildBridge(options, metrics).then(r => r.bridge),
+    getMetrics: () => metrics.getMetrics(),
+  };
+}
+
+async function buildBridge(
+  options?: BridgeOptions,
+  metrics?: ChatMetricsTracker,
+): Promise<{ bridge: VSCodeBridge }> {
+  const tracker = metrics ?? new ChatMetricsTracker();
   const vscode = new VSCodeApp();
   const page = await vscode.launch(options);
   const chat = new ChatPanel(page);
@@ -41,15 +71,24 @@ export async function createBridge(options?: BridgeOptions): Promise<VSCodeBridg
 
   const defaultTimeout = options?.defaultTimeout ?? 120_000;
 
-  return {
+  const bridge: VSCodeBridge = {
     async sendPrompt(agent: string, prompt: string): Promise<string> {
+      tracker.recordSend(prompt.length);
       await chat.selectAgent(agent);
       const response = await chat.sendAndRead(prompt, defaultTimeout);
+      tracker.recordReceive(response.length);
       return response;
+    },
+
+    async newChat(): Promise<void> {
+      await chat.newChat();
+      tracker.reset();
     },
 
     async close(): Promise<void> {
       await vscode.close();
     },
   };
+
+  return { bridge };
 }

--- a/crew/bridge/src/page-objects/chat-panel.ts
+++ b/crew/bridge/src/page-objects/chat-panel.ts
@@ -290,6 +290,44 @@ export class ChatPanel {
   }
 
   /**
+   * Start a new chat session.
+   *
+   * Sends the "New Chat" keyboard shortcut (Ctrl+N / Cmd+N), then waits
+   * for the chat to reset. Falls back to Command Palette if the shortcut
+   * doesn't work.
+   */
+  async newChat(): Promise<void> {
+    // Try Ctrl+N (the "New Chat (Ctrl+N)" shortcut in the Chat panel)
+    await this.page.keyboard.press(`${platformModifier()}+n`);
+
+    // Wait for the chat to reset — response containers should drop to 0
+    try {
+      await this.page.waitForFunction(
+        (sel: string) => document.querySelectorAll(sel).length === 0,
+        SELECTORS.responseContainer,
+        { timeout: 5_000 },
+      );
+      return;
+    } catch {
+      // Shortcut may not have worked — try Command Palette fallback
+    }
+
+    // Fallback: Command Palette → "Chat: New Chat"
+    await this.page.keyboard.press(`${platformModifier()}+Shift+p`);
+    await this.page.waitForSelector(SELECTORS.commandPaletteInput, { timeout: 5_000 });
+    const input = this.page.locator(SELECTORS.commandPaletteInput);
+    await input.fill('Chat: New Chat');
+    await this.page.keyboard.press('Enter');
+
+    // Wait for reset
+    await this.page.waitForFunction(
+      (sel: string) => document.querySelectorAll(sel).length === 0,
+      SELECTORS.responseContainer,
+      { timeout: 10_000 },
+    );
+  }
+
+  /**
    * Capture diagnostic information about the chat panel DOM.
    * Saves screenshots, accessibility tree, CSS selector probe results,
    * and raw HTML to the specified output directory.

--- a/crew/bridge/src/server.ts
+++ b/crew/bridge/src/server.ts
@@ -1,0 +1,269 @@
+/**
+ * HTTP server for the VS Code automation bridge.
+ *
+ * Exposes REST endpoints for CrewAI (Python) to control VS Code's
+ * Copilot chat via Playwright automation.
+ *
+ * Binds to 127.0.0.1 only — no network exposure.
+ * Uses Node's built-in http module — no external dependencies.
+ */
+
+import * as http from 'http';
+import { createBridge, type VSCodeBridge, type BridgeOptions } from './index';
+import type { ChatMetrics } from './chat-metrics';
+
+// --- Types ---
+
+interface StartBody {
+  workspacePath?: string;
+  defaultTimeout?: number;
+}
+
+interface SendBody {
+  agent: string;
+  prompt: string;
+  timeout?: number;
+}
+
+interface JsonResponse {
+  status?: string;
+  response?: string;
+  error?: string;
+  [key: string]: unknown;
+}
+
+// --- State ---
+
+let bridge: VSCodeBridge | null = null;
+let metricsAccessor: (() => ChatMetrics) | null = null;
+
+// --- Helpers ---
+
+function jsonResponse(res: http.ServerResponse, statusCode: number, body: JsonResponse | ChatMetrics): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    const MAX_BODY = 1024 * 1024; // 1 MB limit
+
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY) {
+        req.destroy();
+        reject(new Error('Request body too large'));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+function parseJson<T>(raw: string): T {
+  if (!raw.trim()) return {} as T;
+  return JSON.parse(raw) as T;
+}
+
+// --- Route handlers ---
+
+async function handleSessionStart(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  if (bridge) {
+    jsonResponse(res, 409, { error: 'Session already active. Close it first.' });
+    return;
+  }
+
+  const body = parseJson<StartBody>(await readBody(req));
+  const options: BridgeOptions = {};
+  if (body.workspacePath) options.workspacePath = body.workspacePath;
+  if (body.defaultTimeout) options.defaultTimeout = body.defaultTimeout;
+
+  // createBridge returns a VSCodeBridge; we also need the metrics accessor.
+  // Import createBridgeWithMetrics which we'll add to index.ts.
+  const { createBridgeWithMetrics } = await import('./index');
+  const result = createBridgeWithMetrics(options);
+  bridge = await result.bridge;
+  metricsAccessor = result.getMetrics;
+
+  jsonResponse(res, 200, { status: 'ok' });
+}
+
+async function handleChatSend(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  if (!bridge) {
+    jsonResponse(res, 503, { error: 'No active session. Call /session/start first.' });
+    return;
+  }
+
+  const body = parseJson<SendBody>(await readBody(req));
+  if (!body.agent || typeof body.agent !== 'string') {
+    jsonResponse(res, 400, { error: 'Missing or invalid "agent" field.' });
+    return;
+  }
+  if (!body.prompt || typeof body.prompt !== 'string') {
+    jsonResponse(res, 400, { error: 'Missing or invalid "prompt" field.' });
+    return;
+  }
+
+  const response = await bridge.sendPrompt(body.agent, body.prompt);
+  jsonResponse(res, 200, { response });
+}
+
+async function handleChatNew(_req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  if (!bridge) {
+    jsonResponse(res, 503, { error: 'No active session. Call /session/start first.' });
+    return;
+  }
+
+  await bridge.newChat();
+  jsonResponse(res, 200, { status: 'ok' });
+}
+
+function handleChatMetrics(_req: http.IncomingMessage, res: http.ServerResponse): void {
+  if (!bridge || !metricsAccessor) {
+    jsonResponse(res, 503, { error: 'No active session. Call /session/start first.' });
+    return;
+  }
+
+  jsonResponse(res, 200, metricsAccessor());
+}
+
+async function handleSessionClose(_req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  if (!bridge) {
+    jsonResponse(res, 200, { status: 'ok' }); // idempotent
+    return;
+  }
+
+  await bridge.close();
+  bridge = null;
+  metricsAccessor = null;
+  jsonResponse(res, 200, { status: 'ok' });
+}
+
+function handleHealth(_req: http.IncomingMessage, res: http.ServerResponse): void {
+  jsonResponse(res, 200, { status: 'ok' });
+}
+
+// --- Router ---
+
+type RouteHandler = (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void> | void;
+
+const routes: Record<string, Record<string, RouteHandler>> = {
+  'POST': {
+    '/session/start': handleSessionStart,
+    '/chat/send': handleChatSend,
+    '/chat/new': handleChatNew,
+    '/session/close': handleSessionClose,
+  },
+  'GET': {
+    '/chat/metrics': handleChatMetrics,
+    '/health': handleHealth,
+  },
+};
+
+async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  const method = req.method ?? 'GET';
+  const url = req.url ?? '/';
+
+  const handler = routes[method]?.[url];
+  if (!handler) {
+    jsonResponse(res, 404, { error: `Not found: ${method} ${url}` });
+    return;
+  }
+
+  try {
+    await handler(req, res);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Error handling ${method} ${url}:`, message);
+    jsonResponse(res, 500, { error: message });
+  }
+}
+
+// --- Server lifecycle ---
+
+function parsePort(args: string[]): number {
+  const portEnv = process.env.PORT;
+  if (portEnv) {
+    const parsed = parseInt(portEnv, 10);
+    if (!isNaN(parsed) && parsed > 0 && parsed < 65536) return parsed;
+  }
+
+  const portIdx = args.indexOf('--port');
+  if (portIdx !== -1 && args[portIdx + 1]) {
+    const parsed = parseInt(args[portIdx + 1], 10);
+    if (!isNaN(parsed) && parsed > 0 && parsed < 65536) return parsed;
+  }
+
+  return 7400;
+}
+
+export function startServer(port?: number): http.Server {
+  const resolvedPort = port ?? parsePort(process.argv);
+
+  const server = http.createServer((req, res) => {
+    handleRequest(req, res).catch((err) => {
+      console.error('Unhandled error:', err);
+      if (!res.headersSent) {
+        jsonResponse(res, 500, { error: 'Internal server error' });
+      }
+    });
+  });
+
+  server.listen(resolvedPort, '127.0.0.1', () => {
+    console.log(`NSE Bridge server listening on http://127.0.0.1:${resolvedPort}`);
+  });
+
+  return server;
+}
+
+// --- Graceful shutdown ---
+
+function setupShutdownHandlers(server: http.Server): void {
+  let shuttingDown = false;
+
+  const shutdown = async (signal: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`\n${signal} received — shutting down...`);
+
+    // Close active bridge session
+    if (bridge) {
+      try {
+        await bridge.close();
+      } catch (err) {
+        console.error('Error closing bridge during shutdown:', err);
+      }
+      bridge = null;
+      metricsAccessor = null;
+    }
+
+    server.close(() => {
+      console.log('Server closed.');
+      process.exit(0);
+    });
+
+    // Force exit after 10s if graceful close hangs
+    setTimeout(() => {
+      console.error('Forced exit after timeout.');
+      process.exit(1);
+    }, 10_000).unref();
+  };
+
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+}
+
+// --- Main entry point ---
+
+if (require.main === module) {
+  const server = startServer();
+  setupShutdownHandlers(server);
+}

--- a/crew/crews/vscode_crew.py
+++ b/crew/crews/vscode_crew.py
@@ -1,0 +1,52 @@
+"""VS Code agent crew — delegates tasks to VS Code Copilot via HTTP bridge."""
+
+from crewai import Agent, Crew, Process, Task
+
+from crew.tools.vscode_agent import VSCodeAgentTool
+
+
+def create_vscode_crew(
+    task_description: str,
+    agent_name: str = "developer",
+    bridge_url: str = "http://127.0.0.1:7400",
+) -> Crew:
+    """Create a crew that delegates work to a VS Code Copilot agent.
+
+    Args:
+        task_description: What the crew should accomplish.
+        agent_name: VS Code agent mode to use (default: "developer").
+        bridge_url: URL of the HTTP bridge server.
+
+    Returns:
+        A Crew ready to kick off.
+    """
+    tool = VSCodeAgentTool(bridge_url=bridge_url, agent=agent_name)
+
+    coder = Agent(
+        role="VS Code Developer",
+        goal=(
+            "Complete the assigned task by delegating work to the VS Code Copilot "
+            "agent, which has full workspace access including file editing, "
+            "terminal commands, and all VS Code tools."
+        ),
+        backstory=(
+            "You are a project manager who delegates coding tasks to a VS Code "
+            "Copilot agent. You break down the task, send clear instructions, "
+            "and verify the results."
+        ),
+        tools=[tool],
+        verbose=True,
+    )
+
+    task = Task(
+        description=task_description,
+        expected_output="Summary of completed work and any issues encountered.",
+        agent=coder,
+    )
+
+    return Crew(
+        agents=[coder],
+        tasks=[task],
+        process=Process.sequential,
+        verbose=True,
+    )

--- a/crew/main.py
+++ b/crew/main.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import subprocess
 
 
 def cmd_extract(args):
@@ -49,10 +50,11 @@ def cmd_vscode(args):
 
     bridge_url = f"http://127.0.0.1:{args.port}"
     proc = None
+    workspace = os.path.abspath(args.workspace)
 
     if not ensure_bridge_running(bridge_url):
         print(f"Starting bridge server on port {args.port}...")
-        proc = start_bridge_server(args.workspace, port=args.port)
+        proc = start_bridge_server(workspace, port=args.port)
         print("Bridge server ready.")
 
     try:
@@ -70,9 +72,13 @@ def cmd_vscode(args):
             try:
                 requests.post(f"{bridge_url}/session/close", timeout=10)
             except requests.RequestException:
-                pass
+                pass  # Best-effort session close; server is being terminated
             proc.terminate()
-            proc.wait(timeout=10)
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
 
 
 def main():

--- a/crew/main.py
+++ b/crew/main.py
@@ -1,6 +1,7 @@
 """CLI entry point for CrewAI orchestration."""
 
 import argparse
+import os
 
 
 def cmd_extract(args):
@@ -39,6 +40,41 @@ def cmd_release(args):
     print(result)
 
 
+def cmd_vscode(args):
+    from crew.crews.vscode_crew import create_vscode_crew
+    from crew.tools.vscode_agent import (
+        ensure_bridge_running,
+        start_bridge_server,
+    )
+
+    bridge_url = f"http://127.0.0.1:{args.port}"
+    proc = None
+
+    if not ensure_bridge_running(bridge_url):
+        print(f"Starting bridge server on port {args.port}...")
+        proc = start_bridge_server(args.workspace, port=args.port)
+        print("Bridge server ready.")
+
+    try:
+        crew = create_vscode_crew(
+            task_description=args.task,
+            agent_name=args.agent,
+            bridge_url=bridge_url,
+        )
+        result = crew.kickoff()
+        print(result)
+    finally:
+        if proc is not None:
+            import requests
+
+            try:
+                requests.post(f"{bridge_url}/session/close", timeout=10)
+            except requests.RequestException:
+                pass
+            proc.terminate()
+            proc.wait(timeout=10)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="CrewAI orchestration for narrative-state-engine"
@@ -66,6 +102,14 @@ def main():
     rel = subparsers.add_parser("release", help="Run release validation crew")
     rel.add_argument("--branch", required=True, help="Branch name to validate")
     rel.set_defaults(func=cmd_release)
+
+    # VS Code agent command
+    vsc = subparsers.add_parser("vscode", help="Delegate a task to VS Code Copilot agent")
+    vsc.add_argument("--task", required=True, help="Task description for the agent")
+    vsc.add_argument("--agent", default="developer", help="VS Code agent mode (default: developer)")
+    vsc.add_argument("--workspace", default=os.getcwd(), help="Workspace path (default: cwd)")
+    vsc.add_argument("--port", type=int, default=7400, help="Bridge server port (default: 7400)")
+    vsc.set_defaults(func=cmd_vscode)
 
     args = parser.parse_args()
     args.func(args)

--- a/crew/requirements.txt
+++ b/crew/requirements.txt
@@ -1,2 +1,3 @@
 crewai>=0.80.0
 crewai-tools>=0.14.0
+requests>=2.31.0

--- a/crew/tools/vscode_agent.py
+++ b/crew/tools/vscode_agent.py
@@ -1,0 +1,167 @@
+"""VS Code Copilot agent bridge tools for CrewAI."""
+
+import os
+import subprocess
+import time
+
+import requests
+from crewai.tools import BaseTool
+from pydantic import Field
+
+BRIDGE_DIR = os.path.join(os.path.dirname(__file__), "..", "bridge")
+
+
+def ensure_bridge_running(url: str = "http://127.0.0.1:7400") -> bool:
+    """Check if the bridge server is running by hitting /health."""
+    try:
+        resp = requests.get(f"{url}/health", timeout=5)
+        return resp.status_code == 200
+    except requests.ConnectionError:
+        return False
+
+
+def start_bridge_server(workspace_path: str, port: int = 7400) -> subprocess.Popen:
+    """Launch the HTTP bridge server and wait for it to be ready.
+
+    Args:
+        workspace_path: Absolute path to the workspace for VS Code.
+        port: Port for the bridge server (default 7400).
+
+    Returns:
+        The subprocess handle for the running server.
+
+    Raises:
+        RuntimeError: If the server doesn't become healthy within 30 seconds.
+    """
+    url = f"http://127.0.0.1:{port}"
+
+    if ensure_bridge_running(url):
+        raise RuntimeError(
+            f"Port {port} is already in use. Stop the existing server first."
+        )
+
+    proc = subprocess.Popen(
+        ["node", "dist/server.js", "--port", str(port)],
+        cwd=os.path.abspath(BRIDGE_DIR),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            stderr = proc.stderr.read().decode() if proc.stderr else ""
+            raise RuntimeError(
+                f"Bridge server exited with code {proc.returncode}: {stderr}"
+            )
+        if ensure_bridge_running(url):
+            # Start a session with the workspace path
+            try:
+                requests.post(
+                    f"{url}/session/start",
+                    json={"workspacePath": workspace_path},
+                    timeout=30,
+                )
+            except requests.RequestException as exc:
+                proc.terminate()
+                raise RuntimeError(
+                    f"Bridge started but session/start failed: {exc}"
+                ) from exc
+            return proc
+        time.sleep(1)
+
+    proc.terminate()
+    raise RuntimeError("Bridge server did not become healthy within 30 seconds")
+
+
+class VSCodeAgentTool(BaseTool):
+    """Send a prompt to a VS Code Copilot agent and get the response.
+
+    The agent has full access to the workspace, can read/write files,
+    run terminal commands, and use all VS Code tools.
+    """
+
+    name: str = "vscode_agent"
+    description: str = (
+        "Send a prompt to a VS Code Copilot agent and get the response. "
+        "The agent has full access to the workspace, can read/write files, "
+        "run terminal commands, and use all VS Code tools."
+    )
+    bridge_url: str = Field(default="http://127.0.0.1:7400")
+    agent: str = Field(default="developer")
+
+    def _run(self, prompt: str) -> str:
+        try:
+            resp = requests.post(
+                f"{self.bridge_url}/chat/send",
+                json={"agent": self.agent, "prompt": prompt},
+                timeout=300,
+            )
+            resp.raise_for_status()
+            return resp.json().get("response", "")
+        except requests.ConnectionError:
+            return "Error: Bridge server is not running. Start it with start_bridge_server()."
+        except requests.Timeout:
+            return "Error: Request timed out after 300 seconds."
+        except requests.HTTPError as exc:
+            return f"Error: HTTP {exc.response.status_code} — {exc.response.text}"
+        except requests.RequestException as exc:
+            return f"Error: {exc}"
+
+
+class VSCodeNewChatTool(BaseTool):
+    """Start a new chat session in VS Code, clearing previous context."""
+
+    name: str = "vscode_new_chat"
+    description: str = "Start a new chat session in VS Code, clearing previous context."
+    bridge_url: str = Field(default="http://127.0.0.1:7400")
+
+    def _run(self, **kwargs) -> str:
+        try:
+            resp = requests.post(f"{self.bridge_url}/chat/new", timeout=30)
+            resp.raise_for_status()
+            return "New chat session started."
+        except requests.RequestException as exc:
+            return f"Error: {exc}"
+
+
+class VSCodeMetricsTool(BaseTool):
+    """Get usage metrics for the current VS Code chat session."""
+
+    name: str = "vscode_metrics"
+    description: str = (
+        "Get usage metrics for the current VS Code chat session: "
+        "turn count, characters sent/received, estimated tokens."
+    )
+    bridge_url: str = Field(default="http://127.0.0.1:7400")
+
+    def _run(self, **kwargs) -> str:
+        try:
+            resp = requests.get(f"{self.bridge_url}/chat/metrics", timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+            return (
+                f"Turns: {data.get('turnCount', 0)}, "
+                f"Sent: {data.get('totalCharsSent', 0)} chars "
+                f"(~{data.get('estimatedTokensSent', 0)} tokens), "
+                f"Received: {data.get('totalCharsReceived', 0)} chars "
+                f"(~{data.get('estimatedTokensReceived', 0)} tokens)"
+            )
+        except requests.RequestException as exc:
+            return f"Error: {exc}"
+
+
+class VSCodeSessionCloseTool(BaseTool):
+    """Close the VS Code chat session and clean up resources."""
+
+    name: str = "vscode_session_close"
+    description: str = "Close the VS Code chat session and clean up resources."
+    bridge_url: str = Field(default="http://127.0.0.1:7400")
+
+    def _run(self, **kwargs) -> str:
+        try:
+            resp = requests.post(f"{self.bridge_url}/session/close", timeout=30)
+            resp.raise_for_status()
+            return "Session closed."
+        except requests.RequestException as exc:
+            return f"Error: {exc}"

--- a/crew/tools/vscode_agent.py
+++ b/crew/tools/vscode_agent.py
@@ -16,7 +16,7 @@ def ensure_bridge_running(url: str = "http://127.0.0.1:7400") -> bool:
     try:
         resp = requests.get(f"{url}/health", timeout=5)
         return resp.status_code == 200
-    except requests.ConnectionError:
+    except requests.RequestException:
         return False
 
 
@@ -40,26 +40,36 @@ def start_bridge_server(workspace_path: str, port: int = 7400) -> subprocess.Pop
             f"Port {port} is already in use. Stop the existing server first."
         )
 
+    bridge_abs = os.path.abspath(BRIDGE_DIR)
+    server_js = os.path.join(bridge_abs, "dist", "server.js")
+    if not os.path.isfile(server_js):
+        raise RuntimeError(
+            f"Bridge server not built: {server_js} not found. "
+            f"Run 'npm install && npm run build' in {bridge_abs}"
+        )
+
     proc = subprocess.Popen(
         ["node", "dist/server.js", "--port", str(port)],
-        cwd=os.path.abspath(BRIDGE_DIR),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        cwd=bridge_abs,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
 
     deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
         if proc.poll() is not None:
-            stderr = proc.stderr.read().decode() if proc.stderr else ""
             raise RuntimeError(
-                f"Bridge server exited with code {proc.returncode}: {stderr}"
+                f"Bridge server exited with code {proc.returncode}"
             )
         if ensure_bridge_running(url):
             # Start a session with the workspace path
             try:
                 requests.post(
                     f"{url}/session/start",
-                    json={"workspacePath": workspace_path},
+                    json={
+                        "workspacePath": workspace_path,
+                        "defaultTimeout": 300000,
+                    },
                     timeout=30,
                 )
             except requests.RequestException as exc:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -251,6 +251,31 @@ All data structures are defined in `schemas/`. See each schema file for field de
 | `tools/stop_extraction_detached.ps1` | Stop detached extraction runs by PID file |
 | `tools/run_with_heartbeat.py` / `.ps1` / `.sh` | Heartbeat wrapper — keeps terminal alive during long commands for idle-detection-based completion notification |
 
+### CrewAI HTTP Bridge
+
+The `crew/bridge/` directory contains a TypeScript HTTP server that bridges CrewAI agents to VS Code Copilot Chat. Python tools in `crew/tools/vscode_agent.py` communicate with the bridge via HTTP.
+
+**Bridge endpoints** (default `http://127.0.0.1:7400`):
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/health` | GET | Liveness check |
+| `/session/start` | POST | Initialize workspace session |
+| `/chat/send` | POST | Send a prompt to a VS Code Copilot agent and receive the response |
+| `/chat/new` | POST | Start a new chat session (clears context) |
+| `/chat/metrics` | GET | Return usage metrics (turns, tokens sent/received) |
+| `/session/close` | POST | Close session and clean up |
+
+**Python tools** (`crew/tools/vscode_agent.py`):
+- `VSCodeAgentTool` — CrewAI `BaseTool` that sends prompts to `/chat/send` (300s timeout for long-running agent responses)
+- `VSCodeNewChatTool`, `VSCodeMetricsTool`, `VSCodeSessionCloseTool` — auxiliary tools for session management
+- `start_bridge_server()` — launches the Node.js bridge, polls `/health` until ready (max 30s)
+- `ensure_bridge_running()` — checks bridge availability
+
+**Crew** (`crew/crews/vscode_crew.py`): `create_vscode_crew()` creates a single-agent crew that delegates a task description to VS Code Copilot via the bridge.
+
+**CLI** (`crew/main.py`): `python -m crew.main vscode --task "..." [--agent developer] [--workspace .] [--port 7400]` starts the bridge (if not running), kicks off the crew, and cleans up on completion.
+
 ---
 
 ## Design Decisions

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,6 +40,7 @@ Divide session processing across multiple specialized agents, each with a focuse
 | Timeline agent | Extract temporal signals and estimate in-game time progression | **Implemented** (#137) |
 | Story summary agent | Generate narrative arc summary from extracted entities, events, and plot threads | **Implemented** (#262) |
 | Planning layer | Synthesize catalog data into actionable derived planning files | **Implemented** (#259) |
+| VS Code agent bridge | Delegate tasks to VS Code Copilot agents via HTTP bridge | **Implemented** (#346) |
 
 The **Catalog agent** is implemented as `tools/semantic_extraction.py` — a five-agent LLM pipeline (Entity Discovery → Entity Detail → Relationship Mapper → Event Extractor → Temporal Signal Extractor) that runs during bootstrap and incremental ingestion. It uses prompt templates in `templates/extraction/` and a provider-agnostic LLM client (`tools/llm_client.py`) supporting OpenAI and Ollama.
 


### PR DESCRIPTION
## Summary

Add Python CrewAI tools and crew for delegating tasks to VS Code Copilot agents via the HTTP bridge server (#346).

## What changed

### `crew/tools/vscode_agent.py` (new)
- `VSCodeAgentTool` — CrewAI `BaseTool` that POSTs prompts to `/chat/send` with 300s timeout
- `VSCodeNewChatTool` — starts a new chat session via `/chat/new`
- `VSCodeMetricsTool` — fetches session metrics from `/chat/metrics`
- `VSCodeSessionCloseTool` — closes the session via `/session/close`
- `start_bridge_server()` — launches the Node.js bridge, polls `/health` with 30s deadline
- `ensure_bridge_running()` — checks bridge liveness

### `crew/crews/vscode_crew.py` (new)
- `create_vscode_crew()` — creates a single-agent crew that delegates a task description to VS Code Copilot via the bridge

### `crew/main.py` (modified)
- Added `vscode` subcommand: `python -m crew.main vscode --task "..." [--agent developer] [--workspace .] [--port 7400]`
- Auto-starts bridge if not running, cleans up on completion

### `crew/requirements.txt` (modified)
- Added `requests>=2.31.0`

### Documentation (Rule 8)
- `docs/architecture.md` — added CrewAI HTTP Bridge section documenting endpoints, Python tools, crew, and CLI
- `docs/roadmap.md` — added VS Code agent bridge row to Phase 2 agent table

Closes #346
