### PR TITLE
fix: reject body parts and abstract concepts as entities (#338)

### DIFF
--- a/tests/test_body_part_filter.py
+++ b/tests/test_body_part_filter.py
@@ -19,6 +19,14 @@ class TestBodyPartCharacterRejection:
         entity = {"name": "Two", "type": "character"}
         assert _is_misclassified_character(entity)
 
+    def test_four_rejected_as_character(self):
+        entity = {"name": "Four", "type": "character"}
+        assert _is_misclassified_character(entity)
+
+    def test_ten_rejected_as_character(self):
+        entity = {"name": "ten", "type": "character"}
+        assert _is_misclassified_character(entity)
+
     def test_men_rejected_as_character(self):
         entity = {"name": "men", "type": "character"}
         assert _is_misclassified_character(entity)

--- a/tests/test_body_part_filter.py
+++ b/tests/test_body_part_filter.py
@@ -1,0 +1,71 @@
+"""Tests for body part and abstract concept entity rejection (#338)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from semantic_extraction import (
+    _is_misclassified_character,
+    _is_misclassified_location,
+)
+
+
+class TestBodyPartCharacterRejection:
+    def test_shoulders_rejected_as_character(self):
+        entity = {"name": "his shoulders", "type": "character"}
+        assert _is_misclassified_character(entity)
+
+    def test_two_rejected_as_character(self):
+        entity = {"name": "Two", "type": "character"}
+        assert _is_misclassified_character(entity)
+
+    def test_men_rejected_as_character(self):
+        entity = {"name": "men", "type": "character"}
+        assert _is_misclassified_character(entity)
+
+    def test_valid_character_not_rejected(self):
+        entity = {"name": "Kael", "type": "character"}
+        assert not _is_misclassified_character(entity)
+
+    def test_elder_not_rejected(self):
+        """'Elder' is in the role allowlist and should not be rejected."""
+        entity = {"name": "Elder", "type": "character"}
+        assert not _is_misclassified_character(entity)
+
+
+class TestBodyPartLocationRejection:
+    def test_body_rejected_as_location(self):
+        entity = {"name": "the body", "type": "location"}
+        assert _is_misclassified_location(entity)
+
+    def test_lips_rejected_as_location(self):
+        entity = {"name": "his lips", "type": "location"}
+        assert _is_misclassified_location(entity)
+
+    def test_shoulders_rejected_as_location(self):
+        entity = {"name": "shoulders", "type": "location"}
+        assert _is_misclassified_location(entity)
+
+    def test_ground_rejected_as_location(self):
+        entity = {"name": "the ground", "type": "location"}
+        assert _is_misclassified_location(entity)
+
+    def test_edge_rejected_as_location(self):
+        entity = {"name": "the edge", "type": "location"}
+        assert _is_misclassified_location(entity)
+
+    def test_reaction_rejected_as_location(self):
+        entity = {"name": "the river's reaction", "type": "location"}
+        assert _is_misclassified_location(entity)
+
+    def test_valid_location_not_rejected(self):
+        entity = {"name": "the longhouse", "type": "location"}
+        assert not _is_misclassified_location(entity)
+
+    def test_forest_not_rejected(self):
+        entity = {"name": "the forest", "type": "location"}
+        assert not _is_misclassified_location(entity)
+
+    def test_non_location_type_ignored(self):
+        entity = {"name": "the body", "type": "character"}
+        assert not _is_misclassified_location(entity)

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -1549,26 +1549,30 @@ _GENERIC_STEMS = {
     "she", "he", "they", "it", "her", "him", "them",
     "his", "hers", "its", "their", "theirs",
     # Generic group nouns and number words (#338)
-    "two", "three", "men", "women", "people", "others", "figures",
+    "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+    "men", "women", "people", "others", "figures",
 }
 
 # --- Type classification filters (#303) ---
 # Leading articles stripped before matching against blocklists.
 _LEADING_ARTICLE_RE = re.compile(r"^(?:the|a|an)\s+", re.IGNORECASE)
 
+# Shared body-part words used by both character and location filters (#338)
+_BODY_PART_WORDS = {
+    "shoulders", "lips", "body", "hands", "eyes", "skin",
+    "chest", "head", "face", "arms", "legs", "feet",
+    "throat", "neck", "back", "fingers", "toes",
+}
+
 # Extra non-character words beyond _PC_ALIAS_WORD_BLOCKLIST.
 _NON_CHARACTER_EXTRAS = {
     "birth", "belly", "feast", "meal", "sickness", "disease",
     "structure", "fragment", "celebration",
-    # Body parts (#338)
-    "shoulders", "lips", "body", "hands", "eyes", "skin",
-    "chest", "head", "face", "arms", "legs", "feet",
-    "throat", "neck", "back", "fingers", "toes",
     # Generic group nouns (#338)
     "figures", "men", "women", "people", "others",
     # Numbers-as-names (#338)
     "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
-}
+} | _BODY_PART_WORDS
 # Words in _PC_ALIAS_WORD_BLOCKLIST that ARE valid character names/roles and
 # must not trigger the type classification filter.
 _CHARACTER_ROLE_ALLOWLIST = {
@@ -1594,14 +1598,11 @@ def _get_non_character_names() -> set[str]:
 # Names that are clearly non-spatial and should never be type "location"
 _NON_LOCATION_NAMES = {
     "feast", "celebration", "fragment", "birth", "death",
-    # Body parts (#338)
-    "body", "lips", "shoulders", "hands", "eyes", "skin",
-    "chest", "head", "face", "arms", "legs", "feet",
-    "belly", "throat", "neck", "back", "fingers", "toes",
+    "belly",
     # Abstract concepts / generic surfaces (#338)
     "edge", "ground", "surface", "air", "sky",
     "reaction", "pattern", "method", "result",
-}
+} | _BODY_PART_WORDS
 
 
 def _strip_leading_article(name: str) -> str:

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -1548,6 +1548,8 @@ _GENERIC_STEMS = {
     # Pronouns — should never become entity IDs
     "she", "he", "they", "it", "her", "him", "them",
     "his", "hers", "its", "their", "theirs",
+    # Generic group nouns and number words (#338)
+    "two", "three", "men", "women", "people", "others", "figures",
 }
 
 # --- Type classification filters (#303) ---
@@ -1558,6 +1560,14 @@ _LEADING_ARTICLE_RE = re.compile(r"^(?:the|a|an)\s+", re.IGNORECASE)
 _NON_CHARACTER_EXTRAS = {
     "birth", "belly", "feast", "meal", "sickness", "disease",
     "structure", "fragment", "celebration",
+    # Body parts (#338)
+    "shoulders", "lips", "body", "hands", "eyes", "skin",
+    "chest", "head", "face", "arms", "legs", "feet",
+    "throat", "neck", "back", "fingers", "toes",
+    # Generic group nouns (#338)
+    "figures", "men", "women", "people", "others",
+    # Numbers-as-names (#338)
+    "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
 }
 # Words in _PC_ALIAS_WORD_BLOCKLIST that ARE valid character names/roles and
 # must not trigger the type classification filter.
@@ -1582,7 +1592,16 @@ def _get_non_character_names() -> set[str]:
 
 
 # Names that are clearly non-spatial and should never be type "location"
-_NON_LOCATION_NAMES = {"feast", "celebration", "fragment", "birth", "death"}
+_NON_LOCATION_NAMES = {
+    "feast", "celebration", "fragment", "birth", "death",
+    # Body parts (#338)
+    "body", "lips", "shoulders", "hands", "eyes", "skin",
+    "chest", "head", "face", "arms", "legs", "feet",
+    "belly", "throat", "neck", "back", "fingers", "toes",
+    # Abstract concepts / generic surfaces (#338)
+    "edge", "ground", "surface", "air", "sky",
+    "reaction", "pattern", "method", "result",
+}
 
 
 def _strip_leading_article(name: str) -> str:
@@ -1622,6 +1641,16 @@ def _is_misclassified_location(entity: dict) -> bool:
     stripped = _strip_leading_article(name).strip()
     if name in _NON_LOCATION_NAMES or stripped in _NON_LOCATION_NAMES:
         return True
+    # Reject if head noun (last token) is a blocklisted word (#338)
+    head = stripped.split()[-1] if stripped else ""
+    if head and head in _NON_LOCATION_NAMES:
+        return True
+    # Reject possessive body references: "his lips", "her shoulders" (#338)
+    tokens = stripped.split()
+    if tokens and tokens[0] in ("his", "her", "their", "its", "my"):
+        remainder = " ".join(tokens[1:])
+        if remainder in _NON_LOCATION_NAMES:
+            return True
     return False
 
 


### PR DESCRIPTION
## Summary

Reject body parts, abstract concepts, generic group nouns, and number-words from entity discovery during semantic extraction. These were being misclassified as characters or locations by the LLM.

## Changes

### Expanded `_NON_LOCATION_NAMES` blocklist
Added body parts (`body`, `lips`, `shoulders`, `hands`, `eyes`, `skin`, `chest`, `head`, `face`, `arms`, `legs`, `feet`, `belly`, `throat`, `neck`, `back`, `fingers`, `toes`) and abstract/generic surface concepts (`edge`, `ground`, `surface`, `air`, `sky`, `reaction`, `pattern`, `method`, `result`).

### Expanded `_NON_CHARACTER_EXTRAS` blocklist
Added body parts (same set as above), generic group nouns (`figures`, `men`, `women`, `people`, `others`), and number-as-name words (`two` through `ten`).

### Enhanced `_is_misclassified_location()`
- **Head noun check**: Rejects multi-word location names where the last token is blocklisted (e.g. "the river's reaction" → head noun "reaction" is blocked).
- **Possessive body references**: Rejects patterns like "his lips", "her shoulders", "their chest" where a possessive pronoun precedes a blocklisted body part.

### Added generic group stems to `_GENERIC_STEMS`
Added `two`, `three`, `men`, `women`, `people`, `others`, `figures` to prevent these from becoming entity IDs.

### Entities this would have caught in run16

| Entity | Discovered as | Now rejected by |
|---|---|---|
| `his shoulders` | character | `_NON_CHARACTER_EXTRAS` |
| `the body` | location | `_NON_LOCATION_NAMES` |
| `his lips` | location | possessive body reference check |
| `the edge` | location | `_NON_LOCATION_NAMES` |
| `the ground` | location | `_NON_LOCATION_NAMES` |
| `Two` | character | `_NON_CHARACTER_EXTRAS` (numbers) |
| `men` | character | `_NON_CHARACTER_EXTRAS` (group nouns) |

### Tests
Added `tests/test_body_part_filter.py` with 14 tests covering:
- Body parts rejected as characters
- Number-words rejected as characters
- Group nouns rejected as characters
- Valid characters not rejected (including allowlisted roles like "Elder")
- Body parts/abstract concepts rejected as locations
- Multi-word names with blocklisted head nouns rejected
- Possessive body references rejected as locations
- Valid locations not rejected
- Non-location entity types not affected

Closes #338
