### PR TITLE
fix: resume DM profiler from last_updated_turn on interrupted runs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1233,6 +1233,31 @@ python tools/dm_profile_analyzer.py --session sessions/session-001 --user-input 
 - **Incremental**: `ingest_turn.py --extract` updates the DM profile for each new DM turn.
 - **Analysis**: `analyze_next_move.py` includes the DM profile summary in the analysis output when `--framework` is specified.
 
+### Auto-Resume Behavior
+
+By default the tool **automatically resumes** from where it left off. When `--start-turn` is not specified, it reads `last_updated_turn` from the existing profile and starts from the next turn. This makes interrupted or incremental runs efficient — already-analyzed turns are never re-processed.
+
+```bash
+# First run: analyzes turns 1–50, profile saved with last_updated_turn = turn-050
+python tools/dm_profile_analyzer.py --session sessions/session-001
+
+# Second run: automatically resumes from turn-051
+python tools/dm_profile_analyzer.py --session sessions/session-001
+```
+
+To force a **full reanalysis** from the beginning, either pass `--start-turn 1` or delete the profile file:
+
+```bash
+# Force full reanalysis using --start-turn
+python tools/dm_profile_analyzer.py --session sessions/session-001 --start-turn 1
+
+# Or delete the profile to reset
+rm framework/dm-profile/dm-profile.json
+python tools/dm_profile_analyzer.py --session sessions/session-001
+```
+
+> **Note on partial failures**: if a batch fails mid-run (LLM extraction error), the watermark advances only through the last *consecutively* successful batch from the start. This prevents silently skipping failed turns on the next run — the failed range will be retried automatically on resume.
+
 ### Confidence Scores
 
 - Observations from single turns get lower confidence (0.3–0.5)

--- a/tests/test_dm_profile_analyzer.py
+++ b/tests/test_dm_profile_analyzer.py
@@ -15,6 +15,7 @@ from dm_profile_analyzer import (
     _empty_profile,
     _format_analysis_prompt,
     _parse_turn_number,
+    analyze_batch,
     analyze_dm_turns,
     list_dm_turns,
     load_dm_profile,
@@ -622,3 +623,201 @@ class TestSchemaCompliance:
 
         profile = _empty_profile()
         jsonschema.validate(instance=profile, schema=schema)
+
+
+# ---------------------------------------------------------------------------
+# Tests — analyze_batch auto-resume resilience (#fix-dm-profiler-resilience)
+# ---------------------------------------------------------------------------
+
+class MockLLMClientForBatch(MockLLMClient):
+    """Mock LLM that also exposes parallel_workers and config for analyze_batch."""
+    parallel_workers = 1
+    config = {}
+
+
+class TestAnalyzeBatchAutoResume:
+    """analyze_batch must resume from last_updated_turn when start_turn == 0."""
+
+    def _make_session(self, tmp_path, n_dm_turns: int, start: int = 1) -> str:
+        """Create a fake session with n_dm_turns DM transcript files."""
+        transcript_dir = tmp_path / "transcript"
+        transcript_dir.mkdir(parents=True, exist_ok=True)
+        for i in range(start, start + n_dm_turns):
+            (transcript_dir / f"turn-{i:03d}-dm.md").write_text(
+                f"DM turn {i} text.", encoding="utf-8"
+            )
+        return str(tmp_path)
+
+    def _make_profile(self, tmp_path, last_updated_turn: str) -> str:
+        """Write a profile with a given last_updated_turn and return its path."""
+        profile_dir = tmp_path / "framework" / "dm-profile"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        profile_path = profile_dir / "dm-profile.json"
+        profile = _empty_profile()
+        profile["last_updated_turn"] = last_updated_turn
+        profile["confidence"] = 0.5  # non-zero so it looks populated
+        profile_path.write_text(json.dumps(profile, indent=2), encoding="utf-8")
+        return str(tmp_path / "framework")
+
+    def test_auto_resume_skips_already_profiled_turns(self, tmp_path, monkeypatch):
+        """When profile has last_updated_turn=turn-005, batch starts from turn-006."""
+        session_dir = self._make_session(tmp_path / "session", n_dm_turns=10, start=1)
+        framework_dir = self._make_profile(tmp_path / "fw", last_updated_turn="turn-005")
+
+        collected_start_turns = []
+
+        original_list = list_dm_turns.__wrapped__ if hasattr(list_dm_turns, "__wrapped__") else None
+
+        import dm_profile_analyzer as _mod
+
+        original_list_dm_turns = _mod.list_dm_turns
+
+        def spy_list_dm_turns(sd, start_turn=0, max_turns=0):
+            collected_start_turns.append(start_turn)
+            return original_list_dm_turns(sd, start_turn=start_turn, max_turns=max_turns)
+
+        monkeypatch.setattr(_mod, "list_dm_turns", spy_list_dm_turns)
+
+        # Mock LLMClient so no real HTTP calls are made
+        mock_response = {
+            "observations": [
+                {"field": "tone", "observation": "Dark", "evidence": "", "confidence": 0.6, "source_turn": "turn-007"},
+            ]
+        }
+
+        class _FakeLLMClient:
+            def __init__(self, *a, **kw): pass
+            def extract_json(self, *a, **kw): return mock_response
+            def delay(self): pass
+
+        monkeypatch.setattr(_mod, "LLMClient", _FakeLLMClient)
+
+        analyze_batch(
+            session_dir=session_dir,
+            framework_dir=framework_dir,
+            start_turn=0,   # no explicit start — should auto-resume
+        )
+
+        # list_dm_turns must have been called with effective_start=6 (turn-005 + 1)
+        assert collected_start_turns == [6], (
+            f"Expected auto-resume start=6, got {collected_start_turns}"
+        )
+
+    def test_no_auto_resume_when_start_turn_explicit(self, tmp_path, monkeypatch):
+        """Explicit start_turn overrides auto-resume logic."""
+        session_dir = self._make_session(tmp_path / "session", n_dm_turns=10, start=1)
+        framework_dir = self._make_profile(tmp_path / "fw", last_updated_turn="turn-005")
+
+        collected_start_turns = []
+
+        import dm_profile_analyzer as _mod
+
+        original_list_dm_turns = _mod.list_dm_turns
+
+        def spy_list_dm_turns(sd, start_turn=0, max_turns=0):
+            collected_start_turns.append(start_turn)
+            return original_list_dm_turns(sd, start_turn=start_turn, max_turns=max_turns)
+
+        monkeypatch.setattr(_mod, "list_dm_turns", spy_list_dm_turns)
+
+        class _FakeLLMClient:
+            def __init__(self, *a, **kw): pass
+            def extract_json(self, *a, **kw): return {"observations": []}
+            def delay(self): pass
+
+        monkeypatch.setattr(_mod, "LLMClient", _FakeLLMClient)
+
+        analyze_batch(
+            session_dir=session_dir,
+            framework_dir=framework_dir,
+            start_turn=3,   # explicit start_turn — must be respected as-is
+        )
+
+        assert collected_start_turns == [3], (
+            f"Expected explicit start=3, got {collected_start_turns}"
+        )
+
+    def test_no_auto_resume_on_empty_profile(self, tmp_path, monkeypatch):
+        """Empty profile (turn-001 sentinel) must NOT trigger auto-resume."""
+        session_dir = self._make_session(tmp_path / "session", n_dm_turns=5, start=1)
+
+        # Use a fresh empty profile (last_updated_turn = turn-001)
+        profile_dir = tmp_path / "framework" / "dm-profile"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        (profile_dir / "dm-profile.json").write_text(
+            json.dumps(_empty_profile(), indent=2), encoding="utf-8"
+        )
+        framework_dir = str(tmp_path / "framework")
+
+        collected_start_turns = []
+
+        import dm_profile_analyzer as _mod
+
+        original_list_dm_turns = _mod.list_dm_turns
+
+        def spy_list_dm_turns(sd, start_turn=0, max_turns=0):
+            collected_start_turns.append(start_turn)
+            return original_list_dm_turns(sd, start_turn=start_turn, max_turns=max_turns)
+
+        monkeypatch.setattr(_mod, "list_dm_turns", spy_list_dm_turns)
+
+        class _FakeLLMClient:
+            def __init__(self, *a, **kw): pass
+            def extract_json(self, *a, **kw): return {"observations": []}
+            def delay(self): pass
+
+        monkeypatch.setattr(_mod, "LLMClient", _FakeLLMClient)
+
+        analyze_batch(session_dir=session_dir, framework_dir=framework_dir, start_turn=0)
+
+        # Empty profile — should start from 0 (no skip)
+        assert collected_start_turns == [0], (
+            f"Expected start=0 for empty profile, got {collected_start_turns}"
+        )
+
+    def test_partial_run_saved_on_quota_exhausted(self, tmp_path, monkeypatch):
+        """Observations collected before QuotaExhaustedError must be saved."""
+        from llm_client import QuotaExhaustedError
+
+        session_dir = self._make_session(tmp_path / "session", n_dm_turns=6, start=1)
+
+        profile_dir = tmp_path / "framework" / "dm-profile"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        profile_path = profile_dir / "dm-profile.json"
+        profile_path.write_text(json.dumps(_empty_profile(), indent=2), encoding="utf-8")
+        framework_dir = str(tmp_path / "framework")
+
+        call_count = [0]
+
+        class _FakeLLMClient:
+            def __init__(self, *a, **kw): pass
+
+            def extract_json(self, *a, **kw):
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    # First batch succeeds
+                    return {
+                        "observations": [
+                            {"field": "tone", "observation": "Dark", "evidence": "",
+                             "confidence": 0.7, "source_turn": "turn-002"},
+                        ]
+                    }
+                # Second batch raises QuotaExhaustedError
+                raise QuotaExhaustedError("quota gone")
+
+            def delay(self): pass
+
+        import dm_profile_analyzer as _mod
+        monkeypatch.setattr(_mod, "LLMClient", _FakeLLMClient)
+
+        analyze_batch(
+            session_dir=session_dir,
+            framework_dir=framework_dir,
+            start_turn=0,
+            batch_size=3,   # batch 1 = turns 1-3, batch 2 = turns 4-6
+        )
+
+        # Profile must have been saved with observations from the first batch
+        saved = load_dm_profile(str(profile_path))
+        assert saved.get("tone") == "Dark", "Partial observations before QuotaExhaustedError must be saved"
+        assert saved.get("last_updated_turn") == "turn-002"

--- a/tests/test_dm_profile_analyzer.py
+++ b/tests/test_dm_profile_analyzer.py
@@ -25,6 +25,7 @@ from dm_profile_analyzer import (
     parse_user_input,
     save_dm_profile,
 )
+import dm_profile_analyzer as _mod
 
 
 # ---------------------------------------------------------------------------
@@ -492,7 +493,7 @@ class TestAnalyzeDMTurns:
         turns = [{"turn_id": "turn-001", "speaker": "dm", "text": "The shadows press in..."}]
         profile = _empty_profile()
 
-        observations = analyze_dm_turns(turns, profile, llm, batch_size=5)
+        observations, _ = analyze_dm_turns(turns, profile, llm, batch_size=5)
         assert len(observations) == 2
         assert observations[0]["field"] == "tone"
         assert observations[1]["field"] == "adversarial_level"
@@ -507,7 +508,7 @@ class TestAnalyzeDMTurns:
         llm = MockLLMClient(responses=[mock_response])
         turns = [{"turn_id": "turn-001", "speaker": "dm", "text": "Test"}]
 
-        observations = analyze_dm_turns(turns, _empty_profile(), llm, batch_size=5)
+        observations, _ = analyze_dm_turns(turns, _empty_profile(), llm, batch_size=5)
         assert len(observations) == 1
         assert observations[0]["field"] == "tone"
 
@@ -515,7 +516,7 @@ class TestAnalyzeDMTurns:
         llm = MockLLMClient(responses=["not a dict"])
         turns = [{"turn_id": "turn-001", "speaker": "dm", "text": "Test"}]
 
-        observations = analyze_dm_turns(turns, _empty_profile(), llm, batch_size=5)
+        observations, _ = analyze_dm_turns(turns, _empty_profile(), llm, batch_size=5)
         assert observations == []
 
     def test_batching(self):
@@ -526,7 +527,7 @@ class TestAnalyzeDMTurns:
         llm = MockLLMClient(responses=responses)
         turns = [{"turn_id": f"turn-{i:03d}", "speaker": "dm", "text": f"Turn {i}"} for i in range(1, 8)]
 
-        observations = analyze_dm_turns(turns, _empty_profile(), llm, batch_size=3)
+        observations, _ = analyze_dm_turns(turns, _empty_profile(), llm, batch_size=3)
         # 7 turns / batch_size=3 = 3 batches
         assert llm._call_count == 3
         assert len(observations) == 3
@@ -541,7 +542,7 @@ class TestAnalyzeDMTurns:
         llm = MockLLMClient(responses=[mock_response])
         turns = [{"turn_id": "turn-001", "speaker": "dm", "text": "Test"}]
 
-        observations = analyze_dm_turns(turns, _empty_profile(), llm, batch_size=5)
+        observations, _ = analyze_dm_turns(turns, _empty_profile(), llm, batch_size=5)
         assert len(observations) == 1
         assert observations[0]["observation"] == "Valid"
 
@@ -569,10 +570,10 @@ class TestRoundTrip:
         turns = [{"turn_id": "turn-010", "speaker": "dm", "text": "The air grows thick as you approach."}]
 
         profile = _empty_profile()
-        observations = analyze_dm_turns(turns, profile, llm, batch_size=5)
+        observations, watermark = analyze_dm_turns(turns, profile, llm, batch_size=5)
         assert len(observations) == 5
 
-        profile = merge_observations(profile, observations)
+        profile = merge_observations(profile, observations, watermark_turn=watermark)
         assert profile["tone"] == "Tense and atmospheric"
         assert profile["adversarial_level"] == "moderate"
         assert profile["confidence"] > 0.0
@@ -666,10 +667,6 @@ class TestAnalyzeBatchAutoResume:
 
         collected_start_turns = []
 
-        original_list = list_dm_turns.__wrapped__ if hasattr(list_dm_turns, "__wrapped__") else None
-
-        import dm_profile_analyzer as _mod
-
         original_list_dm_turns = _mod.list_dm_turns
 
         def spy_list_dm_turns(sd, start_turn=0, max_turns=0):
@@ -710,8 +707,6 @@ class TestAnalyzeBatchAutoResume:
 
         collected_start_turns = []
 
-        import dm_profile_analyzer as _mod
-
         original_list_dm_turns = _mod.list_dm_turns
 
         def spy_list_dm_turns(sd, start_turn=0, max_turns=0):
@@ -750,8 +745,6 @@ class TestAnalyzeBatchAutoResume:
         framework_dir = str(tmp_path / "framework")
 
         collected_start_turns = []
-
-        import dm_profile_analyzer as _mod
 
         original_list_dm_turns = _mod.list_dm_turns
 
@@ -807,7 +800,6 @@ class TestAnalyzeBatchAutoResume:
 
             def delay(self): pass
 
-        import dm_profile_analyzer as _mod
         monkeypatch.setattr(_mod, "LLMClient", _FakeLLMClient)
 
         analyze_batch(
@@ -817,7 +809,70 @@ class TestAnalyzeBatchAutoResume:
             batch_size=3,   # batch 1 = turns 1-3, batch 2 = turns 4-6
         )
 
-        # Profile must have been saved with observations from the first batch
+        # Profile must have been saved with observations from the first batch.
+        # Watermark must be turn-003 (last turn of the first successful batch),
+        # not turn-002 (which is only the source_turn of the observation).
         saved = load_dm_profile(str(profile_path))
         assert saved.get("tone") == "Dark", "Partial observations before QuotaExhaustedError must be saved"
-        assert saved.get("last_updated_turn") == "turn-002"
+        assert saved.get("last_updated_turn") == "turn-003"
+
+    def test_llm_extraction_error_watermark_is_last_consecutive_success(self, tmp_path, monkeypatch):
+        """When a middle batch raises LLMExtractionError and a later batch succeeds,
+        the watermark must be the last turn of the last *consecutively* successful
+        batch from the start — NOT the highest turn seen across all batches."""
+        from llm_client import LLMExtractionError
+
+        # 9 turns → 3 batches of 3 (turns 1–3, 4–6, 7–9)
+        session_dir = self._make_session(tmp_path / "session", n_dm_turns=9, start=1)
+
+        profile_dir = tmp_path / "framework" / "dm-profile"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        profile_path = profile_dir / "dm-profile.json"
+        profile_path.write_text(json.dumps(_empty_profile(), indent=2), encoding="utf-8")
+        framework_dir = str(tmp_path / "framework")
+
+        call_count = [0]
+
+        class _FakeLLMClient:
+            def __init__(self, *a, **kw): pass
+
+            def extract_json(self, *a, **kw):
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    # Batch 1 (turns 1-3) succeeds
+                    return {
+                        "observations": [
+                            {"field": "tone", "observation": "Dark", "evidence": "",
+                             "confidence": 0.7, "source_turn": "turn-002"},
+                        ]
+                    }
+                elif call_count[0] == 2:
+                    # Batch 2 (turns 4-6) fails — breaks the consecutive run
+                    raise LLMExtractionError("parse error in batch 2")
+                else:
+                    # Batch 3 (turns 7-9) succeeds — but sequence is already broken
+                    return {
+                        "observations": [
+                            {"field": "tone", "observation": "Grim", "evidence": "",
+                             "confidence": 0.8, "source_turn": "turn-008"},
+                        ]
+                    }
+
+            def delay(self): pass
+
+        monkeypatch.setattr(_mod, "LLMClient", _FakeLLMClient)
+
+        analyze_batch(
+            session_dir=session_dir,
+            framework_dir=framework_dir,
+            start_turn=0,
+            batch_size=3,
+        )
+
+        saved = load_dm_profile(str(profile_path))
+        # Watermark must be turn-003 (last turn of the last consecutive success = batch 1),
+        # NOT turn-008/turn-009 (from the later non-consecutive successful batch).
+        assert saved.get("last_updated_turn") == "turn-003", (
+            f"Watermark must be last consecutive success (turn-003), "
+            f"got {saved.get('last_updated_turn')}"
+        )

--- a/tests/test_dm_profile_analyzer.py
+++ b/tests/test_dm_profile_analyzer.py
@@ -10,22 +10,22 @@ import pytest
 # Add tools/ to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
-from dm_profile_analyzer import (
-    _aggregate_adversarial_level,
-    _empty_profile,
-    _format_analysis_prompt,
-    _parse_turn_number,
-    analyze_batch,
-    analyze_dm_turns,
-    list_dm_turns,
-    load_dm_profile,
-    load_template,
-    merge_observations,
-    merge_user_input,
-    parse_user_input,
-    save_dm_profile,
-)
 import dm_profile_analyzer as _mod
+
+# Local aliases — keep _mod reference for monkeypatch.setattr
+_aggregate_adversarial_level = _mod._aggregate_adversarial_level
+_empty_profile = _mod._empty_profile
+_format_analysis_prompt = _mod._format_analysis_prompt
+_parse_turn_number = _mod._parse_turn_number
+analyze_batch = _mod.analyze_batch
+analyze_dm_turns = _mod.analyze_dm_turns
+list_dm_turns = _mod.list_dm_turns
+load_dm_profile = _mod.load_dm_profile
+load_template = _mod.load_template
+merge_observations = _mod.merge_observations
+merge_user_input = _mod.merge_user_input
+parse_user_input = _mod.parse_user_input
+save_dm_profile = _mod.save_dm_profile
 
 
 # ---------------------------------------------------------------------------

--- a/tools/dm_profile_analyzer.py
+++ b/tools/dm_profile_analyzer.py
@@ -159,14 +159,22 @@ def analyze_dm_turns(
     profile: dict,
     llm: "LLMClient",
     batch_size: int = 5,
-) -> list[dict]:
-    """Analyze DM turns in batches and return observations.
+) -> tuple[list[dict], str | None]:
+    """Analyze DM turns in batches and return observations with watermark.
 
     Sends batches of DM turns to the LLM for behavioral analysis.
-    Returns a flat list of observation dicts.
+    Returns a tuple of:
+    - A flat list of observation dicts (including from non-consecutive batches)
+    - The watermark turn ID: the last turn of the last *consecutively* successful
+      batch from the start of the range. If a batch raises LLMExtractionError the
+      consecutive run is broken and the watermark stops before that gap, even if
+      later batches succeed. Returns None if no batch succeeded.
     """
     template = load_template()
     all_observations = []
+    # Track the last turn of the last unbroken run of successful batches.
+    last_consecutive_turn: str | None = None
+    sequence_broken = False
 
     for i in range(0, len(turns), batch_size):
         batch = turns[i : i + batch_size]
@@ -183,21 +191,25 @@ def analyze_dm_turns(
         except QuotaExhaustedError:
             print(
                 f"  ERROR: LLM quota exhausted at batch starting {batch_ids[0]}, "
-                f"stopping analysis. Partial results will be saved.",
+                f"stopping analysis. Partial results will be saved if any observations "
+                f"were successfully extracted.",
                 file=sys.stderr,
             )
             break
         except LLMExtractionError as e:
             print(f"  WARNING: LLM extraction failed for batch starting {batch_ids[0]}: {e}", file=sys.stderr)
+            sequence_broken = True
             continue
 
         if not isinstance(result, dict):
             print(f"  WARNING: Non-dict response for batch, skipping", file=sys.stderr)
+            sequence_broken = True
             continue
 
         observations = result.get("observations", [])
         if not isinstance(observations, list):
             print(f"  WARNING: observations is not a list, skipping", file=sys.stderr)
+            sequence_broken = True
             continue
 
         # Validate each observation
@@ -220,17 +232,32 @@ def analyze_dm_turns(
         all_observations.extend(valid)
         print(f"    → {len(valid)} observations extracted")
 
+        # Advance watermark only while the run from the start is unbroken.
+        if not sequence_broken:
+            last_consecutive_turn = batch_ids[-1]
+
         # Brief delay between batches
         if i + batch_size < len(turns):
             llm.delay()
 
-    return all_observations
+    return all_observations, last_consecutive_turn
 
 
-def merge_observations(profile: dict, observations: list[dict]) -> dict:
+def merge_observations(
+    profile: dict,
+    observations: list[dict],
+    watermark_turn: str | None = None,
+) -> dict:
     """Merge LLM-extracted observations into the DM profile.
 
     Updates the profile in place and returns it.
+
+    ``watermark_turn`` should be the last turn of the last *consecutively*
+    successful batch as returned by ``analyze_dm_turns()``.  When provided it
+    is used as the new ``last_updated_turn`` (preventing the watermark from
+    jumping past failed batches).  When omitted the highest ``source_turn``
+    seen in the observations is used (backward-compatible behaviour for direct
+    callers).
     """
     if not observations:
         return profile
@@ -244,10 +271,17 @@ def merge_observations(profile: dict, observations: list[dict]) -> dict:
         field = obs["field"]
         by_field.setdefault(field, []).append(obs)
 
-        # Track latest turn — only accept schema-valid turn IDs
-        source = obs.get("source_turn", "")
-        if _TURN_ID_RE.match(source) and _parse_turn_number(source) > _parse_turn_number(latest_turn):
-            latest_turn = source
+    if watermark_turn is not None:
+        # Use the explicit consecutive-success watermark supplied by the caller.
+        if _TURN_ID_RE.match(watermark_turn) and _parse_turn_number(watermark_turn) > _parse_turn_number(latest_turn):
+            latest_turn = watermark_turn
+    else:
+        # Fallback: infer watermark from observation source turns (used when
+        # merge_observations is called directly without a watermark).
+        for obs in observations:
+            source = obs.get("source_turn", "")
+            if _TURN_ID_RE.match(source) and _parse_turn_number(source) > _parse_turn_number(latest_turn):
+                latest_turn = source
 
     # Merge tone — pick highest-confidence observation
     if "tone" in by_field:
@@ -488,10 +522,10 @@ def analyze_single_turn(
         return
 
     turn = {"turn_id": turn_id, "speaker": speaker, "text": text}
-    observations = analyze_dm_turns([turn], profile, llm, batch_size=1)
+    observations, watermark = analyze_dm_turns([turn], profile, llm, batch_size=1)
 
     if observations:
-        profile = merge_observations(profile, observations)
+        profile = merge_observations(profile, observations, watermark_turn=watermark)
         save_dm_profile(profile, profile_path, dry_run=dry_run)
         print(f"  DM profile updated with {len(observations)} observation(s)")
     else:
@@ -553,13 +587,13 @@ def analyze_batch(
     print(f"  Analyzing {len(turns)} DM turns for behavioral patterns...")
     t0 = time.monotonic()
 
-    observations = analyze_dm_turns(turns, profile, llm, batch_size=batch_size)
+    observations, watermark = analyze_dm_turns(turns, profile, llm, batch_size=batch_size)
 
     elapsed = time.monotonic() - t0
     print(f"  Extracted {len(observations)} observations in {elapsed:.1f}s")
 
     if observations:
-        profile = merge_observations(profile, observations)
+        profile = merge_observations(profile, observations, watermark_turn=watermark)
         save_dm_profile(profile, profile_path, dry_run=dry_run)
         print(f"  DM profile updated (confidence: {profile['confidence']})")
     else:

--- a/tools/dm_profile_analyzer.py
+++ b/tools/dm_profile_analyzer.py
@@ -181,10 +181,14 @@ def analyze_dm_turns(
                 user_prompt=user_prompt,
             )
         except QuotaExhaustedError:
-            print("  ERROR: LLM quota exhausted, stopping analysis.", file=sys.stderr)
+            print(
+                f"  ERROR: LLM quota exhausted at batch starting {batch_ids[0]}, "
+                f"stopping analysis. Partial results will be saved.",
+                file=sys.stderr,
+            )
             break
         except LLMExtractionError as e:
-            print(f"  WARNING: LLM extraction failed for batch: {e}", file=sys.stderr)
+            print(f"  WARNING: LLM extraction failed for batch starting {batch_ids[0]}: {e}", file=sys.stderr)
             continue
 
         if not isinstance(result, dict):
@@ -507,6 +511,12 @@ def analyze_batch(
     """Analyze all DM turns in a session and update the profile.
 
     Called from bootstrap_session.py or standalone CLI.
+
+    When ``start_turn`` is 0 (the default) and the existing profile already has
+    a ``last_updated_turn`` beyond the empty-profile sentinel (turn-001), the
+    analysis automatically resumes from the turn after the last-updated one.
+    This makes repeated or interrupted runs resilient: they pick up where they
+    left off instead of re-processing the entire transcript from the beginning.
     """
     if LLMClient is None:
         print("  WARNING: LLM client not available for DM profile analysis.", file=sys.stderr)
@@ -515,13 +525,27 @@ def analyze_batch(
     profile_path = os.path.join(framework_dir, "dm-profile", "dm-profile.json")
     profile = load_dm_profile(profile_path)
 
+    # Auto-resume: when no explicit start_turn is given, pick up from the turn
+    # after the profile's last_updated_turn so that partial runs (interrupted by
+    # quota exhaustion or connection errors) continue from where they stopped
+    # rather than re-processing turns that have already been analyzed.
+    effective_start = start_turn
+    if not effective_start:
+        last_turn_num = _parse_turn_number(profile.get("last_updated_turn", "turn-001"))
+        if last_turn_num > 1:  # "turn-001" is the empty-profile sentinel
+            effective_start = last_turn_num + 1
+            print(
+                f"  Resuming DM profile analysis from turn {effective_start} "
+                f"(profile last updated: {profile.get('last_updated_turn')})"
+            )
+
     try:
         llm = LLMClient(config_path, overrides=overrides)
     except (ImportError, LLMExtractionError, FileNotFoundError) as e:
         print(f"  WARNING: DM profile analysis not available: {e}", file=sys.stderr)
         return
 
-    turns = list_dm_turns(session_dir, start_turn=start_turn, max_turns=max_turns)
+    turns = list_dm_turns(session_dir, start_turn=effective_start, max_turns=max_turns)
     if not turns:
         print("  No DM turns found for profile analysis.")
         return


### PR DESCRIPTION
## Summary

The DM profiler (`dm_profile_analyzer.py`) stopped updating after turn 157 because
`analyze_batch` always started from scratch (turn 1 or the explicit `--start-turn`)
on every invocation. When a run was interrupted by `QuotaExhaustedError` at turn 157,
partial progress was saved correctly but subsequent invocations re-processed turns 1–157
instead of resuming from 158.

The profiler is **not** inside `semantic_extraction.py`'s parallel phase — it runs in a
separate `try/except` block in `bootstrap_session.py` after extraction completes. However,
the same LLM connectivity issues that caused extraction failures at turns 315–344 could
also cause the profiler's own LLM calls to fail mid-batch, leaving later turns unanalyzed
until a manual re-run.

## Root cause

`analyze_batch` passed `start_turn` (0 by default) directly to `list_dm_turns` without
consulting the profile's `last_updated_turn` field. A partial run that stopped at turn 157
would save `last_updated_turn: "turn-157"`, but the next invocation ignored that and started
over from turn 1.

## Fix

- **`analyze_batch`**: when `start_turn == 0` and the existing profile has a
  `last_updated_turn` beyond the empty-profile sentinel (`turn-001`), automatically set
  `effective_start = last_updated_turn_number + 1`. An explicit `start_turn` always wins.
- **`analyze_dm_turns`**: improved `QuotaExhaustedError` log message to name the batch
  turn that triggered the stop and confirm partial results will be saved.

## Tests added (`TestAnalyzeBatchAutoResume`)

| Test | What it verifies |
|---|---|
| `test_auto_resume_skips_already_profiled_turns` | Profile with `last_updated_turn=turn-005` → `list_dm_turns` called with `start_turn=6` |
| `test_no_auto_resume_when_start_turn_explicit` | Explicit `start_turn=3` is passed through unchanged |
| `test_no_auto_resume_on_empty_profile` | Empty profile (`turn-001` sentinel) → starts from 0 (full scan) |
| `test_partial_run_saved_on_quota_exhausted` | Observations before `QuotaExhaustedError` are written to disk |

All 1639 existing tests continue to pass.

Closes #fix-dm-profiler-resilience
