### PR TITLE
fix: move --llm to each subparser to eliminate root/vscode shadowing

### DIFF
--- a/crew/main.py
+++ b/crew/main.py
@@ -125,10 +125,6 @@ def main():
     parser = argparse.ArgumentParser(
         description="CrewAI orchestration for narrative-state-engine"
     )
-    parser.add_argument(
-        "--llm", default="ollama/qwen2.5:14b-8k",
-        help="LLM identifier for agent reasoning (default: ollama/qwen2.5:14b-8k)"
-    )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # Extract command
@@ -136,17 +132,29 @@ def main():
     ext.add_argument("--session", required=True, help="Session directory name")
     ext.add_argument("--start", type=int, required=True, help="Start turn number")
     ext.add_argument("--end", type=int, required=True, help="End turn number")
+    ext.add_argument(
+        "--llm", default="ollama/qwen2.5:14b-8k",
+        help="LLM identifier for agent reasoning (default: ollama/qwen2.5:14b-8k)"
+    )
     ext.set_defaults(func=cmd_extract)
 
     # Optimize command
     opt = subparsers.add_parser("optimize", help="Run optimization crew")
     opt.add_argument("--target", choices=["b70", "rtx4070"], required=True, help="GPU target")
     opt.add_argument("--model", default="qwen2.5:14b", help="Model to benchmark")
+    opt.add_argument(
+        "--llm", default="ollama/qwen2.5:14b-8k",
+        help="LLM identifier for agent reasoning (default: ollama/qwen2.5:14b-8k)"
+    )
     opt.set_defaults(func=cmd_optimize)
 
     # Release command
     rel = subparsers.add_parser("release", help="Run release validation crew")
     rel.add_argument("--branch", required=True, help="Branch name to validate")
+    rel.add_argument(
+        "--llm", default="ollama/qwen2.5:14b-8k",
+        help="LLM identifier for agent reasoning (default: ollama/qwen2.5:14b-8k)"
+    )
     rel.set_defaults(func=cmd_release)
 
     # VS Code agent command


### PR DESCRIPTION
﻿## Summary

Move --llm from the root parser to each individual subparser, eliminating the argparse shadowing bug where the vscode subparser's --llm default silently overwrote any value passed at the root level.

## Root cause

Both the root parser and the scode subparser defined --llm. Argparse resolves duplicate argument names by letting the subparser win, so python crew/main.py --llm foo vscode --task ... ignored oo and used qwen3.5-9b-q4_k_m instead.

## Fix

Option (a) from issue #355: remove --llm from the root parser and add it explicitly to each subparser:

- extract, optimize, elease → --llm with default ollama/qwen2.5:14b-8k
- scode → --llm with default qwen3.5-9b-q4_k_m (unchanged)

Users now pass --llm after the subcommand name, and each subcommand's value is honoured without interference.

Closes #355
