### PR TITLE
feat: add /admin/flush endpoint to drain orphan requests

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -245,7 +245,7 @@ All data structures are defined in `schemas/`. See each schema file for field de
 | `tools/llm_client.py` | Provider-agnostic LLM client (OpenAI, Ollama, Google Gemini, etc.) with automatic fallback provider support (#301) |
 | `tools/dedup_audit.py` | LLM-assisted post-extraction dedup: identifies duplicate entities via name similarity heuristics, scores with LLM, auto-merges or flags for review (#306) |
 | `tools/discovery_baseline.py` | Discovery output measurement harness: runs entity discovery against a live LLM, reports token consumption, entity counts, and categorization (active/passive/spurious) (#310) |
-| `server/ov_serve.py` | OpenVINO GenAI REST server — OpenAI-compatible `/v1/chat/completions` endpoint using `ContinuousBatchingPipeline` with prefix caching and dynamic batching. Supports `--device` flag for multi-GPU targeting (e.g., `GPU.0`, `GPU.1`) (#299) |
+| `server/ov_serve.py` | OpenVINO GenAI REST server — OpenAI-compatible `/v1/chat/completions` endpoint using `ContinuousBatchingPipeline` with prefix caching and dynamic batching. Supports `--device` flag for multi-GPU targeting (e.g., `GPU.0`, `GPU.1`) (#299). `POST /admin/flush` drains orphan queued requests (#361) |
 | `tools/start_extraction_detached.ps1` | Launch semantic extraction in a detached process with log/PID files; supports `-Framework`/`-PlayerLabel` passthrough and safe argument quoting for values with spaces |
 | `tools/watch_extraction_detached.ps1` | Show status and tail logs for detached extraction runs |
 | `tools/stop_extraction_detached.ps1` | Stop detached extraction runs by PID file |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -379,7 +379,7 @@ python server/ov_serve.py --model-dir ./models/qwen3-8b-int4-ov --port 8000 \
 
 The included `server/ov_serve.py` provides:
 
-- **OpenAI-compatible API** — `/v1/chat/completions`, `/v1/models`, `/health` endpoints
+- **OpenAI-compatible API** — `/v1/chat/completions`, `/v1/models`, `/health`, `/admin/flush` endpoints
 - **Thinking suppression** — passes `enable_thinking=False` in
   `apply_chat_template(..., extra_context={'enable_thinking': False})`,
   preventing qwen3 models from wasting ~80% of output tokens on `<think>`
@@ -394,6 +394,10 @@ The included `server/ov_serve.py` provides:
 - **HTTP keep-alive** (#316) — defaults to 120-second keep-alive timeout,
   preventing TCP connection drops between sequential extraction requests.
   Configurable via `--timeout-keep-alive`.
+- **Admin flush** (#361) — `POST /admin/flush` drains all queued requests,
+  failing them with 503. Use this to recover from orphan requests left by
+  killed extraction processes without restarting the server. In-flight
+  batches complete normally. Returns `{"flushed": N, "status": "ok"}`.
 
 Configure `config/llm.json` on the client machine:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -379,7 +379,7 @@ python server/ov_serve.py --model-dir ./models/qwen3-8b-int4-ov --port 8000 \
 
 The included `server/ov_serve.py` provides:
 
-- **OpenAI-compatible API** — `/v1/chat/completions`, `/v1/models`, `/health`, `/admin/flush` endpoints
+- **OpenAI-compatible API** — `/v1/chat/completions`, `/v1/models`, `/health` endpoints
 - **Thinking suppression** — passes `enable_thinking=False` in
   `apply_chat_template(..., extra_context={'enable_thinking': False})`,
   preventing qwen3 models from wasting ~80% of output tokens on `<think>`

--- a/server/ov_serve.py
+++ b/server/ov_serve.py
@@ -12,6 +12,7 @@ Endpoints:
   POST /v1/chat/completions  — OpenAI-compatible chat completions
   GET  /v1/models            — List available models
   GET  /health               — Health check
+  POST /admin/flush          — Drain queued requests (503 each)
 
 Usage:
   pip install fastapi uvicorn openvino-genai
@@ -247,6 +248,26 @@ async def health():
         "queue_depth": queue_size,
         "request_timeout_s": REQUEST_TIMEOUT_S,
     }
+
+@app.post("/admin/flush")
+async def admin_flush():
+    """Drain all queued requests, failing them with 503.
+
+    In-flight batches (currently in pipeline.generate()) are NOT interrupted.
+    Only requests waiting in the queue are cancelled.
+    """
+    flushed = 0
+    while not batch_queue.empty():
+        try:
+            queued_req = batch_queue.get_nowait()
+            if not queued_req.future.done():
+                queued_req.future.set_exception(
+                    HTTPException(status_code=503, detail="Flushed by admin")
+                )
+            flushed += 1
+        except asyncio.QueueEmpty:
+            break
+    return {"flushed": flushed, "status": "ok"}
 
 @app.get("/v1/models")
 async def list_models():

--- a/server/ov_serve.py
+++ b/server/ov_serve.py
@@ -256,8 +256,10 @@ async def admin_flush():
     In-flight batches (currently in pipeline.generate()) are NOT interrupted.
     Only requests waiting in the queue are cancelled.
     """
+    if batch_queue is None:
+        return {"flushed": 0, "status": "ok"}
     flushed = 0
-    while not batch_queue.empty():
+    while True:
         try:
             queued_req = batch_queue.get_nowait()
             if not queued_req.future.done():

--- a/tests/test_ov_serve_keepalive.py
+++ b/tests/test_ov_serve_keepalive.py
@@ -229,7 +229,7 @@ async def test_cli_timeout_keep_alive_forwarded_to_uvicorn():
 
 @pytest.mark.asyncio
 async def test_admin_flush_drains_queue(async_client):
-    """POST /admin/flush drains queued requests with 503 (#361)."""
+    """POST /admin/flush returns ok when queue is empty (#361)."""
     # Queue is empty initially
     resp = await async_client.post("/admin/flush")
     assert resp.status_code == 200
@@ -273,6 +273,11 @@ async def test_admin_flush_clears_pending_requests(_patch_globals):
     assert data["status"] == "ok"
     assert ov_serve.batch_queue.qsize() == 0
 
+    # Verify /health also reports queue_depth: 0 after flush
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        health_resp = await client.get("/health")
+    assert health_resp.json()["queue_depth"] == 0
+
     # All futures should have exceptions
     for f in futures:
         assert f.done()
@@ -280,3 +285,22 @@ async def test_admin_flush_clears_pending_requests(_patch_globals):
         with pytest.raises(HTTPException) as exc_info:
             f.result()
         assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_admin_flush_before_queue_init(_patch_globals):
+    """POST /admin/flush returns gracefully when batch_queue is None (#361)."""
+    import httpx
+
+    saved_queue = ov_serve.batch_queue
+    ov_serve.batch_queue = None
+    try:
+        transport = httpx.ASGITransport(app=ov_serve.app, raise_app_exceptions=False)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            resp = await client.post("/admin/flush")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["flushed"] == 0
+        assert data["status"] == "ok"
+    finally:
+        ov_serve.batch_queue = saved_queue

--- a/tests/test_ov_serve_keepalive.py
+++ b/tests/test_ov_serve_keepalive.py
@@ -225,3 +225,58 @@ async def test_cli_timeout_keep_alive_forwarded_to_uvicorn():
     finally:
         for attr, val in saved.items():
             setattr(ov_serve, attr, val)
+
+
+@pytest.mark.asyncio
+async def test_admin_flush_drains_queue(async_client):
+    """POST /admin/flush drains queued requests with 503 (#361)."""
+    # Queue is empty initially
+    resp = await async_client.post("/admin/flush")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["flushed"] == 0
+    assert data["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_admin_flush_clears_pending_requests(_patch_globals):
+    """Flush cancels queued requests that haven't started processing (#361)."""
+    import httpx
+
+    ov_serve.batch_queue = asyncio.Queue()
+    # Do NOT start batch_worker — requests will stay queued
+
+    loop = asyncio.get_running_loop()
+
+    # Queue some fake requests
+    futures = []
+    for i in range(3):
+        future = loop.create_future()
+        futures.append(future)
+        req = ov_serve.BatchRequest(
+            prompt=f"test prompt {i}",
+            gen_config=None,
+            future=future,
+        )
+        await ov_serve.batch_queue.put(req)
+
+    assert ov_serve.batch_queue.qsize() == 3
+
+    # Call flush via the endpoint
+    transport = httpx.ASGITransport(app=ov_serve.app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post("/admin/flush")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["flushed"] == 3
+    assert data["status"] == "ok"
+    assert ov_serve.batch_queue.qsize() == 0
+
+    # All futures should have exceptions
+    for f in futures:
+        assert f.done()
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc_info:
+            f.result()
+        assert exc_info.value.status_code == 503


### PR DESCRIPTION
## Summary

Adds a `POST /admin/flush` endpoint to `server/ov_serve.py` that drains all queued batch requests, failing them with 503. This allows recovery from orphan requests left by killed extraction processes without restarting the server.

## Changes

- **server/ov_serve.py**: New `/admin/flush` endpoint that drains `batch_queue`, failing each queued request with 503. In-flight batches (currently in `pipeline.generate()`) are not interrupted.
- **tests/test_ov_serve_keepalive.py**: Two new tests — empty queue flush and flush with pending requests.
- **docs/usage.md**: Document the flush endpoint in the ov_serve.py feature list.
- **docs/architecture.md**: Updated ov_serve.py description to mention flush endpoint.

## Usage

```bash
# Flush orphan requests after killing an extraction process
curl -X POST http://192.168.10.169:8000/admin/flush
# Returns: {"flushed": 7, "status": "ok"}
```

## Test results

1587 passed, 1 skipped, 0 failures.

Closes #361
