### PR TITLE
fix: add same-turn dedup gate for synonym explosion (#337)

### DIFF
--- a/templates/extraction/entity-discovery.md
+++ b/templates/extraction/entity-discovery.md
@@ -53,4 +53,9 @@ Rules:
 - proposed_id and existing_id are mutually exclusive.
 - Extract from ALL text: narration, descriptions, memories, quest briefings.
 - Environmental locations where action occurs should be extracted.
+- SYNONYM CONSOLIDATION: If the DM uses multiple synonyms for the same place, object, or
+  group in one turn (e.g. "safe haven", "hidden refuge", "defensible sanctuary" all
+  describing the same location), extract ONE entity using the most specific or proper name.
+  Do NOT create separate entities for each synonym. When unsure, prefer the name that would
+  make the best catalog entry title.
 - Abstract/distant references count (departed village, sought artifact).

--- a/tests/test_synonym_dedup.py
+++ b/tests/test_synonym_dedup.py
@@ -1,10 +1,13 @@
 """Tests for same-turn synonym explosion dedup gate (#337)."""
 import os
 import sys
+from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
+import semantic_extraction as se
 from semantic_extraction import _same_turn_dedup_gate
+from catalog_merger import CATALOG_KEYS
 
 
 def _make_proposal(name, etype="location", turn="turn-169", is_new=True):
@@ -94,3 +97,83 @@ class TestSameTurnDedupGate:
         turn_200 = [e for e in result if e["source_turn"] == "turn-200" and e["is_new"]]
         assert len(turn_100) == 1
         assert len(turn_200) == 2
+
+
+def _fresh_catalogs():
+    return {fn: [] for fn in CATALOG_KEYS}
+
+
+def _make_stub_llm(discovery_entities):
+    """Build a stub LLM that returns given entities from discovery."""
+    llm = MagicMock()
+    llm.default_timeout = 10
+    llm.pc_max_tokens = 4096
+    llm.delay = MagicMock()
+    llm.config = {"checkpoint_interval": 100}
+
+    def _extract_json(system_prompt, user_prompt, timeout=None, max_tokens=None, schema=None, temperature=None):
+        prompt_lower = system_prompt.lower()
+        if "discover" in prompt_lower or "discovery" in prompt_lower:
+            return {"entities": discovery_entities}
+        if "detail" in prompt_lower:
+            return {"entity": {
+                "id": "char-player",
+                "name": "Player Character",
+                "type": "character",
+                "identity": "The player character.",
+                "first_seen_turn": "turn-001",
+                "last_updated_turn": "turn-001",
+            }}
+        if "relationship" in prompt_lower:
+            return {"relationships": []}
+        if "event" in prompt_lower:
+            return {"events": []}
+        return {}
+
+    llm.extract_json = MagicMock(side_effect=_extract_json)
+    return llm
+
+
+class TestSynonymExplosionWarningLog:
+    """synonym_explosion_warning field in extraction log (#337)."""
+
+    def test_warning_set_when_above_threshold(self, monkeypatch):
+        """Log record includes synonym_explosion_warning when >3 new entities of a type."""
+        monkeypatch.setattr(se, "load_template", lambda name: f"{name} template")
+        se._reset_pc_failure_tracking()
+        entities = [
+            {"name": f"location-{i}", "type": "location", "is_new": True,
+             "source_turn": "turn-001", "proposed_id": f"loc-{i}", "confidence": 0.8}
+            for i in range(5)
+        ]
+        llm = _make_stub_llm(entities)
+        catalogs = _fresh_catalogs()
+        events = []
+        turn = {"turn_id": "turn-001", "speaker": "dm", "text": "Five locations mentioned."}
+
+        _, _, _, log = se.extract_and_merge(
+            turn, catalogs, events, llm, min_confidence=0.6,
+        )
+
+        assert log["synonym_explosion_warning"] is not None
+        assert log["synonym_explosion_warning"]["location"] == 5
+
+    def test_warning_absent_when_below_threshold(self, monkeypatch):
+        """Log record has no synonym_explosion_warning when <=3 new entities per type."""
+        monkeypatch.setattr(se, "load_template", lambda name: f"{name} template")
+        se._reset_pc_failure_tracking()
+        entities = [
+            {"name": f"location-{i}", "type": "location", "is_new": True,
+             "source_turn": "turn-001", "proposed_id": f"loc-{i}", "confidence": 0.8}
+            for i in range(3)
+        ]
+        llm = _make_stub_llm(entities)
+        catalogs = _fresh_catalogs()
+        events = []
+        turn = {"turn_id": "turn-001", "speaker": "dm", "text": "Three locations."}
+
+        _, _, _, log = se.extract_and_merge(
+            turn, catalogs, events, llm, min_confidence=0.6,
+        )
+
+        assert log["synonym_explosion_warning"] is None

--- a/tests/test_synonym_dedup.py
+++ b/tests/test_synonym_dedup.py
@@ -6,8 +6,9 @@ from unittest.mock import MagicMock
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
 import semantic_extraction as se
-from semantic_extraction import _same_turn_dedup_gate
 from catalog_merger import CATALOG_KEYS
+
+_same_turn_dedup_gate = se._same_turn_dedup_gate
 
 
 def _make_proposal(name, etype="location", turn="turn-169", is_new=True):

--- a/tests/test_synonym_dedup.py
+++ b/tests/test_synonym_dedup.py
@@ -1,0 +1,96 @@
+"""Tests for same-turn synonym explosion dedup gate (#337)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from semantic_extraction import _same_turn_dedup_gate
+
+
+def _make_proposal(name, etype="location", turn="turn-169", is_new=True):
+    return {
+        "name": name,
+        "type": etype,
+        "is_new": is_new,
+        "source_turn": turn,
+        "proposed_id": f"loc-{name.lower().replace(' ', '-')}" if is_new else None,
+        "existing_id": None if is_new else f"loc-{name.lower().replace(' ', '-')}",
+        "confidence": 0.8,
+    }
+
+
+class TestSameTurnDedupGate:
+    def test_14_synonyms_reduced_to_1(self):
+        entities = [
+            _make_proposal("camouflaged entrance"),
+            _make_proposal("defensible place"),
+            _make_proposal("defensible sanctuary"),
+            _make_proposal("hidden location"),
+            _make_proposal("hidden refuge"),
+            _make_proposal("the hidden sanctuary"),
+            _make_proposal("the protected location"),
+            _make_proposal("sanctuary for the vulnerable"),
+            _make_proposal("safe haven"),
+            _make_proposal("safe location"),
+            _make_proposal("safety sanctuary"),
+            _make_proposal("secure location"),
+            _make_proposal("strategic location"),
+            _make_proposal("strategic sanctuary"),
+        ]
+        result = _same_turn_dedup_gate(entities, threshold=3)
+        new_locations = [e for e in result if e["is_new"] and e["type"] == "location"]
+        assert len(new_locations) == 1
+        assert len(new_locations[0]["name"]) == max(len(e["name"]) for e in entities)
+
+    def test_below_threshold_untouched(self):
+        entities = [
+            _make_proposal("the forest"),
+            _make_proposal("the river"),
+            _make_proposal("the camp"),
+        ]
+        result = _same_turn_dedup_gate(entities, threshold=3)
+        assert len(result) == 3
+
+    def test_existing_entities_preserved(self):
+        entities = [
+            _make_proposal("hidden refuge"),
+            _make_proposal("safe haven"),
+            _make_proposal("secure location"),
+            _make_proposal("strategic sanctuary"),
+            _make_proposal("known place", is_new=False),
+        ]
+        result = _same_turn_dedup_gate(entities, threshold=3)
+        existing = [e for e in result if not e["is_new"]]
+        assert len(existing) == 1
+
+    def test_different_types_counted_separately(self):
+        entities = [
+            _make_proposal("place a", etype="location"),
+            _make_proposal("place b", etype="location"),
+            _make_proposal("place c", etype="location"),
+            _make_proposal("place d", etype="location"),
+            _make_proposal("person a", etype="character"),
+            _make_proposal("person b", etype="character"),
+            _make_proposal("person c", etype="character"),
+            _make_proposal("person d", etype="character"),
+        ]
+        result = _same_turn_dedup_gate(entities, threshold=3)
+        new_locs = [e for e in result if e["type"] == "location" and e["is_new"]]
+        new_chars = [e for e in result if e["type"] == "character" and e["is_new"]]
+        assert len(new_locs) == 1
+        assert len(new_chars) == 1
+
+    def test_different_turns_counted_separately(self):
+        entities = [
+            _make_proposal("place a", turn="turn-100"),
+            _make_proposal("place b", turn="turn-100"),
+            _make_proposal("place c", turn="turn-100"),
+            _make_proposal("place d", turn="turn-100"),
+            _make_proposal("place e", turn="turn-200"),
+            _make_proposal("place f", turn="turn-200"),
+        ]
+        result = _same_turn_dedup_gate(entities, threshold=3)
+        turn_100 = [e for e in result if e["source_turn"] == "turn-100" and e["is_new"]]
+        turn_200 = [e for e in result if e["source_turn"] == "turn-200" and e["is_new"]]
+        assert len(turn_100) == 1
+        assert len(turn_200) == 2

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -1706,7 +1706,9 @@ def _same_turn_dedup_gate(
     are always kept.
     """
     groups: dict[tuple[str, str], list[dict]] = {}
-    for entity in entities:
+    identity_index: dict[int, int] = {}  # id(entity) -> index in entities list
+    for idx, entity in enumerate(entities):
+        identity_index[id(entity)] = idx
         if not entity.get("is_new", True):
             continue
         key = (entity.get("source_turn", ""), entity.get("type", ""))
@@ -1721,7 +1723,7 @@ def _same_turn_dedup_gate(
         survivor_name = survivor.get("name", "")
         for entity in group[1:]:
             eid = entity.get("proposed_id") or entity.get("existing_id", "")
-            idx = next((i for i, e in enumerate(entities) if e is entity), None)
+            idx = identity_index.get(id(entity))
             if idx is not None:
                 to_remove.add(idx)
                 print(f"  DEDUP-GATE: dropping '{entity.get('name')}' ({eid}) "

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -1691,6 +1691,49 @@ def _find_cross_catalog_type_conflict(
     return None
 
 
+def _same_turn_dedup_gate(
+    entities: list[dict],
+    threshold: int = 3,
+) -> list[dict]:
+    """Consolidate same-turn, same-type entity proposals that likely refer to the same thing (#337).
+
+    When more than ``threshold`` new entities of the same type share the same
+    source_turn, keep only the entity with the longest (most specific) name
+    per type. This catches synonym explosion where the DM uses multiple
+    phrases for the same concept.
+
+    Only applies to NEW entities (is_new=True). Existing entity references
+    are always kept.
+    """
+    groups: dict[tuple[str, str], list[dict]] = {}
+    for entity in entities:
+        if not entity.get("is_new", True):
+            continue
+        key = (entity.get("source_turn", ""), entity.get("type", ""))
+        groups.setdefault(key, []).append(entity)
+
+    to_remove: set[int] = set()
+    for (turn, etype), group in groups.items():
+        if len(group) <= threshold:
+            continue
+        group.sort(key=lambda e: len(e.get("name", "")), reverse=True)
+        survivor = group[0]
+        survivor_name = survivor.get("name", "")
+        for entity in group[1:]:
+            eid = entity.get("proposed_id") or entity.get("existing_id", "")
+            idx = next((i for i, e in enumerate(entities) if e is entity), None)
+            if idx is not None:
+                to_remove.add(idx)
+                print(f"  DEDUP-GATE: dropping '{entity.get('name')}' ({eid}) "
+                      f"— same turn/type as '{survivor_name}' "
+                      f"({len(group)} {etype} proposals in {turn})",
+                      file=sys.stderr)
+
+    if not to_remove:
+        return entities
+    return [e for i, e in enumerate(entities) if i not in to_remove]
+
+
 # Meta-labels that should never be accepted as PC aliases (#186)
 _PC_ALIAS_BLOCKLIST = {
     "player character", "pc", "player", "the player",
@@ -2309,6 +2352,18 @@ def extract_and_merge(
         _cross_catalog_filtered.append(entity_ref)
     qualified = _cross_catalog_filtered
 
+    # Same-turn dedup gate: consolidate synonym explosion (#337)
+    qualified = _same_turn_dedup_gate(qualified, threshold=3)
+
+    # Log same-turn entity density (#337)
+    _new_by_type: dict[str, int] = {}
+    for _ent in discovered:
+        if _ent.get("is_new", True):
+            _etype = _ent.get("type", "unknown")
+            _new_by_type[_etype] = _new_by_type.get(_etype, 0) + 1
+    if any(v > 3 for v in _new_by_type.values()):
+        _phase_log["synonym_explosion_warning"] = _new_by_type
+
     # --- Pre-compute task inputs for phases 2-4 ---
 
     # Filter qualified entities and snapshot current entries for detail extraction
@@ -2903,6 +2958,7 @@ def extract_and_merge(
         "new_temporal_signals": max(0, _temporal_after - _temporal_before),
         "discovery_proposals": _discovery_proposals,
         "discovery_filtered": _discovery_filtered,
+        "synonym_explosion_warning": _phase_log.get("synonym_explosion_warning"),
         "elapsed_ms": _elapsed_ms,
     }
     return catalogs, events_list, turn_failed, _log_record


### PR DESCRIPTION
## Summary

Adds a same-turn dedup gate to the entity discovery pipeline that prevents synonym explosion — when the LLM extracts many near-duplicate entities of the same type from a single turn.

## Problem

Turn-169 produced 14 new location entities that were all synonyms for the same concept (e.g. "safe haven", "hidden refuge", "defensible sanctuary", "strategic location"). This floods the catalog with duplicates that must be cleaned up later.

## Changes

### 1. `_same_turn_dedup_gate()` function (`tools/semantic_extraction.py`)
- Groups new (is_new=True) entities by (source_turn, type)
- When a group exceeds the threshold (default: 3), keeps only the entity with the longest name (most specific)
- Existing entity references are never affected
- Logs each dropped entity to stderr for diagnostics

### 2. Pipeline wiring
- Gate runs after all existing filters (confidence, concept-prefix, misclassification, cross-catalog) and before task input computation

### 3. Discovery logging
- Adds `synonym_explosion_warning` field to extraction log when any type has >3 new entities in a turn
- Records per-type counts for monitoring

### 4. Prompt hardening (`templates/extraction/entity-discovery.md`)
- Added SYNONYM CONSOLIDATION rule instructing the LLM to extract one entity per concept, not one per synonym

### 5. Tests (`tests/test_synonym_dedup.py`)
- 14 synonyms → 1 survivor (keeps longest name)
- Below-threshold lists untouched
- Existing entities always preserved
- Different types counted separately
- Different turns counted separately

## Impact

Turn-169 would go from 14 new location entities to 1. The prompt-level rule should also reduce synonym proposals at the LLM level.

Closes #337
