### PR TITLE
fix: add end-of-loop checkpoint to prevent entity loss on interruption

### DIFF
--- a/tests/test_checkpoint_persistence.py
+++ b/tests/test_checkpoint_persistence.py
@@ -375,3 +375,60 @@ class TestResumeLoadsPersisted:
         ids = {e["id"] for e in chars}
         assert "char-alpha" in ids, "Pre-existing entity char-alpha not loaded on resume"
         assert "char-beta" in ids, "Pre-existing entity char-beta not loaded on resume"
+
+
+# ---------------------------------------------------------------------------
+# Non-segmented path: end-of-loop checkpoint (#379)
+# ---------------------------------------------------------------------------
+
+class TestEndOfLoopCheckpoint:
+    """Verify the unconditional save after the main extraction loop."""
+
+    def test_end_of_loop_checkpoint_saves_when_under_interval(self, tmp_path):
+        """save_catalogs must be called after the loop even when fewer than
+        checkpoint_interval turns are processed (no modulo checkpoint fired)."""
+        session_dir, framework_dir, catalog_dir = _setup_session(tmp_path)
+
+        def mock_extract_and_merge(turn, catalogs, events, llm, min_conf, catalog_dir=None, **kwargs):
+            catalogs["characters.json"].append(
+                _make_entity(f"char-eol-{len(catalogs['characters.json']) + 1}",
+                             f"EolEnt {len(catalogs['characters.json'])}")
+            )
+            return catalogs, events, False, {}
+
+        turns = _make_turns(1, 5)  # 5 turns, checkpoint_interval=25 → no modulo checkpoint
+
+        save_calls = []
+
+        def tracking_save(cdir, cats, **kw):
+            save_calls.append(sum(len(v) for v in cats.values()))
+
+        with patch("semantic_extraction.LLMClient") as mock_llm_cls, \
+             patch("semantic_extraction.extract_and_merge", side_effect=mock_extract_and_merge), \
+             patch("semantic_extraction._ensure_player_character"), \
+             patch("semantic_extraction.find_stale_entities", return_value=[]), \
+             patch("semantic_extraction.save_catalogs", side_effect=tracking_save), \
+             patch("semantic_extraction.save_events"), \
+             patch("semantic_extraction.save_timeline"), \
+             patch("semantic_extraction.cleanup_dangling_relationships", return_value={}), \
+             patch("semantic_extraction._post_batch_orphan_sweep", return_value=0), \
+             patch("semantic_extraction._name_mention_discovery", return_value=0), \
+             patch("semantic_extraction.load_catalogs", return_value=_empty_catalogs()), \
+             patch("semantic_extraction.load_events", return_value=[]), \
+             patch("semantic_extraction.load_timeline", return_value=[]):
+            mock_llm_cls.return_value = MagicMock(config={"checkpoint_interval": 25})
+
+            from semantic_extraction import extract_semantic_batch
+            extract_semantic_batch(
+                turns, session_dir, framework_dir=framework_dir,
+                config_path="unused",
+            )
+
+        # With 5 turns and checkpoint_interval=25, no modulo checkpoint fires.
+        # The end-of-loop checkpoint (#379) must still call save_catalogs.
+        assert len(save_calls) >= 1, (
+            "save_catalogs was never called — end-of-loop checkpoint missing"
+        )
+        assert save_calls[0] == 5, (
+            f"Expected 5 entities at end-of-loop save, got {save_calls[0]}"
+        )

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -5754,6 +5754,13 @@ def extract_semantic_batch(
                 save_events(catalog_dir, events_list)
                 save_timeline(catalog_dir, timeline)
 
+    # --- End-of-loop checkpoint: ensure entities survive if process is killed during
+    # post-batch passes (refresh, dedup, orphan sweep, etc.) (#379)
+    if not dry_run and turn_dicts:
+        save_catalogs(catalog_dir, catalogs)
+        save_events(catalog_dir, events_list)
+        save_timeline(catalog_dir, timeline)
+
     # Shut down the discovery prefetch executor
     if _prefetch_executor is not None:
         _prefetch_executor.shutdown(wait=False)


### PR DESCRIPTION
## Summary

Adds an unconditional catalog save after the main extraction loop exits, before post-batch passes begin. This prevents entity data loss when extraction is interrupted during the post-batch dedup/refresh/cleanup phase or when fewer than `checkpoint_interval` turns are processed.

## Root Cause

The modulo checkpoint in `extract_semantic_batch` only fires when `(i + 1) % checkpoint_interval == 0` (default 25). If the extraction processes fewer than 25 turns, no checkpoint is triggered during the loop. The final save at the bottom of the function is unreachable if the process is killed during post-batch passes (refresh, dedup, orphan sweep).

## Fix

Added a 4-line end-of-loop checkpoint (guarded by `not dry_run and turn_dicts`) immediately after the main extraction loop exits and before the discovery prefetch executor shutdown. This ensures all discovered entities are persisted to disk before any post-batch processing begins.

Closes #379
