### PR TITLE
fix: wire per-call timeout from /chat/send to bridge sendPrompt

### DIFF
--- a/crew/bridge/src/index.ts
+++ b/crew/bridge/src/index.ts
@@ -13,8 +13,11 @@ export interface BridgeOptions extends VSCodeLaunchOptions {
 }
 
 export interface VSCodeBridge {
-  /** Send a prompt to the specified agent and return the full response text. */
-  sendPrompt(agent: string, prompt: string): Promise<string>;
+  /**
+   * Send a prompt to the specified agent and return the full response text.
+   * @param timeout - Per-call timeout in ms. Falls back to the session default when omitted.
+   */
+  sendPrompt(agent: string, prompt: string, timeout?: number): Promise<string>;
   /** Start a new chat session, resetting conversation context. */
   newChat(): Promise<void>;
   /** Close VS Code and clean up. */
@@ -72,10 +75,10 @@ async function buildBridge(
   const defaultTimeout = options?.defaultTimeout ?? 120_000;
 
   const bridge: VSCodeBridge = {
-    async sendPrompt(agent: string, prompt: string): Promise<string> {
+    async sendPrompt(agent: string, prompt: string, timeout?: number): Promise<string> {
       tracker.recordSend(prompt.length);
       await chat.selectAgent(agent);
-      const response = await chat.sendAndRead(prompt, defaultTimeout);
+      const response = await chat.sendAndRead(prompt, timeout ?? defaultTimeout);
       tracker.recordReceive(response.length);
       return response;
     },

--- a/crew/bridge/src/server.ts
+++ b/crew/bridge/src/server.ts
@@ -112,7 +112,7 @@ async function handleChatSend(req: http.IncomingMessage, res: http.ServerRespons
     return;
   }
 
-  const response = await bridge.sendPrompt(body.agent, body.prompt);
+  const response = await bridge.sendPrompt(body.agent, body.prompt, body.timeout);
   jsonResponse(res, 200, { response });
 }
 

--- a/crew/bridge/src/server.ts
+++ b/crew/bridge/src/server.ts
@@ -111,6 +111,10 @@ async function handleChatSend(req: http.IncomingMessage, res: http.ServerRespons
     jsonResponse(res, 400, { error: 'Missing or invalid "prompt" field.' });
     return;
   }
+  if (body.timeout !== undefined && (typeof body.timeout !== 'number' || body.timeout <= 0 || !isFinite(body.timeout))) {
+    jsonResponse(res, 400, { error: '"timeout" must be a positive finite number.' });
+    return;
+  }
 
   const response = await bridge.sendPrompt(body.agent, body.prompt, body.timeout);
   jsonResponse(res, 200, { response });


### PR DESCRIPTION
﻿## Summary

Wire the 	imeout field from the /chat/send HTTP request body through to ridge.sendPrompt() so callers can override the session-level default timeout on a per-call basis.

## Changes

- **crew/bridge/src/index.ts**: Added optional 	imeout?: number parameter to VSCodeBridge.sendPrompt() interface. Updated uildBridge implementation to use the per-call timeout when provided, falling back to defaultTimeout when omitted.
- **crew/bridge/src/server.ts**: Pass ody.timeout from handleChatSend to ridge.sendPrompt().

## Testing

- TypeScript build passes (
pm run build)
- Playwright test suite passes (smoke/diagnostic tests skip correctly without live VS Code)

Closes #351
