### PR TITLE
feat: improve extraction quality filters

### DIFF
--- a/tests/test_dedup_fuzzy.py
+++ b/tests/test_dedup_fuzzy.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
-from semantic_extraction import _dedup_catalogs
+from semantic_extraction import _dedup_catalogs, _within_turn_dedup
 
 
 def _make_entity(id_, name, turn="turn-001"):
@@ -137,6 +137,74 @@ def test_no_false_merge_herb_party_vs_hunting_party():
     count, merge_map = _dedup_catalogs(catalogs)
     assert count == 0
     assert len(catalogs["factions.json"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# #365 — Within-turn dedup
+# ---------------------------------------------------------------------------
+
+def _make_discovery(name, is_new=True):
+    """Make a minimal discovery entity for _within_turn_dedup tests."""
+    return {"name": name, "is_new": is_new, "type": "character"}
+
+
+def test_within_turn_dedup_elder_eldorman():
+    """'elder' is a substring of 'eldorman' → keep 'eldorman'."""
+    entities = [_make_discovery("elder"), _make_discovery("eldorman")]
+    result = _within_turn_dedup(entities)
+    names = [e["name"] for e in result]
+    assert "eldorman" in names
+    assert "elder" not in names
+
+
+def test_within_turn_dedup_camp_camping_grounds():
+    """'camp' is a substring of 'camping grounds' → keep 'camping grounds'."""
+    entities = [_make_discovery("camp"), _make_discovery("camping grounds")]
+    result = _within_turn_dedup(entities)
+    names = [e["name"] for e in result]
+    assert "camping grounds" in names
+    assert "camp" not in names
+
+
+def test_within_turn_dedup_no_similarity():
+    """Dissimilar names → keep both."""
+    entities = [_make_discovery("wizard"), _make_discovery("goblin")]
+    result = _within_turn_dedup(entities)
+    assert len(result) == 2
+
+
+def test_within_turn_dedup_short_names_kept():
+    """Short dissimilar names skip substring check and have high Levenshtein → keep both."""
+    entities = [_make_discovery("ax"), _make_discovery("grove")]
+    result = _within_turn_dedup(entities)
+    assert len(result) == 2
+
+
+def test_within_turn_dedup_non_new_untouched():
+    """Non-new entities should not be deduped."""
+    entities = [
+        _make_discovery("elder", is_new=False),
+        _make_discovery("eldorman", is_new=True),
+    ]
+    result = _within_turn_dedup(entities)
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# #365 — Character substring in _dedup_catalogs
+# ---------------------------------------------------------------------------
+
+def test_char_substring_merge_star_starlight():
+    """'star' is a character substring of 'starlight' → merge in _dedup_catalogs."""
+    catalogs = {
+        "items.json": [
+            _make_entity("item-star", "star", "turn-001"),
+            _make_entity("item-starlight", "starlight", "turn-001"),
+        ]
+    }
+    count, merge_map = _dedup_catalogs(catalogs)
+    assert count == 1
+    assert len(catalogs["items.json"]) == 1
 
 
 def test_no_false_merge_broad_figure_vs_lone_figure():

--- a/tests/test_dedup_fuzzy.py
+++ b/tests/test_dedup_fuzzy.py
@@ -301,3 +301,63 @@ def test_dedup_normalize_map_in_merge_map():
     # The turn-tagged entity gets normalized + deduped; its old ID is in merge_map
     assert "char-shaman-turn-082" in merge_map
     assert merge_map["char-shaman-turn-082"] == "char-shaman"
+
+
+# ---------------------------------------------------------------------------
+# #365 review feedback - Additional within-turn dedup tests
+# ---------------------------------------------------------------------------
+
+
+def test_within_turn_dedup_levenshtein_merge():
+    """Levenshtein distance <= 3 should merge (e.g. 'shaman' vs 'shamn')."""
+    entities = [_make_discovery("shaman"), _make_discovery("shamn")]
+    result = _within_turn_dedup(entities)
+    names = [e["name"] for e in result]
+    assert len(result) == 1
+    assert "shaman" in names
+
+
+def test_within_turn_dedup_sequence_matcher_merge():
+    """SequenceMatcher ratio >= 0.6 should merge similar names (lev > 3, not substring)."""
+    # 'elder spirit totem' vs 'elder spirits totem pole' -- ratio ~0.86, lev=6
+    entities = [_make_discovery("elder spirit totem"), _make_discovery("elder spirits totem pole")]
+    result = _within_turn_dedup(entities)
+    assert len(result) == 1
+    names = [e["name"] for e in result]
+    assert "elder spirits totem pole" in names  # longer name kept
+
+
+def test_within_turn_dedup_no_false_merge_oaks_cloaks():
+    """'oaks' is a substring of 'cloaks of shadow' but not a token prefix -- no merge."""
+    entities = [_make_discovery("oaks"), _make_discovery("cloaks of shadow")]
+    result = _within_turn_dedup(entities)
+    assert len(result) == 2
+
+
+def test_within_turn_dedup_preserves_ordering():
+    """Result should preserve original entity ordering (non-new + new interleaved)."""
+    entities = [
+        _make_discovery("existing-npc", is_new=False),
+        _make_discovery("elder"),
+        _make_discovery("another-npc", is_new=False),
+        _make_discovery("eldorman"),
+    ]
+    result = _within_turn_dedup(entities)
+    names = [e["name"] for e in result]
+    # elder dropped, eldorman kept; non-new entities stay in original positions
+    assert names == ["existing-npc", "another-npc", "eldorman"]
+
+
+def test_within_turn_dedup_cascade_drop():
+    """If A is dropped because of B, A should not cause further drops against C."""
+    entities = [
+        _make_discovery("camp"),
+        _make_discovery("camping grounds"),
+        _make_discovery("forest clearing"),
+    ]
+    result = _within_turn_dedup(entities)
+    names = [e["name"] for e in result]
+    assert "camp" not in names
+    assert "camping grounds" in names
+    assert "forest clearing" in names
+    assert len(result) == 2

--- a/tests/test_run8_followup.py
+++ b/tests/test_run8_followup.py
@@ -983,3 +983,97 @@ class TestPCAliasFalsePositives:
         assert "char-anya" not in merged
         # 1 original PC + 5 non-merged entities = 6 remain
         assert len(catalogs["characters.json"]) == 6
+
+
+# ---------------------------------------------------------------------------
+# #364 — PC alias token match
+# ---------------------------------------------------------------------------
+
+class TestPCAliasTokenMatch:
+    """Verify _merge_pc_aliases() token-match rescue merges PC alias forks."""
+
+    def test_token_match_fenouille_moonwind(self):
+        """'Fenouille Moonwind' with PC alias 'Fenouille' and zero events → merge."""
+        catalogs = {
+            "characters.json": [
+                {
+                    **_make_entity("char-player", "Player Character", "turn-001"),
+                    "stable_attributes": {
+                        "aliases": {"value": ["Fenouille"], "source_turn": "turn-001"},
+                    },
+                },
+                _make_entity("char-fenouille-moonwind", "Fenouille Moonwind",
+                             "turn-059", "turn-059"),
+            ]
+        }
+        # Candidate name does NOT appear >=2 times in PC text (no occurrence rescue)
+        events = [
+            _make_event("evt-1", "The druid enters the cave", ["char-player"], "turn-100"),
+        ]
+        merged = _merge_pc_aliases(catalogs, events, "")
+        assert "char-fenouille-moonwind" in merged
+        assert len(catalogs["characters.json"]) == 1
+
+    def test_token_match_with_independent_events_no_merge(self):
+        """Token match but candidate has independent events → don't merge."""
+        catalogs = {
+            "characters.json": [
+                {
+                    **_make_entity("char-player", "Player Character", "turn-001"),
+                    "stable_attributes": {
+                        "aliases": {"value": ["Fenouille"], "source_turn": "turn-001"},
+                    },
+                },
+                _make_entity("char-fenouille-moonwind", "Fenouille Moonwind",
+                             "turn-059", "turn-059"),
+            ]
+        }
+        events = [
+            _make_event("evt-1", "The druid enters the cave", ["char-player"], "turn-100"),
+            # Independent events (without char-player)
+            _make_event("evt-2", "Fenouille Moonwind speaks to the elder",
+                        ["char-fenouille-moonwind"], "turn-101"),
+        ]
+        merged = _merge_pc_aliases(catalogs, events, "")
+        assert "char-fenouille-moonwind" not in merged
+        assert len(catalogs["characters.json"]) == 2
+
+    def test_short_token_no_match(self):
+        """Token 'Mo' is < 4 chars → should not trigger token match."""
+        catalogs = {
+            "characters.json": [
+                {
+                    **_make_entity("char-player", "Player Character", "turn-001"),
+                    "stable_attributes": {
+                        "aliases": {"value": ["Mo"], "source_turn": "turn-001"},
+                    },
+                },
+                _make_entity("char-mo-nightwalker", "Mo Nightwalker",
+                             "turn-059", "turn-059"),
+            ]
+        }
+        events = [
+            _make_event("evt-1", "The druid enters the cave", ["char-player"], "turn-100"),
+        ]
+        merged = _merge_pc_aliases(catalogs, events, "")
+        assert "char-mo-nightwalker" not in merged
+
+    def test_non_alias_token_no_match(self):
+        """'Elder' is not a PC alias — should not trigger token match."""
+        catalogs = {
+            "characters.json": [
+                {
+                    **_make_entity("char-player", "Player Character", "turn-001"),
+                    "stable_attributes": {
+                        "aliases": {"value": ["Fenouille"], "source_turn": "turn-001"},
+                    },
+                },
+                _make_entity("char-the-elder", "The Elder",
+                             "turn-016", "turn-016"),
+            ]
+        }
+        events = [
+            _make_event("evt-1", "The druid enters the cave", ["char-player"], "turn-100"),
+        ]
+        merged = _merge_pc_aliases(catalogs, events, "")
+        assert "char-the-elder" not in merged

--- a/tests/test_type_classification.py
+++ b/tests/test_type_classification.py
@@ -100,3 +100,29 @@ class TestValidLocationNotRejected:
 
     def test_dense_forest_not_rejected(self):
         assert not _is_misclassified_location({"name": "dense forest", "type": "location"})
+
+
+class TestPossessivePrefixLocationRejected:
+    """Possessive-pronoun prefixed location names are body parts, not locations (#363)."""
+
+    def test_his_lips_rejected(self):
+        assert _is_misclassified_location({"name": "his lips", "type": "location"})
+
+    def test_his_shoulders_rejected(self):
+        assert _is_misclassified_location({"name": "his shoulders", "type": "location"})
+
+    def test_her_hands_rejected(self):
+        assert _is_misclassified_location({"name": "her hands", "type": "location"})
+
+    def test_their_backs_rejected(self):
+        assert _is_misclassified_location({"name": "their backs", "type": "location"})
+
+    def test_my_kingdom_rejected(self):
+        assert _is_misclassified_location({"name": "my kingdom", "type": "location"})
+
+    def test_frigid_woods_not_rejected(self):
+        assert not _is_misclassified_location({"name": "frigid woods", "type": "location"})
+
+    def test_historic_building_not_rejected(self):
+        """'historic' starts with 'his' as substring but not as a word."""
+        assert not _is_misclassified_location({"name": "historic building", "type": "location"})

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -1602,6 +1602,10 @@ def _get_non_character_names() -> set[str]:
 # Names that are clearly non-spatial and should never be type "location"
 _NON_LOCATION_NAMES = {"feast", "celebration", "fragment", "birth", "death"}
 
+# Possessive-pronoun prefix — location names starting with these are body parts
+# or personal attributes, not real locations (#363)
+_POSSESSIVE_PREFIX_RE = re.compile(r"^(?:his|her|their|my|your|its)\s+", re.IGNORECASE)
+
 
 def _strip_leading_article(name: str) -> str:
     """Strip leading 'the', 'a', 'an' from a name for blocklist matching."""
@@ -1640,6 +1644,9 @@ def _is_misclassified_location(entity: dict) -> bool:
     stripped = _strip_leading_article(name).strip()
     if name in _NON_LOCATION_NAMES or stripped in _NON_LOCATION_NAMES:
         return True
+    # Reject possessive-pronoun prefixed names (body parts / personal attributes) (#363)
+    if _POSSESSIVE_PREFIX_RE.match(name):
+        return True
     return False
 
 
@@ -1657,6 +1664,80 @@ def _is_misclassified_item(entity: dict) -> bool:
     if _ABSTRACT_ITEM_RE.search(name):
         return True
     return False
+
+
+def _within_turn_dedup(entities: list[dict]) -> list[dict]:
+    """Deduplicate is_new entities discovered in the same turn (#365).
+
+    For each pair of is_new=True entities, checks:
+    - Character substring: name_a (lowered, >=4 chars) is substring of name_b, or vice versa
+    - Levenshtein distance <= 3
+    - SequenceMatcher ratio >= 0.6
+
+    Keeps the entity with the longer name (more specific).
+    """
+    from difflib import SequenceMatcher
+
+    new_entities = [e for e in entities if e.get("is_new", False)]
+    non_new = [e for e in entities if not e.get("is_new", False)]
+
+    if len(new_entities) < 2:
+        return entities
+
+    # Track which indices to drop (keep the longer-named entity)
+    drop_indices: set[int] = set()
+
+    for i in range(len(new_entities)):
+        if i in drop_indices:
+            continue
+        name_a = new_entities[i].get("name", "").strip().lower()
+        if not name_a:
+            continue
+        for j in range(i + 1, len(new_entities)):
+            if j in drop_indices:
+                continue
+            name_b = new_entities[j].get("name", "").strip().lower()
+            if not name_b:
+                continue
+
+            matched = False
+
+            # Check 1: Character substring (both names >= 4 chars)
+            if len(name_a) >= 4 and len(name_b) >= 4:
+                if name_a in name_b or name_b in name_a:
+                    matched = True
+
+            # Check 2: Levenshtein distance <= 3
+            if not matched:
+                dist = _levenshtein(name_a, name_b)
+                if dist <= 3:
+                    matched = True
+
+            # Check 3: SequenceMatcher ratio >= 0.6
+            if not matched:
+                ratio = SequenceMatcher(None, name_a, name_b).ratio()
+                if ratio >= 0.6:
+                    matched = True
+
+            if matched:
+                # Drop the shorter name, keep the longer (more specific)
+                if len(name_a) >= len(name_b):
+                    drop_idx = j
+                    keep_name = name_a
+                    drop_name = name_b
+                else:
+                    drop_idx = i
+                    keep_name = name_b
+                    drop_name = name_a
+                drop_indices.add(drop_idx)
+                print(
+                    f"  WITHIN-TURN DEDUP: dropping '{drop_name}' "
+                    f"in favor of '{keep_name}'",
+                    file=sys.stderr,
+                )
+
+    kept = [e for idx, e in enumerate(new_entities) if idx not in drop_indices]
+    return non_new + kept
 
 
 def _build_catalog_name_index(catalogs: dict) -> dict[str, dict]:
@@ -2358,6 +2439,9 @@ def extract_and_merge(
             continue
         _cross_catalog_filtered.append(entity_ref)
     qualified = _cross_catalog_filtered
+
+    # Within-turn dedup: merge similar is_new entities from same turn (#365)
+    qualified = _within_turn_dedup(qualified)
 
     # --- Pre-compute task inputs for phases 2-4 ---
 
@@ -3075,6 +3159,26 @@ def _dedup_catalogs(catalogs: dict) -> tuple[int, dict[str, str]]:
                         union(idx_a, idx_b)
                         print(f"  DEDUP (token-overlap): linking '{name_a}' and '{name_b}' as duplicates")
                         continue
+
+                # Rule 2b: Character-level substring containment (#365)
+                # If the shorter normalized name (>=4 chars) is a character
+                # substring of the longer name AND is a prefix of at least one
+                # token in the longer name, merge them. This catches name
+                # variants like elder/eldorman and camp/camping grounds without
+                # false-merging coincidental substrings like ring/spring.
+                if len(name_a) >= 4 and len(name_b) >= 4:
+                    if name_a in name_b or name_b in name_a:
+                        shorter = name_a if len(name_a) <= len(name_b) else name_b
+                        longer = name_b if len(name_a) <= len(name_b) else name_a
+                        longer_tokens = longer.replace("-", " ").split()
+                        # Shorter must NOT be a standalone token AND must be
+                        # a prefix of at least one token in the longer name
+                        if shorter not in longer_tokens and any(
+                            t.startswith(shorter) for t in longer_tokens
+                        ):
+                            union(idx_a, idx_b)
+                            print(f"  DEDUP (char-substring): linking '{name_a}' and '{name_b}' as duplicates")
+                            continue
 
                 # Rule 3: ID stem overlap (hyphen-segment containment)
                 # Guard: require smaller stem set to have at least 2 segments
@@ -3903,6 +4007,17 @@ def _merge_pc_aliases(
             pc_cooccurring_ids.update(rel)
     pc_cooccurring_ids.discard("char-player")
 
+    # Build set of known PC aliases for token-match rescue (#364)
+    _pc_alias_set: set[str] = set()
+    _pc_sa = pc_entry.get("stable_attributes", {})
+    _pc_aliases_attr = _pc_sa.get("aliases")
+    if isinstance(_pc_aliases_attr, dict):
+        _alias_val = _pc_aliases_attr.get("value", [])
+        if isinstance(_alias_val, list):
+            _pc_alias_set = {a.strip().lower() for a in _alias_val if isinstance(a, str) and a.strip()}
+        elif isinstance(_alias_val, str) and _alias_val:
+            _pc_alias_set = {a.strip().lower() for a in _alias_val.split(",") if a.strip()}
+
     for entity in list(entities):
         eid = entity.get("id", "")
         if eid == "char-player" or not eid:
@@ -3928,8 +4043,17 @@ def _merge_pc_aliases(
         # to avoid matching substrings inside larger words or names.
         name_pattern = r"(?<!\w)" + re.escape(name) + r"(?!\w)"
         occurrences = len(re.findall(name_pattern, pc_text, re.IGNORECASE))
+        _token_rescued = False
         if occurrences < 2:
-            continue
+            # Rescue via PC alias token match (#364): if a name token matches
+            # a known PC alias (>=4 chars, capitalized), allow the merge.
+            if _pc_alias_set:
+                for token in name.split():
+                    if len(token) >= 4 and token[0].isupper() and token.lower() in _pc_alias_set:
+                        _token_rescued = True
+                        break
+            if not _token_rescued:
+                continue
 
         # Check candidate has minimal data (≤3 turns span)
         first = entity.get("first_seen_turn", "")
@@ -3983,6 +4107,9 @@ def _merge_pc_aliases(
                         _independent_event_counts.get(ref_eid, 0) + 1
                     )
         independent_refs = _independent_event_counts.get(eid, 0)
+        # Token-rescued candidates require zero independent events (#364)
+        if _token_rescued and independent_refs > 0:
+            continue
         if independent_refs >= 2:
             continue
 

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -1670,42 +1670,53 @@ def _within_turn_dedup(entities: list[dict]) -> list[dict]:
     """Deduplicate is_new entities discovered in the same turn (#365).
 
     For each pair of is_new=True entities, checks:
-    - Character substring: name_a (lowered, >=4 chars) is substring of name_b, or vice versa
+    - Character substring with token-prefix guard: the shorter name (>=4 chars)
+      must be a prefix of a token in the longer name (prevents false merges like
+      fire/fireplace)
     - Levenshtein distance <= 3
     - SequenceMatcher ratio >= 0.6
 
     Keeps the entity with the longer name (more specific).
+    Preserves original entity ordering.
     """
     from difflib import SequenceMatcher
 
-    new_entities = [e for e in entities if e.get("is_new", False)]
-    non_new = [e for e in entities if not e.get("is_new", False)]
+    # Build index of which positions in *entities* are is_new
+    new_indices = [i for i, e in enumerate(entities) if e.get("is_new", False)]
 
-    if len(new_entities) < 2:
+    if len(new_indices) < 2:
         return entities
 
-    # Track which indices to drop (keep the longer-named entity)
+    # Track which original indices to drop
     drop_indices: set[int] = set()
 
-    for i in range(len(new_entities)):
-        if i in drop_indices:
+    for ni in range(len(new_indices)):
+        idx_a = new_indices[ni]
+        if idx_a in drop_indices:
             continue
-        name_a = new_entities[i].get("name", "").strip().lower()
+        name_a = entities[idx_a].get("name", "").strip().lower()
         if not name_a:
             continue
-        for j in range(i + 1, len(new_entities)):
-            if j in drop_indices:
+        for nj in range(ni + 1, len(new_indices)):
+            idx_b = new_indices[nj]
+            if idx_b in drop_indices:
                 continue
-            name_b = new_entities[j].get("name", "").strip().lower()
+            name_b = entities[idx_b].get("name", "").strip().lower()
             if not name_b:
                 continue
 
             matched = False
 
-            # Check 1: Character substring (both names >= 4 chars)
+            # Check 1: Character substring with token-prefix guard (both >= 4 chars)
             if len(name_a) >= 4 and len(name_b) >= 4:
                 if name_a in name_b or name_b in name_a:
-                    matched = True
+                    shorter = name_a if len(name_a) <= len(name_b) else name_b
+                    longer = name_b if len(name_a) <= len(name_b) else name_a
+                    longer_tokens = longer.replace("-", " ").split()
+                    # Token-prefix guard: shorter must be a prefix of at least
+                    # one token in the longer name (matches _dedup_catalogs 2b)
+                    if any(t.startswith(shorter) for t in longer_tokens):
+                        matched = True
 
             # Check 2: Levenshtein distance <= 3
             if not matched:
@@ -1722,11 +1733,11 @@ def _within_turn_dedup(entities: list[dict]) -> list[dict]:
             if matched:
                 # Drop the shorter name, keep the longer (more specific)
                 if len(name_a) >= len(name_b):
-                    drop_idx = j
+                    drop_idx = idx_b
                     keep_name = name_a
                     drop_name = name_b
                 else:
-                    drop_idx = i
+                    drop_idx = idx_a
                     keep_name = name_b
                     drop_name = name_a
                 drop_indices.add(drop_idx)
@@ -1735,9 +1746,11 @@ def _within_turn_dedup(entities: list[dict]) -> list[dict]:
                     f"in favor of '{keep_name}'",
                     file=sys.stderr,
                 )
+                # If outer entity was dropped, stop comparing it
+                if drop_idx == idx_a:
+                    break
 
-    kept = [e for idx, e in enumerate(new_entities) if idx not in drop_indices]
-    return non_new + kept
+    return [e for i, e in enumerate(entities) if i not in drop_indices]
 
 
 def _build_catalog_name_index(catalogs: dict) -> dict[str, dict]:


### PR DESCRIPTION
## Summary

Three independent extraction quality improvements from the B70 175-turn quality assessment.

## Issue #363 — Possessive-pronoun prefix rejection for locations

Adds a possessive-pronoun prefix regex check to `_is_misclassified_location()`. Location names starting with his/her/their/my/your/its followed by a space are rejected. Catches `loc-lips` ("his lips") and similar body-part-as-location misclassifications.

## Issue #364 — PC alias token match

Adds a token-match rescue to `_merge_pc_aliases()`. When a candidate entity fails the normal occurrence threshold (< 2 mentions in PC text), it can still be merged if:
- A token in the candidate name (>= 4 chars, capitalized) matches a known PC alias (case-insensitive)
- The candidate has zero independent events (no event references it without also referencing char-player)

Catches `char-fenouille-moonwind` where "Fenouille" was already a known PC alias but the full name didn't appear frequently enough in PC event text.

## Issue #365 — Within-turn dedup at discovery time

Adds `_within_turn_dedup()` that checks same-turn `is_new` entities for:
- Character substring matches (both names >= 4 chars)
- Levenshtein distance <= 3
- SequenceMatcher ratio >= 0.6

Keeps the longer/more specific name. Also adds a character-level substring check (Rule 2b) to `_dedup_catalogs()` fuzzy pass — merges entities when the shorter name is a prefix of a token in the longer name (e.g., "star"/"starlight") but not when it's a standalone token (e.g., "bowl"/"steaming bowl").

Closes #363
Closes #364
Closes #365
