### PR TITLE
fix: add LLM server health check before crew kickoff

### DIFF
--- a/crew/main.py
+++ b/crew/main.py
@@ -46,6 +46,9 @@ def cmd_release(args):
 
 
 def cmd_vscode(args):
+    import urllib.error
+    import urllib.request
+
     from crewai import LLM
 
     from crew.crews.vscode_crew import create_vscode_crew
@@ -61,6 +64,28 @@ def cmd_vscode(args):
         base_url=args.llm_base_url,
         api_key="not-needed",
     )
+
+    # Verify LLM server is reachable before starting crew
+    health_url = args.llm_base_url.rstrip("/").rsplit("/v1", 1)[0] + "/health"
+    try:
+        req = urllib.request.Request(health_url, method="GET")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            pass  # 200 OK is enough
+    except (urllib.error.URLError, OSError) as e:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(args.llm_base_url)
+        port = parsed.port or 8081
+        print(f"\nError: LLM server not reachable at {args.llm_base_url}")
+        print(f"Health check failed: {e}\n")
+        print("Start llama-server in a persistent terminal:")
+        print()
+        print(f"  llama-server -m <MODEL_PATH> -ngl 99 -np 1 -c 32768 \\")
+        print(f"    --port {port} --reasoning-format none --reasoning off -t 1")
+        print()
+        print(f"Default model: {args.llm}")
+        print("Then retry this command.")
+        sys.exit(1)
 
     bridge_url = f"http://127.0.0.1:{args.port}"
     proc = None


### PR DESCRIPTION
## Summary

When the LLM server (llama-server) is not running, `crew/main.py vscode` fails deep inside CrewAI with an opaque stacktrace that gives no indication of what went wrong or how to fix it. This is especially common when VS Code exits and kills a terminal-launched llama-server.

This PR adds a pre-flight health check in `cmd_vscode()` that hits the `/health` endpoint before creating the CrewAI crew. If the server is unreachable, it prints:

- A clear error message identifying the problem
- The exact `llama-server` launch command with the correct port extracted from `--llm-base-url`
- The model name from `--llm` for reference

Then exits cleanly with code 1.

### Implementation details

- Uses only stdlib (`urllib.request`) — no extra dependencies in the pre-flight path
- Health URL is derived by stripping `/v1` from the base URL and appending `/health`
- Port is extracted from the base URL via `urllib.parse.urlparse`
- The check runs after constructing the `LLM` object but before `create_vscode_crew()`

### Testing

- All existing tests pass (`python -m pytest tests/ -x -q`)
- Verified clean error output with unreachable server:
  ```
  python crew/main.py vscode --task "test" --agent developer --workspace . --llm-base-url http://localhost:9999/v1
  ```
  Prints helpful message and exits 1 (no stacktrace)
- `python crew/main.py vscode --help` still works
