### PR TITLE
feat: register A/B tests as orchestrator jobs (#406)

### DIFF
--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -1,4 +1,4 @@
-# A/B Testing Standard
+# A/B Testing
 
 ## When Required
 
@@ -13,22 +13,178 @@ A/B testing is required for any PR that modifies extraction behavior:
 2. **Same model, same turns, same hardware** for both variants
 3. **Results posted as PR comment** with entity count comparison
 
-## Running A/B Tests
+## Overview
 
-Use the orchestrator's AB test adapter or run manually:
+A/B tests compare extraction quality between two code variants (e.g. a feature
+branch vs. `main`) by running `bootstrap_session.py` N times per variant and
+measuring entity counts. Results are tracked on the orchestrator dashboard.
+
+An A/B test is submitted as an `ab_test` task to the orchestrator. The
+orchestrator adapter:
+
+1. Runs `bootstrap_session.py` for each variant × run combination
+2. Counts extracted entities per run
+3. Flags **zero-entity runs** as immediate failures
+4. Computes inter-variant and intra-variant divergence
+5. Reports progress and a final comparison summary to the dashboard
+
+## Prerequisites
+
+- Both variant repos checked out locally (or on the extraction machine)
+- LLM server(s) running and accessible (one URL per variant, or a shared URL)
+- Orchestrator service running (`python -m saas.orchestrator run`)
+
+## Submitting an A/B Test
+
+Use `tools/submit_ab_test.py` to generate a task definition and optionally
+submit it to the orchestrator.
+
+### Minimal example
 
 ```bash
-python saas/orchestrator/scripts/ab_test.py
+python tools/submit_ab_test.py \
+    --pr 399 \
+    --variant-a main \
+    --variant-b feat/my-prompt-change \
+    --repo-a /path/to/repo-main \
+    --repo-b /path/to/repo-feat
 ```
 
-Environment variables:
-- `AB_TEST_REPO_A` — path to main branch worktree
-- `AB_TEST_REPO_B` — path to variant branch worktree
-- `AB_TEST_BASE_URL_A` / `AB_TEST_BASE_URL_B` — LLM endpoint URLs
-- `AB_TEST_RUNS` — number of runs per variant (default: 3)
+This writes `ab-test-pr399.json` and prints the submit command:
+
+```
+To submit:
+  python -m saas.orchestrator submit ab-test-pr399.json
+```
+
+### Submit immediately
+
+```bash
+python tools/submit_ab_test.py \
+    --pr 399 \
+    --variant-a main \
+    --variant-b feat/my-prompt-change \
+    --repo-a /path/to/repo-main \
+    --repo-b /path/to/repo-feat \
+    --submit
+```
+
+### Full options
+
+```
+--pr INT              PR number being tested (required)
+--variant-a BRANCH    Branch name for variant A / baseline (required)
+--variant-b BRANCH    Branch name for variant B / candidate (required)
+--repo-a PATH         Filesystem path to the variant A repo checkout
+--repo-b PATH         Filesystem path to the variant B repo checkout
+--runs INT            Runs per variant (default: orchestrator config, typically 3)
+--turns RANGE         Turn range to process, e.g. "1-30" or "30"
+--base-url-a URL      LLM endpoint for variant A (default: http://localhost:8080/v1)
+--base-url-b URL      LLM endpoint for variant B (default: http://localhost:8081/v1)
+--session PATH        Session directory (e.g. sessions/session-import)
+--transcript PATH     Path to transcript file
+--output-dir PATH     Directory for per-run output files
+--task-id ID          Override auto-generated task ID
+--timeout SECONDS     Task timeout (default: 7200)
+--divergence-threshold FLOAT
+                      Max inter-variant divergence % before flagging (default: 20.0)
+--output FILE         Write task JSON here (default: ab-test-pr<N>.json)
+--submit              Submit immediately via the orchestrator CLI
+--orchestrator-config FILE
+                      Path to orchestrator config.json (only with --submit)
+```
+
+## Task Definition Format
+
+The generated JSON follows the orchestrator's `TaskDefinition` schema:
+
+```json
+{
+  "id": "ab-test-pr399-a1b2c3",
+  "name": "A/B test PR #399: main vs feat/my-change",
+  "adapter": "ab_test",
+  "timeout": 7200,
+  "metadata": {
+    "pr_number": 399,
+    "variant_a_branch": "main",
+    "variant_b_branch": "feat/my-change",
+    "repo_a": "/path/to/repo-main",
+    "repo_b": "/path/to/repo-feat",
+    "runs_per_variant": 3,
+    "turns": "1-30"
+  },
+  "success_criteria": [
+    { "type": "exit_code", "expected": 0 },
+    { "type": "entity_count", "expected": 1 },
+    { "type": "variant_divergence", "expected": 20.0 }
+  ]
+}
+```
+
+You can submit this directly without the helper script:
+
+```bash
+python -m saas.orchestrator submit ab-test-pr399.json
+```
+
+## Monitoring Progress
+
+Check task status on the dashboard or via the CLI:
+
+```bash
+# Table view
+python -m saas.orchestrator status
+
+# JSON output
+python -m saas.orchestrator status --json
+```
+
+The dashboard at `arclight:8080` shows per-variant, per-run progress with live
+entity counts. Zero-entity runs are flagged as errors within 60 seconds of
+completion.
+
+## Result Interpretation
+
+After the task completes, the log output contains:
+
+```
+[RESULT] variant=a run=1 entities=142 exit_code=0 duration=312.5
+[RESULT] variant=a run=2 entities=145 exit_code=0 duration=308.2
+[RESULT] variant=b run=1 entities=138 exit_code=0 duration=320.1
+[RESULT] variant=b run=2 entities=141 exit_code=0 duration=315.7
+[SUMMARY] pr=399 variant_a_mean=143.5 variant_b_mean=139.5 divergence_pct=2.8
+```
+
+| Metric | Description |
+|--------|-------------|
+| `variant_a_mean` / `variant_b_mean` | Average entity count across runs for each variant |
+| `divergence_pct` | `abs(A_mean - B_mean) / max(A_mean, B_mean) × 100` |
+| `max_intra_variant_divergence_pct` | Max spread within the same variant (consistency check) |
+
+The task is marked **failed** if:
+- Any run produces 0 entities
+- `exit_code != 0` for any run
+- Inter-variant divergence exceeds `--divergence-threshold` (default 20 %)
+
+## Log Files
+
+Each run writes an `output.log` under the configured `output_dir`:
+
+```
+<output_dir>/
+  a/run_1/output.log
+  a/run_1/framework/catalogs/...
+  a/run_2/output.log
+  b/run_1/output.log
+  ...
+```
+
+A combined `master.log` is written to the orchestrator's log directory and
+parsed for the structured `[RESULT]` / `[SUMMARY]` lines.
 
 ## Acceptance Criteria
 
 - No variant produces 0 entities (infra failure)
-- Intra-variant divergence < 20%
+- Intra-variant divergence < 20 %
+- Inter-variant divergence within `--divergence-threshold` (default 20 %)
 - Results clearly demonstrate the PR's claimed improvement

--- a/tools/submit_ab_test.py
+++ b/tools/submit_ab_test.py
@@ -6,7 +6,7 @@ optionally submits it directly via the orchestrator CLI.
 
 The orchestrator adapter runs bootstrap_session.py for each variant × run
 combination, collects per-run entity counts, and flags anomalies (zero-entity
-runs, >20 % intra-variant divergence) on the dashboard.
+runs, >20 % inter-variant divergence) on the dashboard.
 
 Usage
 -----
@@ -44,8 +44,23 @@ import uuid
 from pathlib import Path
 
 
-_BRANCH_PATTERN = re.compile(r'^[a-zA-Z0-9/_.\-]+$')
 _TASK_ID_PATTERN = re.compile(r'^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$')
+
+
+def _validate_branch_name(name: str) -> bool:
+    """Validate branch name using git check-ref-format (authoritative).
+
+    Falls back to a permissive regex if git is not available.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "check-ref-format", "--branch", name],
+            capture_output=True,
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        # git not available — fall back to permissive pattern
+        return bool(re.match(r'^[^\x00-\x1f ~^:?*\[\\]+$', name))
 
 
 def _make_task_id(pr: int, suffix: str | None = None) -> str:
@@ -70,7 +85,7 @@ def build_task(args: argparse.Namespace) -> dict:
         ("variant_a", args.variant_a),
         ("variant_b", args.variant_b),
     ]:
-        if value and not _BRANCH_PATTERN.match(value):
+        if value and not _validate_branch_name(value):
             raise ValueError(f"Invalid branch name for {field}: {value!r}")
 
     metadata: dict = {
@@ -78,9 +93,9 @@ def build_task(args: argparse.Namespace) -> dict:
         "variant_a_branch": args.variant_a,
         "variant_b_branch": args.variant_b,
     }
-    if args.runs:
+    if args.runs is not None:
         metadata["runs_per_variant"] = args.runs
-    if args.turns:
+    if args.turns is not None:
         metadata["turns"] = args.turns
     if args.repo_a:
         metadata["repo_a"] = str(Path(args.repo_a).resolve())
@@ -132,8 +147,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--runs", type=int, default=None,
                         help="Runs per variant (default: orchestrator config, typically 3)")
     parser.add_argument("--turns", default=None, help="Turn range, e.g. '1-30' or '30'")
-    parser.add_argument("--base-url-a", default=None, help="LLM endpoint URL for variant A")
-    parser.add_argument("--base-url-b", default=None, help="LLM endpoint URL for variant B")
+    parser.add_argument("--base-url-a", default="http://localhost:8080/v1",
+                        help="LLM endpoint URL for variant A (default: http://localhost:8080/v1)")
+    parser.add_argument("--base-url-b", default="http://localhost:8081/v1",
+                        help="LLM endpoint URL for variant B (default: http://localhost:8081/v1)")
     parser.add_argument("--session", default=None, help="Session path (e.g. sessions/session-import)")
     parser.add_argument("--transcript", default=None, help="Path to transcript file")
     parser.add_argument("--output-dir", default=None, help="Directory for per-run output files")
@@ -153,7 +170,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--orchestrator-config", default=None,
                         help="Path to orchestrator config.json (only used with --submit)")
 
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+
+    if args.runs is not None and args.runs < 1:
+        parser.error("--runs must be >= 1")
+
+    return args
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -168,7 +190,12 @@ def main(argv: list[str] | None = None) -> int:
     task_json = json.dumps(task, indent=2)
 
     out_path = Path(args.output) if args.output else Path(f"ab-test-pr{args.pr}.json")
-    out_path.write_text(task_json + "\n", encoding="utf-8")
+    try:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(task_json + "\n", encoding="utf-8")
+    except OSError as exc:
+        print(f"Error writing {out_path}: {exc}", file=sys.stderr)
+        return 1
     print(f"Task definition written to: {out_path}", file=sys.stderr)
     print(task_json)
 

--- a/tools/submit_ab_test.py
+++ b/tools/submit_ab_test.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Submit an A/B extraction quality test to the orchestrator.
+
+Generates a TaskDefinition JSON file for the ``ab_test`` adapter and
+optionally submits it directly via the orchestrator CLI.
+
+The orchestrator adapter runs bootstrap_session.py for each variant × run
+combination, collects per-run entity counts, and flags anomalies (zero-entity
+runs, >20 % intra-variant divergence) on the dashboard.
+
+Usage
+-----
+    # Generate and immediately submit:
+    python tools/submit_ab_test.py \\
+        --pr 399 \\
+        --variant-a main \\
+        --variant-b feat/my-change \\
+        --repo-a /path/to/repo-a \\
+        --repo-b /path/to/repo-b \\
+        --submit
+
+    # Generate JSON only (inspect before submitting):
+    python tools/submit_ab_test.py \\
+        --pr 399 \\
+        --variant-a main \\
+        --variant-b feat/my-change \\
+        --repo-a /path/to/repo-a \\
+        --repo-b /path/to/repo-b \\
+        --output /tmp/ab-test-pr399.json
+
+Environment variables (set by the orchestrator; not needed for JSON generation):
+    AB_TEST_PR, AB_TEST_VARIANT_A, AB_TEST_VARIANT_B, AB_TEST_RUNS,
+    AB_TEST_TURNS, AB_TEST_BASE_URL_A, AB_TEST_BASE_URL_B,
+    AB_TEST_REPO_A, AB_TEST_REPO_B, AB_TEST_SESSION, AB_TEST_TRANSCRIPT,
+    AB_TEST_OUTPUT_DIR
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+
+_BRANCH_PATTERN = re.compile(r'^[a-zA-Z0-9/_.\-]+$')
+_TASK_ID_PATTERN = re.compile(r'^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$')
+
+
+def _make_task_id(pr: int, suffix: str | None = None) -> str:
+    """Generate a valid task ID for the orchestrator."""
+    short = uuid.uuid4().hex[:6]
+    base = f"ab-test-pr{pr}-{short}"
+    if suffix:
+        safe = re.sub(r'[^a-z0-9-]', '-', suffix.lower())[:20].strip('-')
+        base = f"ab-test-pr{pr}-{safe}-{short}"
+    return base[:64].rstrip('-')
+
+
+def build_task(args: argparse.Namespace) -> dict:
+    """Build a TaskDefinition dict from parsed arguments."""
+    task_id = args.task_id or _make_task_id(args.pr)
+    if not _TASK_ID_PATTERN.match(task_id):
+        raise ValueError(
+            f"Invalid task ID '{task_id}': must match ^[a-z0-9][a-z0-9-]{{0,62}}[a-z0-9]$"
+        )
+
+    for field, value in [
+        ("variant_a", args.variant_a),
+        ("variant_b", args.variant_b),
+    ]:
+        if value and not _BRANCH_PATTERN.match(value):
+            raise ValueError(f"Invalid branch name for {field}: {value!r}")
+
+    metadata: dict = {
+        "pr_number": args.pr,
+        "variant_a_branch": args.variant_a,
+        "variant_b_branch": args.variant_b,
+    }
+    if args.runs:
+        metadata["runs_per_variant"] = args.runs
+    if args.turns:
+        metadata["turns"] = args.turns
+    if args.repo_a:
+        metadata["repo_a"] = str(Path(args.repo_a).resolve())
+    if args.repo_b:
+        metadata["repo_b"] = str(Path(args.repo_b).resolve())
+    if args.base_url_a:
+        metadata["base_url_a"] = args.base_url_a
+    if args.base_url_b:
+        metadata["base_url_b"] = args.base_url_b
+    if args.session:
+        metadata["session"] = args.session
+    if args.transcript:
+        metadata["transcript"] = args.transcript
+    if args.output_dir:
+        metadata["output_dir"] = args.output_dir
+
+    task = {
+        "id": task_id,
+        "name": f"A/B test PR #{args.pr}: {args.variant_a} vs {args.variant_b}",
+        "adapter": "ab_test",
+        "timeout": args.timeout,
+        "metadata": metadata,
+        "success_criteria": [
+            {"type": "exit_code", "expected": 0},
+            {"type": "entity_count", "expected": 1},
+            {"type": "variant_divergence", "expected": args.divergence_threshold},
+        ],
+    }
+    return task
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Submit an A/B extraction quality test to the orchestrator.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    # Required
+    parser.add_argument("--pr", type=int, required=True, help="PR number being tested")
+    parser.add_argument("--variant-a", required=True, help="Branch name for variant A (baseline)")
+    parser.add_argument("--variant-b", required=True, help="Branch name for variant B (candidate)")
+
+    # Repo paths
+    parser.add_argument("--repo-a", help="Filesystem path to the variant A repo checkout")
+    parser.add_argument("--repo-b", help="Filesystem path to the variant B repo checkout")
+
+    # Optional extraction config
+    parser.add_argument("--runs", type=int, default=None,
+                        help="Runs per variant (default: orchestrator config, typically 3)")
+    parser.add_argument("--turns", default=None, help="Turn range, e.g. '1-30' or '30'")
+    parser.add_argument("--base-url-a", default=None, help="LLM endpoint URL for variant A")
+    parser.add_argument("--base-url-b", default=None, help="LLM endpoint URL for variant B")
+    parser.add_argument("--session", default=None, help="Session path (e.g. sessions/session-import)")
+    parser.add_argument("--transcript", default=None, help="Path to transcript file")
+    parser.add_argument("--output-dir", default=None, help="Directory for per-run output files")
+
+    # Task config
+    parser.add_argument("--task-id", default=None, help="Override auto-generated task ID")
+    parser.add_argument("--timeout", type=int, default=7200,
+                        help="Task timeout in seconds (default: 7200)")
+    parser.add_argument("--divergence-threshold", type=float, default=20.0,
+                        help="Max allowed inter-variant divergence %% before flagging (default: 20.0)")
+
+    # Output / submission
+    parser.add_argument("--output", "-o", default=None,
+                        help="Write task JSON to this file (default: ab-test-pr<N>.json)")
+    parser.add_argument("--submit", action="store_true",
+                        help="Submit immediately via 'python -m saas.orchestrator submit'")
+    parser.add_argument("--orchestrator-config", default=None,
+                        help="Path to orchestrator config.json (only used with --submit)")
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    try:
+        task = build_task(args)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    task_json = json.dumps(task, indent=2)
+
+    out_path = Path(args.output) if args.output else Path(f"ab-test-pr{args.pr}.json")
+    out_path.write_text(task_json + "\n", encoding="utf-8")
+    print(f"Task definition written to: {out_path}", file=sys.stderr)
+    print(task_json)
+
+    if args.submit:
+        cmd = [sys.executable, "-m", "saas.orchestrator", "submit", str(out_path)]
+        if args.orchestrator_config:
+            cmd += ["--config", args.orchestrator_config]
+        print(f"\nSubmitting: {' '.join(cmd)}", file=sys.stderr)
+        result = subprocess.run(cmd)
+        return result.returncode
+
+    print(
+        f"\nTo submit:\n  python -m saas.orchestrator submit {out_path}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

A/B tests were previously run as ad-hoc shell scripts via SSH, invisible to the orchestrator dashboard — failures were silent and only discovered by manual log inspection.

This PR adds the public-facing interface for submitting A/B tests as orchestrator jobs (closes #406).

## Changes

### `tools/submit_ab_test.py`

CLI helper that generates an `ab_test` TaskDefinition JSON for the orchestrator. Accepts:
- `--pr` — PR number being tested
- `--variant-a` / `--variant-b` — branch names for baseline vs candidate
- `--repo-a` / `--repo-b` — filesystem paths to the two repo checkouts
- `--runs`, `--turns`, `--base-url-a/b`, `--session`, `--transcript` — extraction config
- `--submit` — submit immediately via `python -m saas.orchestrator submit`

The generated JSON includes success criteria for exit code, entity count, and variant divergence (flags >20 % inter-variant divergence by default).

### `docs/ab-testing.md`

Usage guide covering:
- Prerequisites and submission workflow
- Full flag reference
- Task definition format (for manual submission)
- Monitoring via dashboard (`arclight:8080`) and CLI
- Result interpretation (metrics, failure conditions)
- Log file layout

## Testing

```bash
python tools/submit_ab_test.py \
    --pr 399 \
    --variant-a main \
    --variant-b feat/my-change \
    --repo-a /tmp/repo-a \
    --repo-b /tmp/repo-b
```

All 1691 existing tests pass (`pytest tests/`).