### PR TITLE
fix: use crewai.LLM object instead of string for local llama-server

### DIFF
--- a/crew/crews/vscode_crew.py
+++ b/crew/crews/vscode_crew.py
@@ -19,7 +19,7 @@ def create_vscode_crew(
         task_description: What the crew should accomplish.
         agent_name: VS Code agent mode to use (default: "developer").
         bridge_url: URL of the HTTP bridge server.
-        llm: LLM identifier for agent reasoning.
+        llm: A ``crewai.LLM`` instance or model-name string for agent reasoning.
 
     Returns:
         A Crew ready to kick off.

--- a/crew/crews/vscode_crew.py
+++ b/crew/crews/vscode_crew.py
@@ -1,5 +1,7 @@
 """VS Code agent crew — delegates tasks to VS Code Copilot via HTTP bridge."""
 
+from typing import Any
+
 from crewai import Agent, Crew, Process, Task
 
 from crew.tools.vscode_agent import VSCodeAgentTool
@@ -9,7 +11,7 @@ def create_vscode_crew(
     task_description: str,
     agent_name: str = "developer",
     bridge_url: str = "http://127.0.0.1:7400",
-    llm: str = "openai/qwen3.5-9b-q4_k_m",
+    llm: Any = None,
 ) -> Crew:
     """Create a crew that delegates work to a VS Code Copilot agent.
 

--- a/crew/main.py
+++ b/crew/main.py
@@ -46,16 +46,21 @@ def cmd_release(args):
 
 
 def cmd_vscode(args):
+    from crewai import LLM
+
     from crew.crews.vscode_crew import create_vscode_crew
     from crew.tools.vscode_agent import (
         ensure_bridge_running,
         start_bridge_server,
     )
 
-    # Configure OpenAI-compatible endpoint for litellm (used by openai/ prefix)
-    os.environ.setdefault("OPENAI_API_KEY", "not-needed")
-    os.environ["OPENAI_API_BASE"] = args.llm_base_url
+    # Build LLM object directly — avoids litellm provider matching
     # For arclight, use: --llm-base-url http://arclight:8000/v1
+    llm = LLM(
+        model=args.llm,
+        base_url=args.llm_base_url,
+        api_key="not-needed",
+    )
 
     bridge_url = f"http://127.0.0.1:{args.port}"
     proc = None
@@ -71,7 +76,7 @@ def cmd_vscode(args):
             task_description=args.task,
             agent_name=args.agent,
             bridge_url=bridge_url,
-            llm=args.llm,
+            llm=llm,
         )
         result = crew.kickoff()
         print(result)
@@ -121,8 +126,8 @@ def main():
 
     # VS Code agent command
     vsc = subparsers.add_parser("vscode", help="Delegate a task to VS Code Copilot agent")
-    vsc.add_argument("--llm", default="openai/qwen3.5-9b-q4_k_m",
-        help="LLM identifier (default: openai/qwen3.5-9b-q4_k_m)")
+    vsc.add_argument("--llm", default="qwen3.5-9b-q4_k_m",
+        help="LLM model name (default: qwen3.5-9b-q4_k_m)")
     vsc.add_argument("--llm-base-url", default="http://localhost:8081/v1",
         help="Base URL for OpenAI-compatible LLM server (default: http://localhost:8081/v1)")
     vsc.add_argument("--task", required=True, help="Task description for the agent")


### PR DESCRIPTION
## Summary

CrewAI v1.14.4 doesn't include litellm, and passing `"openai/qwen3.5-9b-q4_k_m"` as a string to `Agent(llm=...)` fails because CrewAI can't match the model name to a recognized native provider.

**Fix**: Construct a `crewai.LLM()` object directly in `cmd_vscode()` with explicit `model`, `base_url`, and `api_key` parameters. This bypasses the string-based provider matching entirely. The `LLM` object is passed through to `create_vscode_crew()` and used by the Agent.

### Changes

- **`crew/main.py`**: Replace `os.environ` setup + string-based LLM with `crewai.LLM()` object construction. Update `--llm` default from `"openai/qwen3.5-9b-q4_k_m"` to `"qwen3.5-9b-q4_k_m"` (no provider prefix needed).
- **`crew/crews/vscode_crew.py`**: Change `llm` parameter type from `str` to `Any` (accepts both string and `LLM` object). Default to `None`.

### Smoke tests

- `python -c "from crew.crews.vscode_crew import create_vscode_crew; print('import OK')"` — OK
- `python crew/main.py vscode --help` — shows correct defaults
- `python -m pytest tests/ -x -q` — all tests pass

Fixes the LLM initialization error from PR #353
