### PR TITLE
chore: fix ruff lint findings

### DIFF
--- a/crew/main.py
+++ b/crew/main.py
@@ -69,7 +69,7 @@ def cmd_vscode(args):
     health_url = args.llm_base_url.rstrip("/").rsplit("/v1", 1)[0] + "/health"
     try:
         req = urllib.request.Request(health_url, method="GET")
-        with urllib.request.urlopen(req, timeout=5) as resp:
+        with urllib.request.urlopen(req, timeout=5) as _:
             pass  # 200 OK is enough
     except (urllib.error.URLError, OSError) as e:
         from urllib.parse import urlparse
@@ -80,7 +80,7 @@ def cmd_vscode(args):
         print(f"Health check failed: {e}\n")
         print("Start llama-server in a persistent terminal:")
         print()
-        print(f"  llama-server -m <MODEL_PATH> -ngl 99 -np 1 -c 32768 \\")
+        print("  llama-server -m <MODEL_PATH> -ngl 99 -np 1 -c 32768 \\")
         print(f"    --port {port} --reasoning-format none --reasoning off -t 1")
         print()
         print(f"Default model: {args.llm}")

--- a/tests/test_bounded_entity_context.py
+++ b/tests/test_bounded_entity_context.py
@@ -109,7 +109,7 @@ class TestBoundedFormatRecentPrioritization:
         assert "aliases: R" in result
         # Dormant entity should be brief (no identity/aliases) because
         # it's outside the recency window and budget is tight.
-        lines = [l for l in result.strip().split("\n") if l.startswith("char-d")]
+        lines = [line for line in result.strip().split("\n") if line.startswith("char-d")]
         assert len(lines) == 1
         assert "Old NPC" not in lines[0]
         assert "Dormy" not in lines[0]
@@ -307,9 +307,9 @@ class TestRecentTierOverflow:
             assert f"char-{i}" in result
         # The result should have at least some entities in brief format
         # (no identity) to stay within budget
-        brief_lines = [l for l in result.strip().split("\n")
-                       if l and "Very long description" not in l
-                       and l.startswith("char-")]
+        brief_lines = [line for line in result.strip().split("\n")
+                       if line and "Very long description" not in line
+                       and line.startswith("char-")]
         assert len(brief_lines) > 0, "Some recent entities should be degraded to brief"
 
     def test_single_recent_entity_not_degraded(self):
@@ -357,7 +357,7 @@ class TestThreeTierFormatting:
             catalogs, current_turn=100, context_length=100000,
             turn_text="Some scene text", recency_window=10)
         lines = result.strip().split("\n")
-        line_map = {l.split(" | ")[0]: l for l in lines if " | " in l}
+        line_map = {line.split(" | ")[0]: line for line in lines if " | " in line}
         # Recent entity should have full detail (identity + aliases)
         assert "Active hero" in line_map.get("char-r", "")
         assert "aliases:" in line_map.get("char-r", "")
@@ -404,12 +404,12 @@ class TestDegradationWithIdOnly:
             catalogs, current_turn=100, context_length=32768,
             entity_context_budget=300,
             turn_text="Entity0 does something", recency_window=10)
-        lines = [l for l in result.strip().split("\n") if l.startswith("char-")]
+        lines = [line for line in result.strip().split("\n") if line.startswith("char-")]
         # At least some entities should be in id-only format (exactly 1 pipe)
-        id_only = [l for l in lines if l.count(" | ") == 1]
+        id_only = [line for line in lines if line.count(" | ") == 1]
         assert len(id_only) > 0, "Budget pressure should produce id-only lines before omitting"
         # No entity should be omitted before all are degraded to id-only
         # (Entity0 is mentioned → priority → kept as full)
-        e0_line = [l for l in lines if l.startswith("char-0")]
+        e0_line = [line for line in lines if line.startswith("char-0")]
         if e0_line:
             assert "Long description" in e0_line[0]

--- a/tests/test_context_aware_entity_selection.py
+++ b/tests/test_context_aware_entity_selection.py
@@ -574,9 +574,9 @@ class TestBoundedWithTurnText:
             turn_text="Hero entered the room")
         lines = result.strip().split("\n")
         # Find positions
-        hero_pos = next(i for i, l in enumerate(lines) if "char-mentioned" in l)
-        shop_pos = next(i for i, l in enumerate(lines) if "char-coloc" in l)
-        back_pos = next(i for i, l in enumerate(lines) if "char-back" in l)
+        hero_pos = next(i for i, line in enumerate(lines) if "char-mentioned" in line)
+        shop_pos = next(i for i, line in enumerate(lines) if "char-coloc" in line)
+        back_pos = next(i for i, line in enumerate(lines) if "char-back" in line)
         assert hero_pos < shop_pos, "Mentioned should come before co-located"
         assert shop_pos < back_pos, "Co-located should come before backfill"
 

--- a/tests/test_entity_refresh.py
+++ b/tests/test_entity_refresh.py
@@ -12,7 +12,6 @@ from semantic_extraction import (
     _DEFAULT_REFRESH_INTERVAL,
     _DEFAULT_REFRESH_BATCH_SIZE,
     _MAX_REFRESH_BATCH_SIZE,
-    _REFRESH_TYPE_SHARES,
     extract_semantic_batch,
     CATALOG_KEYS,
 )
@@ -309,7 +308,7 @@ class TestRefreshEntities:
 
     def test_refresh_preserves_first_seen_turn(self):
         """Refreshed entity should keep its original first_seen_turn."""
-        from unittest.mock import MagicMock, patch, call
+        from unittest.mock import MagicMock, patch
         from semantic_extraction import refresh_entities
 
         elder = _make_entity("char-elder", "Elder", "character", "turn-005", "turn-005")

--- a/tests/test_pc_extraction_quality.py
+++ b/tests/test_pc_extraction_quality.py
@@ -50,7 +50,7 @@ def test_pc_alias_max_count_enforced():
     assert len(result) == _PC_ALIAS_MAX_COUNT
     # Should keep the last N (most recent)
     assert result[-1] == f"Alias{_PC_ALIAS_MAX_COUNT + 4}"
-    assert result[0] == f"Alias5"
+    assert result[0] == "Alias5"
 
 
 def test_pc_alias_valid_names_preserved():

--- a/tests/test_pipeline_v3.py
+++ b/tests/test_pipeline_v3.py
@@ -1001,27 +1001,22 @@ class TestExtractTurnNumber:
     """_extract_turn_number handles various formats."""
 
     def test_dict_with_turn_key(self):
-        from semantic_extraction import _extract_turn_number
 
         assert _extract_turn_number({"turn": "turn-042"}) == 42
 
     def test_dict_with_source_turn(self):
-        from semantic_extraction import _extract_turn_number
 
         assert _extract_turn_number({"source_turn": "turn-100"}) == 100
 
     def test_string_with_turn_pattern(self):
-        from semantic_extraction import _extract_turn_number
 
         assert _extract_turn_number("something at turn-055 happened") == 55
 
     def test_no_turn_info(self):
-        from semantic_extraction import _extract_turn_number
 
         assert _extract_turn_number({"detail": "no turn"}) is None
 
     def test_integer_value(self):
-        from semantic_extraction import _extract_turn_number
 
         assert _extract_turn_number(42) is None
 
@@ -1030,7 +1025,6 @@ class TestExtractThemes:
     """_extract_themes identifies keyword themes from entries."""
 
     def test_finds_keywords(self):
-        from semantic_extraction import _extract_themes
 
         items = [
             {"detail": "pregnancy confirmed"},
@@ -1041,7 +1035,6 @@ class TestExtractThemes:
         assert "harvest" in themes
 
     def test_caps_at_five(self):
-        from semantic_extraction import _extract_themes
 
         items = [
             "pregnancy text", "birth text", "construction text",
@@ -1051,7 +1044,6 @@ class TestExtractThemes:
         assert len(themes) <= 5
 
     def test_fallback_count(self):
-        from semantic_extraction import _extract_themes
 
         items = [{"detail": "unrecognized content"}]
         themes = _extract_themes(items)

--- a/tools/analyze_next_move.py
+++ b/tools/analyze_next_move.py
@@ -501,7 +501,7 @@ def main() -> None:
     derived_dir = os.path.join(session_dir, "derived")
     if not os.path.isdir(derived_dir):
         print(
-            f"ERROR: No derived directory found. Run update_state.py first.", file=sys.stderr
+            "ERROR: No derived directory found. Run update_state.py first.", file=sys.stderr
         )
         sys.exit(1)
 

--- a/tools/bootstrap_session.py
+++ b/tools/bootstrap_session.py
@@ -125,7 +125,7 @@ def parse_labeled_format(
     # Build a regex that matches any known label at the start of a line.
     # Labels may be wrapped in **, [], or nothing.
     def _label_pattern(labels: list[str]) -> str:
-        escaped = [re.escape(l) for l in labels]
+        escaped = [re.escape(lbl) for lbl in labels]
         return r"(?:\*{0,2})(?:\[)?(?:" + "|".join(escaped) + r")(?:\])?\*{0,2}"
 
     dm_label_pattern = _label_pattern(dm_labels)
@@ -207,7 +207,7 @@ def detect_format(content: str, dm_labels: list[str], player_labels: list[str]) 
 
     # Check for speaker labels
     all_labels = dm_labels + player_labels
-    label_pattern = r"^(?:\*{0,2})(?:\[)?(?:" + "|".join(re.escape(l) for l in all_labels) + r")(?:\])?\*{0,2}\s*:"
+    label_pattern = r"^(?:\*{0,2})(?:\[)?(?:" + "|".join(re.escape(lbl) for lbl in all_labels) + r")(?:\])?\*{0,2}\s*:"
     if re.search(label_pattern, content, re.IGNORECASE | re.MULTILINE):
         return "labeled"
 

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -1506,8 +1506,6 @@ def merge_relationships(catalogs: dict, relationships: list, turn_id: str) -> No
     V2: consolidates per (source_id, target_id) pair.
     """
     # Track entities touched so we can dedup once per entity, not per edge.
-    touched_entities: set[int] = set()
-
     for rel in relationships:
         source_id = rel.get("source_id")
         target_id = rel.get("target_id")

--- a/tools/catalog_merger.py
+++ b/tools/catalog_merger.py
@@ -1505,7 +1505,6 @@ def merge_relationships(catalogs: dict, relationships: list, turn_id: str) -> No
 
     V2: consolidates per (source_id, target_id) pair.
     """
-    # Track entities touched so we can dedup once per entity, not per edge.
     for rel in relationships:
         source_id = rel.get("source_id")
         target_id = rel.get("target_id")

--- a/tools/dedup_audit.py
+++ b/tools/dedup_audit.py
@@ -411,7 +411,7 @@ def main():
         summary = apply_review_file(
             args.review_file, args.catalog_dir, dry_run=args.dry_run,
         )
-        print(f"\n=== Summary ===")
+        print("\n=== Summary ===")
         print(f"  Merged:         {summary['merged']}")
         print(f"  Kept separate:  {summary['kept_separate']}")
         print(f"  Pending:        {summary['pending']}")
@@ -462,7 +462,7 @@ def main():
         dry_run=args.dry_run,
     )
 
-    print(f"\n=== Summary ===")
+    print("\n=== Summary ===")
     print(f"  Auto-merged:       {summary['auto_merged']}")
     print(f"  Flagged for review: {summary['flagged_for_review']}")
     print(f"  Discarded:         {summary['discarded']}")

--- a/tools/discovery_baseline.py
+++ b/tools/discovery_baseline.py
@@ -256,7 +256,7 @@ def main():
         known_tokens = _estimate_tokens(known)
 
         # Count how many entities made it into the context
-        entity_lines = [l for l in known.split("\n") if "|" in l and not l.startswith("(")]
+        entity_lines = [line for line in known.split("\n") if "|" in line and not line.startswith("(")]
         entities_in_context = len(entity_lines)
 
         print(f"\n--- Turn {turn_num:03d} ---", flush=True)

--- a/tools/dm_profile_analyzer.py
+++ b/tools/dm_profile_analyzer.py
@@ -202,13 +202,13 @@ def analyze_dm_turns(
             continue
 
         if not isinstance(result, dict):
-            print(f"  WARNING: Non-dict response for batch, skipping", file=sys.stderr)
+            print("  WARNING: Non-dict response for batch, skipping", file=sys.stderr)
             sequence_broken = True
             continue
 
         observations = result.get("observations", [])
         if not isinstance(observations, list):
-            print(f"  WARNING: observations is not a list, skipping", file=sys.stderr)
+            print("  WARNING: observations is not a list, skipping", file=sys.stderr)
             sequence_broken = True
             continue
 

--- a/tools/extract_structured_data.py
+++ b/tools/extract_structured_data.py
@@ -1006,7 +1006,7 @@ def list_turns(transcript_dir: str) -> list[dict]:
             with open(filepath, "r", encoding="utf-8") as f:
                 content = f.read()
             lines = content.split("\n")
-            text_lines = [l for l in lines if not l.startswith("# turn-")]
+            text_lines = [line for line in lines if not line.startswith("# turn-")]
             text = "\n".join(text_lines).strip()
             turns.append({
                 "turn_id": turn_id,
@@ -1055,7 +1055,7 @@ def main() -> None:
     print(f"Extracting structured data from {len(turns)} turn(s)...")
     data = extract_all(turns)
 
-    print(f"\nFound:")
+    print("\nFound:")
     print(f"  {len(data['session_events'])} mechanical event(s)")
     print(f"  {len(data['timeline'])} temporal marker(s)")
     print(f"  {len(data['season_summaries'])} season summary/summaries")

--- a/tools/generate_story_summary.py
+++ b/tools/generate_story_summary.py
@@ -188,7 +188,7 @@ def assemble_story_summary_input(
     parts: list[str] = []
 
     # -- Overview context --
-    parts.append(f"## Campaign Scope")
+    parts.append("## Campaign Scope")
     parts.append(f"Turns covered: {first_turn} through {last_turn}")
     parts.append(f"Total events: {len(events)}")
     parts.append(f"Total entities tracked: {len(grouped)}")

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -783,7 +783,7 @@ class LLMClient:
                 val = float(f"0.{right.replace('.', '')}")
                 return f'"confidence": {min(val, 1.0)}'
         except (ValueError, TypeError):
-            return f'"confidence": 0.5'
+            return '"confidence": 0.5'
 
     def generate_text(
         self,

--- a/tools/narrative_synthesis.py
+++ b/tools/narrative_synthesis.py
@@ -621,7 +621,7 @@ def _build_infobox(entity_id: str, catalog_data: dict | None,
     elif derived_profile:
         entity_type = derived_profile.get("type", "unknown").replace("_", " ").title()
         lines.append(f"| **Type** | {entity_type} |")
-        lines.append(f"| **Source** | Events only (no catalog entry) |")
+        lines.append("| **Source** | Events only (no catalog entry) |")
         first = derived_profile.get("first_event_turn", "")
         last = derived_profile.get("last_event_turn", "")
         if first:
@@ -815,7 +815,7 @@ def assemble_character_page(entity_id: str, entity_name: str,
 
     # Footer
     lines += ["---",
-              f"*Generated from events data — do not edit manually.*"]
+              "*Generated from events data — do not edit manually.*"]
 
     return "\n".join(lines) + "\n"
 
@@ -872,7 +872,7 @@ def assemble_location_page(entity_id: str, entity_name: str,
         lines.append("")
 
     lines += ["---",
-              f"*Generated from events data — do not edit manually.*"]
+              "*Generated from events data — do not edit manually.*"]
     return "\n".join(lines) + "\n"
 
 
@@ -939,7 +939,7 @@ def assemble_faction_page(entity_id: str, entity_name: str,
                                     linked_entities=linked), ""]
 
     lines += ["---",
-              f"*Generated from events data — do not edit manually.*"]
+              "*Generated from events data — do not edit manually.*"]
     return "\n".join(lines) + "\n"
 
 
@@ -976,7 +976,7 @@ def assemble_item_page(entity_id: str, entity_name: str,
                                     linked_entities=linked), ""]
 
     lines += ["---",
-              f"*Generated from events data — do not edit manually.*"]
+              "*Generated from events data — do not edit manually.*"]
     return "\n".join(lines) + "\n"
 
 

--- a/tools/recover_postprocess.py
+++ b/tools/recover_postprocess.py
@@ -203,7 +203,7 @@ def main():
         # Rewrite stale IDs in relationships and events so dangling cleanup
         # redirects references to survivors instead of deleting them.
         _rewrite_stale_ids(catalogs, events_list, merge_map)
-        print(f"  Rewrote stale IDs in relationships and events")
+        print("  Rewrote stale IDs in relationships and events")
 
     # --- Pass 4: Cleanup dangling relationships + dedup relationships (#242) ---
     print("\n=== Pass 4: Cleanup dangling relationships + dedup ===")

--- a/tools/retry_failed_turns.py
+++ b/tools/retry_failed_turns.py
@@ -277,7 +277,7 @@ def main():
     event_count_before = len(events_list)
 
     print(f"Base catalogs: {entity_count_before} entities, {event_count_before} events")
-    print(f"\nStarting parallel extraction...")
+    print("\nStarting parallel extraction...")
     print("-" * 60)
 
     t_start = time.monotonic()
@@ -366,7 +366,7 @@ def main():
 
     # Merge all successful results into the base catalogs
     if succeeded > 0:
-        print(f"\nMerging results into catalogs...")
+        print("\nMerging results into catalogs...")
         # Sort results by turn number for deterministic merge order
         results.sort(key=lambda r: r[0])
         catalogs, events_list, timeline = merge_parallel_results(

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -28,7 +28,6 @@ from catalog_merger import (
     load_events,
     save_catalogs,
     save_events,
-    format_known_entities,
     format_known_entities_bounded,
     find_entity_by_id,
     merge_entity,
@@ -43,7 +42,6 @@ from catalog_merger import (
     _strip_any_prefix,
     _levenshtein,
     CATALOG_KEYS,
-    _filter_entity_aliases,
     _estimate_tokens,
     _find_mentioned_entities,
 )
@@ -2260,7 +2258,7 @@ def _create_orphan_stubs(catalogs: dict, events: list, turn_id: str,
             "id": eid,
             "name": inferred_name,
             "type": inferred_type,
-            "identity": f"Entity referenced in events (stub — auto-created from event data).",
+            "identity": "Entity referenced in events (stub — auto-created from event data).",
             "first_seen_turn": effective_turn,
             "last_updated_turn": turn_id,
             "notes": "Auto-created by event-stub.",
@@ -5437,7 +5435,7 @@ def _extract_segmented(
                 )
             except QuotaExhaustedError as e:
                 print(f"\n  QUOTA EXHAUSTED at {turn_id}: {e}", file=sys.stderr)
-                print(f"  Stopping extraction to preserve quota.", file=sys.stderr)
+                print("  Stopping extraction to preserve quota.", file=sys.stderr)
                 seg_failed_turns.append(turn_id)
                 # Mark remaining turns in this segment as failed
                 for j in range(i + 1, len(segment_turns)):
@@ -5639,7 +5637,7 @@ def _extract_segmented(
         print(f"\n  WARNING: {len(all_failed_turns)} turn(s) had extraction failures:", file=sys.stderr)
         for tid in all_failed_turns:
             print(f"    - {tid}", file=sys.stderr)
-        print(f"  These turns should be re-extracted when the LLM is available.", file=sys.stderr)
+        print("  These turns should be re-extracted when the LLM is available.", file=sys.stderr)
 
     print(f"  Segmented extraction complete: {entities_final} entities, {len(final_events)} events, {len(final_timeline)} temporal signals")
 
@@ -6091,7 +6089,7 @@ def extract_semantic_batch(
             )
         except QuotaExhaustedError as e:
             print(f"\n  QUOTA EXHAUSTED at {turn_id}: {e}", file=sys.stderr)
-            print(f"  Stopping extraction to preserve quota.", file=sys.stderr)
+            print("  Stopping extraction to preserve quota.", file=sys.stderr)
             failed_turns.append(turn_id)
             # Mark remaining turns as failed
             for j in range(i + 1, total):
@@ -6230,7 +6228,7 @@ def extract_semantic_batch(
         print(f"\n  WARNING: {len(failed_turns)} turn(s) had extraction failures:", file=sys.stderr)
         for tid in failed_turns:
             print(f"    - {tid}", file=sys.stderr)
-        print(f"  These turns should be re-extracted when the LLM is available.", file=sys.stderr)
+        print("  These turns should be re-extracted when the LLM is available.", file=sys.stderr)
 
     # Post-batch dedup: merge entities that share the same name/aliases but got separate IDs
     dupes_merged, merge_map = _dedup_catalogs(catalogs)

--- a/tools/temporal_extraction.py
+++ b/tools/temporal_extraction.py
@@ -1048,8 +1048,8 @@ def generate_timeline_wiki_page(timeline: list[dict],
     anchor_turn = anchor.get("turn", "turn-001")
 
     lines.append("## Current Position\n")
-    lines.append(f"| | |")
-    lines.append(f"|---|---|")
+    lines.append("| | |")
+    lines.append("|---|---|")
     lines.append(f"| **Current Season** | {season_label} |")
     lines.append(f"| **Estimated Day** | Day {est_day} |")
     lines.append(f"| **Anchor Event** | {anchor_label} ({anchor_turn}) |")

--- a/tools/update_state.py
+++ b/tools/update_state.py
@@ -35,7 +35,7 @@ def list_turns(transcript_dir: str) -> list[dict]:
                 content = f.read()
             # Strip the heading line to get the raw text
             lines = content.split("\n")
-            text_lines = [l for l in lines if not l.startswith("# turn-")]
+            text_lines = [line for line in lines if not line.startswith("# turn-")]
             text = "\n".join(text_lines).strip()
             turns.append(
                 {


### PR DESCRIPTION
﻿## Summary

Fix 55 ruff lint findings across the codebase. All fixes are purely mechanical with no runtime behavior changes.

## Changes

| Rule | Count | Fix Applied |
|------|-------|-------------|
| F541 | 25 | Removed  prefix from strings without placeholders |
| F401 | 6 | Removed unused imports |
| F811 | 8 | Removed redundant import re-definitions |
| E741 | 12 | Renamed ambiguous variable l to line or lbl |
| F841 | 2 | Removed/renamed unused local variables (esp → _, removed 	ouched_entities) |

## Not Fixed

- **E402** (5 instances): Module-level imports not at top of file — intentionally left because moving these would change runtime behavior (they depend on sys.path manipulation above them, or are intentionally grouped with related test classes).

## Testing

All 1707 tests pass with no regressions.
