### PR TITLE
fix: short-name dedup guard and post-sweep relationship cleanup

### DIFF
--- a/tests/test_dedup_fuzzy.py
+++ b/tests/test_dedup_fuzzy.py
@@ -361,3 +361,35 @@ def test_within_turn_dedup_cascade_drop():
     assert "camping grounds" in names
     assert "forest clearing" in names
     assert len(result) == 2
+
+
+def test_within_turn_dedup_short_name_no_false_merge_furs_forest():
+    """Short name 'furs' must NOT merge with 'forest' — different entity types entirely."""
+    entities = [_make_discovery("furs"), _make_discovery("forest")]
+    result = _within_turn_dedup(entities)
+    names = [e["name"] for e in result]
+    assert "furs" in names
+    assert "forest" in names
+    assert len(result) == 2
+
+
+def test_within_turn_dedup_short_exact_match():
+    """Short names that are exact matches should still be deduped."""
+    entities = [_make_discovery("axe"), _make_discovery("axe")]
+    result = _within_turn_dedup(entities)
+    assert len(result) == 1
+
+
+def test_within_turn_dedup_short_substring_match():
+    """Short names 'ice' vs 'icy' — not exact token match, so no merge."""
+    entities = [_make_discovery("ice"), _make_discovery("icy")]
+    result = _within_turn_dedup(entities)
+    assert len(result) == 2
+
+
+def test_within_turn_dedup_short_name_exact_token():
+    """Short name 'ax' as a token in 'war ax' should merge."""
+    entities = [_make_discovery("ax"), _make_discovery("war ax")]
+    result = _within_turn_dedup(entities)
+    assert len(result) == 1
+    assert result[0]["name"] == "war ax"

--- a/tests/test_pipeline_v3.py
+++ b/tests/test_pipeline_v3.py
@@ -459,6 +459,39 @@ class TestSweepStaleItems:
         removed = _sweep_stale_items(catalogs, [], "invalid")
         assert removed == []
 
+    def test_sweep_then_dangling_cleanup_removes_orphans(self):
+        """After stale sweep removes an item, cleanup should remove relationships to it."""
+        from catalog_merger import cleanup_dangling_relationships
+
+        catalogs = self._base_catalogs()
+        # Add a stale item (only 1 event ref, seen at turn-005, current is turn-040)
+        catalogs["items.json"].append(
+            {"id": "item-stale-thing", "name": "Stale Thing", "type": "item",
+             "first_seen_turn": "turn-005", "relationships": []}
+        )
+        # Add a character that references the stale item
+        catalogs["characters.json"].append(
+            {"id": "char-hero", "name": "Hero", "type": "character",
+             "first_seen_turn": "turn-001", "relationships": [
+                 {"target_id": "item-stale-thing", "type": "social", "description": "owns"}
+             ]}
+        )
+        events = [
+            {"id": "evt-1", "related_entities": ["item-stale-thing"], "turn_id": "turn-005"},
+        ]
+
+        # Step 1: sweep removes the stale item
+        removed = _sweep_stale_items(catalogs, events, "turn-040", min_event_refs=2, staleness_turns=25)
+        assert "item-stale-thing" in removed
+
+        # Step 2: cleanup catches the orphaned relationship
+        dangling = cleanup_dangling_relationships(catalogs)
+        assert "char-hero" in dangling
+        assert "item-stale-thing" in dangling["char-hero"]
+        # The relationship should now be gone
+        hero = [e for e in catalogs["characters.json"] if e["id"] == "char-hero"][0]
+        assert len(hero["relationships"]) == 0
+
 
 # ---------------------------------------------------------------------------
 # Pronoun entity filter tests (#116)

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -1986,8 +1986,23 @@ def _within_turn_dedup(entities: list[dict]) -> list[dict]:
 
             matched = False
 
+            # Short-name guard: names < 5 chars skip fuzzy matching (#dedup-false-positive)
+            min_len = min(len(name_a), len(name_b))
+            if min_len < 5:
+                # Only exact match, exact-token match, or token-prefix for short names
+                if name_a == name_b:
+                    matched = True
+                else:
+                    shorter = name_a if len(name_a) <= len(name_b) else name_b
+                    longer = name_b if len(name_a) <= len(name_b) else name_a
+                    longer_tokens = longer.replace("-", " ").split()
+                    if shorter in longer_tokens or any(t.startswith(shorter) for t in longer_tokens):
+                        matched = True
+                if not matched:
+                    continue  # skip fuzzy checks for this pair
+
             # Check 1: Character substring with token-prefix guard (both >= 4 chars)
-            if len(name_a) >= 4 and len(name_b) >= 4:
+            if not matched and len(name_a) >= 4 and len(name_b) >= 4:
                 if name_a in name_b or name_b in name_a:
                     shorter = name_a if len(name_a) <= len(name_b) else name_b
                     longer = name_b if len(name_a) <= len(name_b) else name_a
@@ -5511,12 +5526,6 @@ def _extract_segmented(
         _rewrite_stale_ids(final_catalogs, final_events, merge_map)
         print(f"  Post-reconciliation dedup merged {dupes_merged} duplicate(s)")
 
-    # Clean up dangling relationship targets (#184)
-    dangling_removed = cleanup_dangling_relationships(final_catalogs)
-    if dangling_removed:
-        total_removed = sum(len(v) for v in dangling_removed.values())
-        print(f"  Removed {total_removed} dangling relationship target(s)")
-
     orphan_stubs = _post_batch_orphan_sweep(final_catalogs, final_events)
     if orphan_stubs:
         print(f"  Post-reconciliation orphan sweep: {orphan_stubs} stub(s)")
@@ -5534,6 +5543,13 @@ def _extract_segmented(
     seg_stale_removed = _sweep_stale_items(final_catalogs, final_events, seg_last_turn, _seg_stale_min, _seg_stale_win)
     if seg_stale_removed:
         print(f"  Post-reconciliation stale-item sweep removed {len(seg_stale_removed)} item(s)")
+
+    # Clean up dangling relationship targets (#184) — runs AFTER stale sweep
+    # so relationships pointing to swept items are also removed
+    dangling_removed = cleanup_dangling_relationships(final_catalogs)
+    if dangling_removed:
+        total_removed = sum(len(v) for v in dangling_removed.values())
+        print(f"  Removed {total_removed} dangling relationship target(s)")
 
     entities_final = sum(len(v) for v in final_catalogs.values())
 
@@ -6144,12 +6160,6 @@ def extract_semantic_batch(
         entities_after = sum(len(v) for v in catalogs.values())
         print(f"  Post-batch dedup merged {dupes_merged} duplicate(s); {entities_after} entities remain")
 
-    # Clean up dangling relationship targets (#184)
-    dangling_removed = cleanup_dangling_relationships(catalogs)
-    if dangling_removed:
-        total_removed = sum(len(v) for v in dangling_removed.values())
-        print(f"  Removed {total_removed} dangling relationship target(s) from {len(dangling_removed)} entit(ies)")
-
     # Apply coreference hints (manual merge rules, #162)
     hints_path = os.path.join(session_dir, "coreference-hints.json")
     if os.path.isfile(hints_path):
@@ -6179,6 +6189,13 @@ def extract_semantic_batch(
     if stale_removed:
         entities_after = sum(len(v) for v in catalogs.values())
         print(f"  Stale-item sweep removed {len(stale_removed)} item(s); {entities_after} entities remain")
+
+    # Clean up dangling relationship targets (#184) — runs AFTER stale sweep
+    # so relationships pointing to swept items are also removed
+    dangling_removed = cleanup_dangling_relationships(catalogs)
+    if dangling_removed:
+        total_removed = sum(len(v) for v in dangling_removed.values())
+        print(f"  Removed {total_removed} dangling relationship target(s) from {len(dangling_removed)} entit(ies)")
 
     # Report if PC extraction was skipped due to consecutive failures (#149)
     if _pc_skipped_turns > 0:


### PR DESCRIPTION
## Summary

Fixes 2 data integrity bugs found during batch extraction validation (turns 1-50):

### Bug 1: Short-name dedup false positive

`_within_turn_dedup()` used levenshtein <= 3 and SequenceMatcher >= 0.6 without a minimum name-length guard. For names < 5 chars, these thresholds are too permissive — "furs" matched "forest" (edit distance 3, ratio 0.6) despite being completely different entities (a clothing material vs a location).

**Fix:** Names shorter than 5 characters now skip fuzzy matching entirely. Only exact match, exact-token match, or token-prefix triggers dedup for short names.

### Bug 2: Orphaned relationships after stale sweep

`_sweep_stale_items()` removed low-signal items from catalogs but left relationship entries pointing to them in other entities. `cleanup_dangling_relationships()` ran before the sweep, so orphans accumulated — 4 orphaned entries found after just 50 turns.

**Fix:** Reordered both pipelines (batch and segmented): stale item sweep now runs before dangling relationship cleanup.

## Tests Added

1. `test_within_turn_dedup_short_name_no_false_merge_furs_forest` — "furs" vs "forest" kept separate
2. `test_within_turn_dedup_short_exact_match` — exact short-name duplicates still merge
3. `test_within_turn_dedup_short_substring_match` — "ice" vs "icy" kept separate (not exact token)
4. `test_within_turn_dedup_short_name_exact_token` — "ax" as token in "war ax" merges correctly
5. `test_sweep_then_dangling_cleanup_removes_orphans` — verifies sweep + cleanup ordering removes orphaned refs

## Evidence

- 1 false positive in 50 turns: `item-furs` merged with `loc-forest`
- 4 orphaned relationship entries: char-player → item-warlock-attire, item-icy-vines, item-crude-wood-hafted-spears, item-rudimentary-tools
