### PR TITLE
fix: reject abstract/concept names when creating character stubs

### DIFF
--- a/tests/test_stub_character_filter.py
+++ b/tests/test_stub_character_filter.py
@@ -1,0 +1,226 @@
+"""Tests for _is_plausible_character_name stub filter and its integration
+with _post_batch_orphan_sweep and _name_mention_discovery (#stub-filter).
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from semantic_extraction import (
+    _is_plausible_character_name,
+    _post_batch_orphan_sweep,
+    _name_mention_discovery,
+)
+
+
+# ---------------------------------------------------------------------------
+# _is_plausible_character_name unit tests
+# ---------------------------------------------------------------------------
+
+class TestIsPlausibleCharacterName:
+    """Tests for _is_plausible_character_name()."""
+
+    # Words that are clearly not character names ─────────────────────────────
+
+    def test_rejects_abstract_noun_echo(self):
+        assert _is_plausible_character_name("echo") is False
+
+    def test_rejects_abstract_noun_pattern(self):
+        assert _is_plausible_character_name("pattern") is False
+
+    def test_rejects_abstract_noun_weave(self):
+        assert _is_plausible_character_name("weave") is False
+
+    def test_rejects_abstract_noun_song(self):
+        assert _is_plausible_character_name("song") is False
+
+    def test_rejects_abstract_noun_precision(self):
+        assert _is_plausible_character_name("precision") is False
+
+    def test_rejects_abstract_noun_disruption(self):
+        assert _is_plausible_character_name("disruption") is False
+
+    def test_rejects_adjective_quiet(self):
+        assert _is_plausible_character_name("quiet") is False
+
+    def test_rejects_adjective_broken(self):
+        assert _is_plausible_character_name("broken") is False
+
+    def test_rejects_adjective_triangular(self):
+        assert _is_plausible_character_name("triangular") is False
+
+    def test_rejects_noun_field(self):
+        assert _is_plausible_character_name("field") is False
+
+    def test_rejects_directional_southern(self):
+        assert _is_plausible_character_name("southern") is False
+
+    def test_rejects_directional_northern(self):
+        assert _is_plausible_character_name("northern") is False
+
+    def test_rejects_directional_eastern(self):
+        assert _is_plausible_character_name("eastern") is False
+
+    def test_rejects_directional_western(self):
+        assert _is_plausible_character_name("western") is False
+
+    def test_rejects_number_word_two(self):
+        assert _is_plausible_character_name("two") is False
+
+    def test_rejects_generic_stem_shadow(self):
+        """Words in _GENERIC_STEMS are rejected."""
+        assert _is_plausible_character_name("shadow") is False
+
+    def test_rejects_generic_stem_figure(self):
+        assert _is_plausible_character_name("figure") is False
+
+    def test_rejects_group_noun_scouts(self):
+        assert _is_plausible_character_name("scouts") is False
+
+    # Case-insensitive handling ───────────────────────────────────────────────
+
+    def test_rejects_mixed_case_abstract(self):
+        assert _is_plausible_character_name("Echo") is False
+
+    def test_rejects_uppercase_abstract(self):
+        assert _is_plausible_character_name("PATTERN") is False
+
+    # Words that ARE plausible character names ────────────────────────────────
+
+    def test_accepts_proper_name_kael(self):
+        assert _is_plausible_character_name("kael") is True
+
+    def test_accepts_proper_name_maelis(self):
+        assert _is_plausible_character_name("maelis") is True
+
+    def test_accepts_proper_name_thorne(self):
+        assert _is_plausible_character_name("thorne") is True
+
+    def test_accepts_proper_name_lyra(self):
+        assert _is_plausible_character_name("lyra") is True
+
+    def test_accepts_multi_word_name(self):
+        """Multi-word stems (e.g. from hyphenated IDs) pass through."""
+        assert _is_plausible_character_name("iron wolf") is True
+
+
+# ---------------------------------------------------------------------------
+# Integration: _post_batch_orphan_sweep rejects abstract character stubs
+# ---------------------------------------------------------------------------
+
+def _make_events(entity_ids: list[str], count: int = 4) -> list[dict]:
+    """Return a minimal events list where each id appears *count* times."""
+    events = []
+    for i in range(count):
+        events.append({
+            "id": f"event-{i}",
+            "turn_id": f"turn-{i+1:03d}",
+            "related_entities": entity_ids,
+        })
+    return events
+
+
+class TestPostBatchOrphanSweepFilter:
+    """_post_batch_orphan_sweep should not create stubs for abstract names."""
+
+    def test_rejects_char_echo(self):
+        catalogs: dict = {}
+        events = _make_events(["char-echo"])
+        _post_batch_orphan_sweep(catalogs, events)
+        chars = catalogs.get("characters.json", [])
+        assert not any(e["id"] == "char-echo" for e in chars)
+
+    def test_rejects_char_pattern(self):
+        catalogs: dict = {}
+        events = _make_events(["char-pattern"])
+        _post_batch_orphan_sweep(catalogs, events)
+        chars = catalogs.get("characters.json", [])
+        assert not any(e["id"] == "char-pattern" for e in chars)
+
+    def test_rejects_char_southern(self):
+        catalogs: dict = {}
+        events = _make_events(["char-southern"])
+        _post_batch_orphan_sweep(catalogs, events)
+        chars = catalogs.get("characters.json", [])
+        assert not any(e["id"] == "char-southern" for e in chars)
+
+    def test_rejects_char_scouts(self):
+        catalogs: dict = {}
+        events = _make_events(["char-scouts"])
+        _post_batch_orphan_sweep(catalogs, events)
+        chars = catalogs.get("characters.json", [])
+        assert not any(e["id"] == "char-scouts" for e in chars)
+
+    def test_accepts_valid_character_id(self):
+        """A legitimate character ID like char-kael should still be stubbed."""
+        catalogs: dict = {}
+        events = _make_events(["char-kael"])
+        _post_batch_orphan_sweep(catalogs, events)
+        chars = catalogs.get("characters.json", [])
+        assert any(e["id"] == "char-kael" for e in chars)
+
+    def test_non_character_abstract_id_not_filtered(self):
+        """Abstract ID with non-character prefix (loc-) is unaffected by char filter."""
+        catalogs: dict = {}
+        events = _make_events(["loc-southern"], count=2)
+        _post_batch_orphan_sweep(catalogs, events)
+        locs = catalogs.get("locations.json", [])
+        assert any(e["id"] == "loc-southern" for e in locs)
+
+
+# ---------------------------------------------------------------------------
+# Integration: _name_mention_discovery rejects abstract capitalized words
+# ---------------------------------------------------------------------------
+
+def _make_desc_events(words: list[str], count: int = 3) -> list[dict]:
+    """Return events whose descriptions each contain the given capitalized words."""
+    events = []
+    for i in range(count):
+        desc = " ".join(words) + f" did something in event {i}."
+        events.append({
+            "id": f"event-{i}",
+            "turn_id": f"turn-{i+1:03d}",
+            "description": desc,
+            "related_entities": [],
+        })
+    return events
+
+
+class TestNameMentionDiscoveryFilter:
+    """_name_mention_discovery should not create stubs for abstract words."""
+
+    def test_rejects_capitalized_echo(self):
+        catalogs: dict = {}
+        events = _make_desc_events(["Echo"])
+        _name_mention_discovery(catalogs, events)
+        chars = catalogs.get("characters.json", [])
+        assert not any(e["id"] == "char-echo" for e in chars)
+
+    def test_rejects_capitalized_pattern(self):
+        catalogs: dict = {}
+        events = _make_desc_events(["Pattern"])
+        _name_mention_discovery(catalogs, events)
+        chars = catalogs.get("characters.json", [])
+        assert not any(e["id"] == "char-pattern" for e in chars)
+
+    def test_rejects_capitalized_southern(self):
+        catalogs: dict = {}
+        events = _make_desc_events(["Southern"])
+        _name_mention_discovery(catalogs, events)
+        chars = catalogs.get("characters.json", [])
+        assert not any(e["id"] == "char-southern" for e in chars)
+
+    def test_rejects_generic_stem_shadow(self):
+        catalogs: dict = {}
+        events = _make_desc_events(["Shadow"])
+        _name_mention_discovery(catalogs, events)
+        chars = catalogs.get("characters.json", [])
+        assert not any(e["id"] == "char-shadow" for e in chars)
+
+    def test_accepts_proper_character_name(self):
+        """A capitalized proper name that isn't blocked should create a stub."""
+        catalogs: dict = {}
+        events = _make_desc_events(["Maelis"])
+        _name_mention_discovery(catalogs, events)
+        chars = catalogs.get("characters.json", [])
+        assert any(e["id"] == "char-maelis" for e in chars)

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -1847,6 +1847,35 @@ _PC_ALIAS_WORD_BLOCKLIST = {
     "guard", "scout", "shaman", "merchant", "captain",
 }
 
+# Single-word stems that are clearly not character names: directional adjectives
+# and generic group nouns not already covered by _PC_ALIAS_WORD_BLOCKLIST or
+# _GENERIC_STEMS.  Used by _is_plausible_character_name().
+_ABSTRACT_CHAR_STEM_BLOCKLIST: frozenset[str] = frozenset({
+    # Cardinal / directional adjectives
+    "northern", "eastern", "western", "central",
+    # Generic plural role nouns not in _GENERIC_STEMS
+    "scouts",
+})
+
+
+def _is_plausible_character_name(name: str) -> bool:
+    """Return True if *name* could plausibly be a character name.
+
+    Returns False for single abstract nouns, common adjectives, directional
+    words, and other patterns that are clearly not character names.  Checks
+    _GENERIC_STEMS, _ABSTRACT_CHAR_STEM_BLOCKLIST, and the derived
+    non-character-names set built from _PC_ALIAS_WORD_BLOCKLIST.
+    """
+    low = name.lower().strip()
+    if low in _GENERIC_STEMS:
+        return False
+    if low in _ABSTRACT_CHAR_STEM_BLOCKLIST:
+        return False
+    if low in _get_non_character_names():
+        return False
+    return True
+
+
 # Maximum volatile_state keys retained for PC after merge (#214)
 _PC_VOLATILE_STATE_MAX_KEYS = 30
 # Core volatile_state keys that are always preserved during pruning (#214)
@@ -1909,6 +1938,9 @@ def _create_orphan_stubs(catalogs: dict, events: list, turn_id: str,
 
         # Infer type and name from the ID
         inferred_type = _infer_type_from_prefix(eid)
+        # Skip abstract/concept single-word names for character stubs
+        if inferred_type == "character" and not _is_plausible_character_name(stem):
+            continue
         # Build a human-readable name: strip prefix, replace hyphens, title-case
         inferred_name = stem.replace("-", " ").title()
 
@@ -3370,6 +3402,9 @@ def _post_batch_orphan_sweep(catalogs: dict, events_list: list) -> int:
             continue
 
         inferred_type = _infer_type_from_prefix(eid)
+        # Skip abstract/concept single-word names for character stubs
+        if inferred_type == "character" and not _is_plausible_character_name(stem):
+            continue
 
         # Type-specific thresholds
         if inferred_type == "location":
@@ -3546,7 +3581,7 @@ def _name_mention_discovery(catalogs: dict, events_list: list) -> int:
             word_lower = word.lower()
             if word_lower in _NAME_MENTION_STOPWORDS:
                 continue
-            if word_lower in _GENERIC_STEMS:
+            if not _is_plausible_character_name(word_lower):
                 continue
             if word_lower in known_names:
                 continue


### PR DESCRIPTION
## Summary

The extraction pipeline was creating stub character entities from relationship mentions and capitalized words in event descriptions, including abstract/concept single-word names that are clearly not characters (e.g. `char-echo`, `char-pattern`, `char-weave`, `char-song`, `char-precision`, `char-field`, `char-quiet`, `char-southern`, `char-triangular`, `char-two`, `char-broken`, `char-disruption`, `char-scouts`).

## Root Cause

`_post_batch_orphan_sweep()`, `_create_orphan_stubs()`, and `_name_mention_discovery()` created character stubs from entity IDs and capitalized words without validating that the name is a plausible character name. These functions already filtered on `_GENERIC_STEMS` but `_PC_ALIAS_WORD_BLOCKLIST` (which contains most of the offending words) was not consulted.

## Fix

- Added `_ABSTRACT_CHAR_STEM_BLOCKLIST` — a small frozenset of directional adjectives (`northern`, `eastern`, `western`, `central`) and generic plural role nouns (`scouts`) not covered by existing sets.
- Added `_is_plausible_character_name(name: str) -> bool` helper that returns `False` when the name appears in `_GENERIC_STEMS`, `_ABSTRACT_CHAR_STEM_BLOCKLIST`, or the non-character names derived from `_PC_ALIAS_WORD_BLOCKLIST`.
- Applied the filter in all three stub-creation paths:
  - `_create_orphan_stubs` — per-turn event orphan stubs
  - `_post_batch_orphan_sweep` — post-dedup orphan stubs
  - `_name_mention_discovery` — capitalized-word scan stubs
- Added `tests/test_stub_character_filter.py` with 36 tests covering the helper directly and both sweep/discovery integration paths.

All 1671 existing tests continue to pass.
