### PR TITLE
fix: guard entity identity corruption and reject abstract items (#339)

### DIFF
--- a/tests/test_catalog_merger_v2.py
+++ b/tests/test_catalog_merger_v2.py
@@ -613,11 +613,25 @@ class TestPCNameProtection:
                 _make_v2_entity("char-elder", "The Elder", turn="turn-015")
             ]
         }
-        update = _make_v2_entity("char-elder", "Tribal Authority", turn="turn-100")
+        # Name with word overlap is accepted (#339 guard allows it)
+        update = _make_v2_entity("char-elder", "Elder Lyra", turn="turn-100")
         merge_entity(catalogs, update)
         npc = catalogs["characters.json"][0]
         # Non-PC entities should still have their name updated
-        assert npc["name"] == "Tribal Authority"
+        assert npc["name"] == "Elder Lyra"
+
+    def test_non_pc_name_rejected_no_overlap(self):
+        """Name change with zero word overlap is rejected (#339)."""
+        catalogs = {
+            "characters.json": [
+                _make_v2_entity("char-elder", "The Elder", turn="turn-015")
+            ]
+        }
+        update = _make_v2_entity("char-elder", "Tribal Authority", turn="turn-100")
+        merge_entity(catalogs, update)
+        npc = catalogs["characters.json"][0]
+        # Guard should reject — no word overlap
+        assert npc["name"] == "The Elder"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_identity_guard.py
+++ b/tests/test_identity_guard.py
@@ -1,0 +1,105 @@
+"""Tests for entity identity corruption guards (#339)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from catalog_merger import merge_entity
+from semantic_extraction import _is_misclassified_item, _coerce_entity_fields
+
+
+def _make_entity(id_, name, etype="item", turn="turn-001", **kwargs):
+    entity = {
+        "id": id_,
+        "name": name,
+        "type": etype,
+        "identity": f"{name} identity.",
+        "first_seen_turn": turn,
+        "last_updated_turn": turn,
+    }
+    entity.update(kwargs)
+    return entity
+
+
+class TestNameStabilityGuard:
+    def test_rejects_spear_to_bowl_rename(self):
+        catalogs = {
+            "items.json": [_make_entity("item-spear", "Crude wood-hafted spear")],
+            "characters.json": [], "locations.json": [], "factions.json": [],
+        }
+        update = _make_entity("item-spear", "sturdy bowl", turn="turn-020")
+        merge_entity(catalogs, update)
+        assert catalogs["items.json"][0]["name"] == "Crude wood-hafted spear"
+
+    def test_allows_legitimate_rename(self):
+        catalogs = {
+            "items.json": [_make_entity("item-spear", "Crude spear")],
+            "characters.json": [], "locations.json": [], "factions.json": [],
+        }
+        update = _make_entity("item-spear", "Crude wood-hafted spear", turn="turn-020")
+        merge_entity(catalogs, update)
+        assert catalogs["items.json"][0]["name"] == "Crude wood-hafted spear"
+
+    def test_allows_proper_name_reveal(self):
+        catalogs = {
+            "characters.json": [_make_entity("char-elder", "The elder", etype="character")],
+            "items.json": [], "locations.json": [], "factions.json": [],
+        }
+        update = _make_entity("char-elder", "Elder Lyra", etype="character", turn="turn-020")
+        merge_entity(catalogs, update)
+        assert catalogs["characters.json"][0]["name"] == "Elder Lyra"
+
+
+class TestIdentityOverwriteGuard:
+    def test_rejects_identity_from_wrong_entity(self):
+        catalogs = {
+            "items.json": [_make_entity("item-spear", "Crude spear", identity="A simple hunting spear.")],
+            "characters.json": [], "locations.json": [], "factions.json": [],
+        }
+        update = {"id": "item-spear", "name": "sturdy bowl", "type": "item",
+                  "identity": "A practical ceramic vessel.", "first_seen_turn": "turn-001",
+                  "last_updated_turn": "turn-020"}
+        merge_entity(catalogs, update)
+        assert "ceramic" not in catalogs["items.json"][0]["identity"].lower()
+
+    def test_allows_identity_update_same_name(self):
+        catalogs = {
+            "items.json": [_make_entity("item-spear", "Crude spear", identity="A spear.")],
+            "characters.json": [], "locations.json": [], "factions.json": [],
+        }
+        update = {"id": "item-spear", "name": "Crude spear", "type": "item",
+                  "identity": "A sturdy hunting spear used for survival.",
+                  "first_seen_turn": "turn-001", "last_updated_turn": "turn-020"}
+        merge_entity(catalogs, update)
+        assert "hunting spear" in catalogs["items.json"][0]["identity"]
+
+
+class TestAbstractItemFilter:
+    def test_method_rejected(self):
+        assert _is_misclassified_item({"name": "Pattern Disruption Method", "type": "item"})
+
+    def test_protocol_rejected(self):
+        assert _is_misclassified_item({"name": "Plague Treatment Protocol", "type": "item"})
+
+    def test_technique_rejected(self):
+        assert _is_misclassified_item({"name": "Ancient technique", "type": "item"})
+
+    def test_real_item_not_rejected(self):
+        assert not _is_misclassified_item({"name": "Crude spear", "type": "item"})
+
+    def test_non_item_ignored(self):
+        assert not _is_misclassified_item({"name": "Pattern Disruption Method", "type": "concept"})
+
+
+class TestCharacterFieldStripping:
+    def test_species_removed_from_item(self):
+        entity = {"id": "item-spear", "name": "Crude spear", "type": "item",
+                  "stable_attributes": {"species": {"value": "wood"}, "race": {"value": "crafted"},
+                                        "class": {"value": "weapon"}, "description": {"value": "A spear"}},
+                  "first_seen_turn": "turn-001", "last_updated_turn": "turn-020"}
+        result = _coerce_entity_fields(entity)
+        sa = result.get("stable_attributes", {})
+        assert "species" not in sa
+        assert "race" not in sa
+        assert "class" not in sa
+        assert "description" in sa

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -1117,7 +1117,20 @@ def _update_existing_entity(current: dict, update: dict, *, known_entity_names: 
     # description that happens to land on the same entity ID.
     if update.get("identity") and update["identity"] != current.get("identity"):
         if not is_pc:
-            current["identity"] = update["identity"]
+            update_name = update.get("name", "").lower()
+            current_name = current.get("name", "").lower()
+            if update_name and current_name and update_name != current_name:
+                _trivial = {"a", "an", "the", "of"}
+                old_tokens = set(current_name.replace("-", " ").split()) - _trivial
+                new_tokens = set(update_name.replace("-", " ").split()) - _trivial
+                if old_tokens and new_tokens and not (old_tokens & new_tokens):
+                    print(f"  GUARD: rejecting identity update for '{current.get('id')}' — "
+                          f"update name '{update_name}' doesn't match current '{current_name}'",
+                          file=sys.stderr)
+                else:
+                    current["identity"] = update["identity"]
+            else:
+                current["identity"] = update["identity"]
 
     if update.get("current_status"):
         current["current_status"] = update["current_status"]
@@ -1166,29 +1179,38 @@ def _update_existing_entity(current: dict, update: dict, *, known_entity_names: 
                     alias_list_pc.append(candidate_name)
                     aliases_pc["value"] = alias_list_pc
         else:
-            old_name = current["name"]
-            if "stable_attributes" not in current:
-                current["stable_attributes"] = {}
-            sa = current["stable_attributes"]
-            existing_aliases = sa.get("aliases", {})
-            if isinstance(existing_aliases, dict):
-                val = existing_aliases.get("value", [])
-                if isinstance(val, str):
-                    val = [a.strip() for a in val.split(",") if a.strip()]
-                if old_name not in val:
-                    val.append(old_name)
-                alias_turn = (update.get("last_updated_turn")
-                              or current.get("last_updated_turn")
-                              or current.get("first_seen_turn", ""))
-                sa["aliases"] = {"value": val, "inference": False,
-                                 "source_turn": alias_turn}
+            # Guard: reject name changes with no word overlap (#339)
+            _trivial = {"a", "an", "the", "of", "and", "with"}
+            old_tokens = set(current["name"].lower().replace("-", " ").split()) - _trivial
+            new_tokens = set(update["name"].lower().replace("-", " ").split()) - _trivial
+            if old_tokens and new_tokens and not (old_tokens & new_tokens):
+                print(f"  GUARD: rejecting name change '{current['name']}' → "
+                      f"'{update['name']}' (no word overlap — possible identity "
+                      f"corruption)", file=sys.stderr)
             else:
-                alias_turn = (update.get("last_updated_turn")
-                              or current.get("last_updated_turn")
-                              or current.get("first_seen_turn", ""))
-                sa["aliases"] = {"value": [old_name], "inference": False,
-                                 "source_turn": alias_turn}
-            current["name"] = update["name"]
+                old_name = current["name"]
+                if "stable_attributes" not in current:
+                    current["stable_attributes"] = {}
+                sa = current["stable_attributes"]
+                existing_aliases = sa.get("aliases", {})
+                if isinstance(existing_aliases, dict):
+                    val = existing_aliases.get("value", [])
+                    if isinstance(val, str):
+                        val = [a.strip() for a in val.split(",") if a.strip()]
+                    if old_name not in val:
+                        val.append(old_name)
+                    alias_turn = (update.get("last_updated_turn")
+                                  or current.get("last_updated_turn")
+                                  or current.get("first_seen_turn", ""))
+                    sa["aliases"] = {"value": val, "inference": False,
+                                     "source_turn": alias_turn}
+                else:
+                    alias_turn = (update.get("last_updated_turn")
+                                  or current.get("last_updated_turn")
+                                  or current.get("first_seen_turn", ""))
+                    sa["aliases"] = {"value": [old_name], "inference": False,
+                                     "source_turn": alias_turn}
+                current["name"] = update["name"]
 
     # Update last_updated_turn — keep the latest (max) to prevent
     # re-extraction of earlier turns from regressing the value (#314).

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -1112,25 +1112,37 @@ def _update_existing_entity(current: dict, update: dict, *, known_entity_names: 
     """Update an existing entity with new information."""
     is_pc = current.get("id") == "char-player"
 
+    # Upfront mismatch detection: if the update's name has zero word overlap
+    # with the current name, skip all merges to prevent identity corruption (#339).
+    _name_mismatch = False
+    if not is_pc and update.get("name") and current.get("name"):
+        update_name_lower = update["name"].lower()
+        current_name_lower = current["name"].lower()
+        if update_name_lower != current_name_lower:
+            _trivial = {"a", "an", "the", "of", "and", "with"}
+            old_tokens = set(current_name_lower.replace("-", " ").split()) - _trivial
+            new_tokens = set(update_name_lower.replace("-", " ").split()) - _trivial
+            if old_tokens and new_tokens and not (old_tokens & new_tokens):
+                _name_mismatch = True
+                print(f"  GUARD: name mismatch for '{current.get('id')}' — "
+                      f"'{current['name']}' vs '{update['name']}' "
+                      f"(no word overlap — skipping all merges)", file=sys.stderr)
+
+    if _name_mismatch:
+        # Only advance last_updated_turn (safe metadata), skip all content merges
+        if update.get("last_updated_turn"):
+            existing_num = _parse_turn_number(current.get("last_updated_turn"))
+            update_num = _parse_turn_number(update["last_updated_turn"])
+            if not existing_num or (update_num and update_num >= existing_num):
+                current["last_updated_turn"] = update["last_updated_turn"]
+        return
+
     # Never overwrite the PC's identity from a per-turn update — the PC's
     # identity is established early and should not be replaced by an NPC
     # description that happens to land on the same entity ID.
     if update.get("identity") and update["identity"] != current.get("identity"):
         if not is_pc:
-            update_name = update.get("name", "").lower()
-            current_name = current.get("name", "").lower()
-            if update_name and current_name and update_name != current_name:
-                _trivial = {"a", "an", "the", "of"}
-                old_tokens = set(current_name.replace("-", " ").split()) - _trivial
-                new_tokens = set(update_name.replace("-", " ").split()) - _trivial
-                if old_tokens and new_tokens and not (old_tokens & new_tokens):
-                    print(f"  GUARD: rejecting identity update for '{current.get('id')}' — "
-                          f"update name '{update_name}' doesn't match current '{current_name}'",
-                          file=sys.stderr)
-                else:
-                    current["identity"] = update["identity"]
-            else:
-                current["identity"] = update["identity"]
+            current["identity"] = update["identity"]
 
     if update.get("current_status"):
         current["current_status"] = update["current_status"]

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -702,6 +702,14 @@ def _coerce_entity_fields(entity_data) -> dict | None:
     if isinstance(vs, dict) and "last_updated_turn" not in vs and has_valid_turn:
         vs["last_updated_turn"] = turn_id
 
+    # Strip character-only schema fields from items (#339)
+    if entity_data.get("type") == "item":
+        _ITEM_INVALID_ATTRS = {"species", "race", "class", "alignment", "age"}
+        sa = entity_data.get("stable_attributes", {})
+        for attr_key in list(sa.keys()):
+            if attr_key.lower() in _ITEM_INVALID_ATTRS:
+                del sa[attr_key]
+
     # Coerce LLM relationship fields to V2 format
     for rel in entity_data.get("relationships", []):
         if "relationship" in rel and "current_relationship" not in rel:
@@ -1625,6 +1633,22 @@ def _is_misclassified_location(entity: dict) -> bool:
     return False
 
 
+_ABSTRACT_ITEM_RE = re.compile(
+    r"\b(method|protocol|technique|process|procedure|approach|strategy|practice|discipline)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_misclassified_item(entity: dict) -> bool:
+    """Return True if entity is an abstract concept misclassified as item."""
+    if entity.get("type") != "item":
+        return False
+    name = entity.get("name", "").strip()
+    if _ABSTRACT_ITEM_RE.search(name):
+        return True
+    return False
+
+
 def _build_catalog_name_index(catalogs: dict) -> dict[str, dict]:
     """Build a normalized-name -> entity lookup across all catalogs.
 
@@ -2288,6 +2312,22 @@ def extract_and_merge(
             continue
         _type_filtered.append(entity_ref)
     qualified = _type_filtered
+
+    # Reject misclassified items (#339)
+    _item_filtered = []
+    for entity_ref in qualified:
+        if _is_misclassified_item(entity_ref):
+            eid = get_entity_id(entity_ref)
+            print(f"  FILTER: rejected '{entity_ref.get('name')}' as item "
+                  f"(abstract concept name pattern)", file=sys.stderr)
+            _discovery_filtered.append({
+                "name": entity_ref.get("name", ""),
+                "id": eid,
+                "reason": "misclassified_item",
+            })
+            continue
+        _item_filtered.append(entity_ref)
+    qualified = _item_filtered
 
     # Reject entities whose name already exists in catalogs under a different type (#303)
     _catalog_name_index = _build_catalog_name_index(catalogs)

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -706,9 +706,10 @@ def _coerce_entity_fields(entity_data) -> dict | None:
     if entity_data.get("type") == "item":
         _ITEM_INVALID_ATTRS = {"species", "race", "class", "alignment", "age"}
         sa = entity_data.get("stable_attributes", {})
-        for attr_key in list(sa.keys()):
-            if attr_key.lower() in _ITEM_INVALID_ATTRS:
-                del sa[attr_key]
+        if isinstance(sa, dict):
+            for attr_key in list(sa.keys()):
+                if attr_key.lower() in _ITEM_INVALID_ATTRS:
+                    del sa[attr_key]
 
     # Coerce LLM relationship fields to V2 format
     for rel in entity_data.get("relationships", []):


### PR DESCRIPTION
## Summary

Guards against entity identity corruption where LLM hallucinations cause unrelated entities to overwrite each other's names and identities (e.g. "Crude wood-hafted spear" → "sturdy bowl"). Also rejects abstract concepts misclassified as items and strips character-only schema fields from item entities.

## Changes

| File | Change |
|---|---|
| `tools/catalog_merger.py` | Name stability guard: rejects name changes with zero meaningful word overlap |
| `tools/catalog_merger.py` | Identity overwrite guard: rejects identity updates when update name doesn't match current name |
| `tools/semantic_extraction.py` | Abstract-item discovery filter: rejects items named with abstract concept patterns (method, protocol, technique, etc.) |
| `tools/semantic_extraction.py` | `_coerce_entity_fields()`: strips character-only fields (species, race, class, alignment, age) from items |
| `tests/test_identity_guard.py` | 11 new tests covering all four guards |
| `tests/test_catalog_merger_v2.py` | Updated existing test for new guard behavior; added no-overlap rejection test |

## Entities caught by these guards

- **Name corruption**: "Crude wood-hafted spear" → "sturdy bowl" (no word overlap — blocked)
- **Identity corruption**: Identity text from a different entity applied to wrong ID (blocked when names don't overlap)
- **Abstract items**: "Pattern Disruption Method", "Plague Treatment Protocol", "Ancient technique" (filtered at discovery)
- **Schema pollution**: species/race/class/alignment/age fields on item entities (stripped during coercion)

## Test results

1575 passed, 1 skipped, 0 failed (12 new tests added: 11 in `test_identity_guard.py`, 1 in `test_catalog_merger_v2.py`)

Closes #339
