### PR TITLE
fix: normalize attribute key casing during entity merges (#336)

### DIFF
--- a/tests/test_case_normalization.py
+++ b/tests/test_case_normalization.py
@@ -1,0 +1,93 @@
+"""Tests for case-insensitive attribute key normalization (#336)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from catalog_merger import merge_entity
+
+
+def _make_entity(id_, name, etype="item", turn="turn-001", **kwargs):
+    entity = {
+        "id": id_,
+        "name": name,
+        "type": etype,
+        "identity": f"{name} identity.",
+        "first_seen_turn": turn,
+        "last_updated_turn": turn,
+    }
+    entity.update(kwargs)
+    return entity
+
+
+def test_stable_attributes_case_normalized():
+    """LLM returning 'Availability' should merge with existing 'availability'."""
+    catalogs = {
+        "items.json": [
+            _make_entity("item-metal", "Metal", stable_attributes={
+                "availability": {"value": "rare", "source_turn": "turn-010"},
+            }),
+        ],
+        "characters.json": [],
+        "locations.json": [],
+        "factions.json": [],
+    }
+    update = _make_entity("item-metal", "Metal", turn="turn-020", stable_attributes={
+        "Availability": {"value": "common", "source_turn": "turn-020"},
+    })
+    merge_entity(catalogs, update)
+    entity = catalogs["items.json"][0]
+    sa = entity["stable_attributes"]
+    availability_keys = [k for k in sa if k.lower() == "availability"]
+    assert len(availability_keys) == 1
+    assert "availability" in sa
+    assert sa["availability"]["value"] == "common"
+
+
+def test_volatile_state_case_normalized():
+    """Volatile state keys should also be normalized to lowercase."""
+    catalogs = {
+        "items.json": [
+            _make_entity("item-bowl", "Bowl", volatile_state={
+                "condition": "good",
+            }),
+        ],
+        "characters.json": [],
+        "locations.json": [],
+        "factions.json": [],
+    }
+    update = _make_entity("item-bowl", "Bowl", turn="turn-020", volatile_state={
+        "Condition": "cracked",
+    })
+    merge_entity(catalogs, update)
+    entity = catalogs["items.json"][0]
+    vs = entity["volatile_state"]
+    condition_keys = [k for k in vs if k.lower() == "condition"]
+    assert len(condition_keys) == 1
+    assert "condition" in vs
+    assert vs["condition"] == "cracked"
+
+
+def test_multiple_case_variants_collapsed():
+    """Multiple casing variants of the same key should collapse to one."""
+    catalogs = {
+        "items.json": [
+            _make_entity("item-ore", "Ore", stable_attributes={
+                "Availability": {"value": "old1"},
+                "availability": {"value": "old2"},
+                "AVAILABILITY": {"value": "old3"},
+            }),
+        ],
+        "characters.json": [],
+        "locations.json": [],
+        "factions.json": [],
+    }
+    update = _make_entity("item-ore", "Ore", turn="turn-020", stable_attributes={
+        "availability": {"value": "new"},
+    })
+    merge_entity(catalogs, update)
+    entity = catalogs["items.json"][0]
+    sa = entity["stable_attributes"]
+    availability_keys = [k for k in sa if k.lower() == "availability"]
+    assert len(availability_keys) == 1
+    assert sa["availability"]["value"] == "new"

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -1129,7 +1129,12 @@ def _update_existing_entity(current: dict, update: dict, *, known_entity_names: 
         if "stable_attributes" not in current:
             current["stable_attributes"] = {}
         for key, value in update["stable_attributes"].items():
-            current["stable_attributes"][key] = value
+            normalized = key.lower()
+            # Remove case-variant duplicates (#336)
+            for existing_key in list(current["stable_attributes"].keys()):
+                if existing_key.lower() == normalized and existing_key != normalized:
+                    del current["stable_attributes"][existing_key]
+            current["stable_attributes"][normalized] = value
         # Cross-reference guard: reject aliases matching other entity names (#302)
         if known_entity_names:
             sa_merged = current["stable_attributes"]
@@ -1145,7 +1150,12 @@ def _update_existing_entity(current: dict, update: dict, *, known_entity_names: 
         if "volatile_state" not in current:
             current["volatile_state"] = {}
         for key, value in update["volatile_state"].items():
-            current["volatile_state"][key] = value
+            normalized = key.lower()
+            # Remove case-variant duplicates (#336)
+            for existing_key in list(current["volatile_state"].keys()):
+                if existing_key.lower() == normalized and existing_key != normalized:
+                    del current["volatile_state"][existing_key]
+            current["volatile_state"][normalized] = value
 
     # Handle name changes / aliases via stable_attributes.aliases
     # For char-player, never overwrite the canonical name — but still record

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -763,6 +763,15 @@ def _coerce_entity_fields(entity_data) -> dict | None:
             else:
                 print(f"  COERCE: relationship type '{rt}' → '{mapped}'", file=sys.stderr)
 
+    # Normalize attribute key casing (#336)
+    for attr_dict_key in ("stable_attributes", "volatile_state"):
+        attr_dict = entity_data.get(attr_dict_key)
+        if isinstance(attr_dict, dict):
+            normalized = {}
+            for k, v in attr_dict.items():
+                normalized[k.lower()] = v
+            entity_data[attr_dict_key] = normalized
+
     return entity_data
 
 


### PR DESCRIPTION
## Summary

Normalizes attribute key casing to lowercase during entity merges and LLM output coercion, preventing duplicate keys caused by inconsistent casing from the LLM (e.g., `Availability` vs `availability`).

## Changes

### `tools/catalog_merger.py`
- `_update_existing_entity()`: stable_attributes merge now lowercases incoming keys and removes any case-variant duplicates from the existing dict before writing.
- `_update_existing_entity()`: volatile_state merge applies the same normalization.

### `tools/semantic_extraction.py`
- `_coerce_entity_fields()`: Added a final normalization pass that lowercases all keys in `stable_attributes` and `volatile_state` dicts before returning, catching variants at extraction time.

### `tests/test_case_normalization.py`
- `test_stable_attributes_case_normalized`: Verifies `Availability` merges with existing `availability`.
- `test_volatile_state_case_normalized`: Verifies `Condition` merges with existing `condition`.
- `test_multiple_case_variants_collapsed`: Verifies multiple casing variants collapse to one lowercase key.

## Test Results

1575 passed, 1 skipped, 0 failures.

Closes #336
