### PR TITLE
docs: route arclight infra tasks to b70-optimizer

### DIFF
--- a/.github/agents/b70-optimizer.agent.md
+++ b/.github/agents/b70-optimizer.agent.md
@@ -31,6 +31,7 @@ Choose the backend based on model availability and workload. Advise other agents
   - https://github.com/huggingface/optimum-intel
   - https://github.com/openvinotoolkit/openvino
 - Diagnose performance regressions and timeout issues
+- Manage arclight server lifecycle: start/stop/restart LLM servers, SSH admin tasks, OS shutdown/reboot for hardware maintenance
 - Document optimal configurations in `config/` and `docs/`
 
 ## Constraints
@@ -49,6 +50,17 @@ Choose the backend based on model availability and workload. Advise other agents
 - Baseline (single B70, llama-server): 52.7 tok/s, ~18s/turn, ~2h for 344 turns
 - qwen3.5 INT4 on OpenVINO: BROKEN (linear attention weight corruption) — use INT8 or FP16
 - Use `skip_response_format: true` in llm.json
+
+## Server Administration
+
+- **Host**: arclight (192.168.10.169)
+- **SSH accounts**: `nse-agent` (no sudo), `david` (sudo, requires `-t` for TTY)
+- **LLM server binary**: `/home/nse-agent/llama-b9127-vulkan/llama-b9127/llama-server`
+- **Model path**: `/home/nse-agent/models/Qwen3.5-9B-Q4_K_M.gguf`
+- **Ports**: 8000 (Vulkan0), 8001 (Vulkan1)
+- **Launch flags**: `-m <model> --port <port> -np 1 --reasoning off --reasoning-format none -c 32768 --host 0.0.0.0 -ngl 999 --split-mode none --device Vulkan{0,1}`
+- **Shutdown**: `ssh -t david@arclight "sudo shutdown now"` (requires interactive password)
+- **Health check**: `Invoke-RestMethod -Uri "http://192.168.10.169:{8000,8001}/health"`
 
 ## Output Format
 

--- a/.github/agents/coordinator.agent.md
+++ b/.github/agents/coordinator.agent.md
@@ -53,13 +53,17 @@ You are the central coordinator for narrative-state-engine. You are the human's 
 | "Automate VS Code agent interactions" | @automation-engineer |
 | "Fix broken selectors after VS Code update" | @automation-engineer |
 | "Build CrewAI → VS Code bridge" | @automation-engineer + @developer (Python side) |
+| "Restart/stop/start LLM servers on arclight" | @b70-optimizer |
+| "Shut down / reboot arclight" | @b70-optimizer |
+| "Check server health / SSH admin tasks" | @b70-optimizer |
+| "Restart/stop/start LLM servers on RTX box" | @rtx4070-optimizer |
 
 ## Scheduling / Long Waits
 
 When monitoring long-running processes (extraction runs, benchmarks):
 - Use the `wait` MCP tool instead of repeatedly dispatching subagents to check status
 - Pattern: estimate remaining time, wait for ~80% of it, then dispatch a status check subagent
-- Example: if extraction ETA is 2 hours, call `wait(seconds=5400, message="extraction run ~2h")`, then dispatch @developer to check progress
+- Example: if extraction ETA is 2 hours, call `wait(seconds=5400, message="extraction run ~2h")`, then dispatch @extraction-specialist to check progress
 - Max wait: 4 hours (14400 seconds)
 
 ## Output Format


### PR DESCRIPTION
## Summary

Squad retrospective: arclight infrastructure tasks (server start/stop, SSH shutdown, health checks) were being routed to @developer, which had to rediscover server paths, launch flags, and SSH accounts every time. The @b70-optimizer has this domain knowledge and should own these tasks.

## Changes

### coordinator.agent.md
- Added 4 rows to decision matrix routing server lifecycle/SSH/health tasks to hardware specialists
- Fixed scheduling example to reference @extraction-specialist instead of @developer for extraction status checks

### b70-optimizer.agent.md
- Added "Manage arclight server lifecycle" to Responsibilities
- Added new "Server Administration" section documenting:
  - Host, SSH accounts, and privilege levels
  - LLM server binary path and model path
  - Port assignments and device mapping
  - Launch flags
  - Shutdown and health check commands
