### PR TITLE
docs: add no-hardcoded-word-lists architecture principle

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -75,6 +75,15 @@ When a code change alters tool behavior, data flow, schemas, or output format:
 - Include documentation updates in the same PR as the code change, not as a separate follow-up.
 - Agent prompt files (`.prompt.md`) must include a "Documentation Updates" section listing which docs to update and what to add.
 
+### 9. No Hardcoded Word Lists
+
+Do not add hardcoded lists of domain-specific words (body parts, game terms, abstract concepts, combat actions, elements, role names, etc.) as programmatic entity filters in Python code.
+
+- Entity classification and rejection logic belongs in LLM extraction templates (`templates/extraction/*.md`), not in Python code.
+- Only function words (articles, prepositions: `a`, `an`, `the`, `of`) and pronoun stems (`he`, `she`, `they`) are acceptable as inline constants.
+- If a PR adds a set or list of more than 5 domain-specific strings used for entity rejection, reject it during review.
+- Existing hardcoded word lists are technical debt — do not extend them; migrate filtering to templates instead.
+
 ---
 
 ## File Conventions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,7 +80,7 @@ When a code change alters tool behavior, data flow, schemas, or output format:
 Do not add hardcoded lists of domain-specific words (body parts, game terms, abstract concepts, combat actions, elements, role names, etc.) as programmatic entity filters in Python code.
 
 - Entity classification and rejection logic belongs in LLM extraction templates (`templates/extraction/*.md`), not in Python code.
-- Only function words (articles, prepositions: `a`, `an`, `the`, `of`) and pronoun stems (`he`, `she`, `they`) are acceptable as inline constants.
+- Only function words (articles, prepositions: `a`, `an`, `the`, `of`) and pronoun stems (`he`, `she`, `they`, `it`) are acceptable as inline constants.
 - If a PR adds a set or list of more than 5 domain-specific strings used for entity rejection, reject it during review.
 - Existing hardcoded word lists are technical debt — do not extend them; migrate filtering to templates instead.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -315,6 +315,35 @@ The `crew/bridge/` directory contains a TypeScript HTTP server that bridges Crew
 
 ---
 
+## Architecture Principles
+
+### No Hardcoded Word Lists in Programmatic Filters
+
+Entity filtering MUST NOT use hardcoded lists of specific words (body parts, common nouns, game terms, combat actions, elements, role names, etc.) in Python code. This approach is:
+
+- **Not scalable** — every new edge case requires adding more words (whack-a-mole)
+- **Not semantically grounded** — a flat word list cannot distinguish context-dependent meanings
+- **A maintenance burden** — lists grow indefinitely and interact unpredictably
+
+The LLM extraction templates (`templates/extraction/*.md`) are the correct place to define what constitutes a valid entity. Templates have semantic understanding and can apply nuanced classification rules that word lists cannot.
+
+**Acceptable inline constants:**
+
+- Function words and articles used for tokenization: `a`, `an`, `the`, `of`
+- Pronoun stems used for ID generation: `he`, `she`, `they`, `it`
+
+**NOT acceptable as inline constants:**
+
+- Domain-specific word lists: body parts, combat terms, elements, role names, generic nouns, abstract concepts
+- Any set of >5 domain-specific strings used for entity rejection
+
+**Policy:**
+
+- Existing hardcoded word lists in the codebase are technical debt to be migrated to template-based filtering
+- New PRs that add hardcoded domain-specific word lists for entity filtering MUST be rejected during review
+
+---
+
 ## Design Decisions
 
 ### Why file-based?

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -329,7 +329,7 @@ The LLM extraction templates (`templates/extraction/*.md`) are the correct place
 
 **Acceptable inline constants:**
 
-- Function words and articles used for tokenization: `a`, `an`, `the`, `of`
+- Function words (articles and prepositions) used for tokenization: `a`, `an`, `the`, `of`
 - Pronoun stems used for ID generation: `he`, `she`, `they`, `it`
 
 **NOT acceptable as inline constants:**


### PR DESCRIPTION
## Summary

Establishes the architectural principle that entity filtering must use LLM extraction templates, not hardcoded word lists in Python code.

### Changes

1. **`docs/architecture.md`** — Added "Architecture Principles" section with a "No Hardcoded Word Lists in Programmatic Filters" principle. Documents why word lists are problematic (not scalable, not semantically grounded, maintenance burden), what is acceptable (function words, pronoun stems), and the policy (existing lists are tech debt, new additions rejected in review).

2. **`.github/copilot-instructions.md`** — Added Rule 9 "No Hardcoded Word Lists" to the Core Rules. Instructs Copilot to reject PRs that add domain-specific word lists as programmatic entity filters, and to direct entity classification logic to LLM templates instead.

### Rationale

Hardcoded word lists for entity rejection are a whack-a-mole pattern that does not scale. The LLM extraction templates have semantic understanding and are the correct layer for defining what constitutes a valid entity. This principle codifies that boundary.
