### PR TITLE
fix: add sys.path setup for crew package imports

### DIFF
--- a/crew/main.py
+++ b/crew/main.py
@@ -2,7 +2,11 @@
 
 import argparse
 import os
+import sys
 import subprocess
+
+# Ensure the repo root is on sys.path so `crew` is importable as a package
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 def cmd_extract(args):


### PR DESCRIPTION
## Summary

Running `python main.py` from the `crew/` directory fails with `ModuleNotFoundError: No module named 'crew'` because the repo root isn't on `sys.path`.

## Fix

- Added `sys.path.insert(0, ...)` at the top of `crew/main.py` to put the repo root on the import path.
- Created `crew/__init__.py` so Python recognizes `crew` as a package.

## Verification

```
cd crew
python main.py --help       # shows all subcommands
python main.py vscode --help # no import errors
```

Full test suite passes (exit code 0).
