### PR TITLE
feat: auto-label PRs needing A/B test when extraction paths modified

### DIFF
--- a/.github/workflows/label-ab-test.yml
+++ b/.github/workflows/label-ab-test.yml
@@ -52,6 +52,6 @@ jobs:
             if (!botComment) {
               await github.rest.issues.createComment({
                 owner, repo, issue_number: pr_number,
-                body: `## ⚠️ A/B Test Required\n\nThis PR modifies extraction behavior (files in \`templates/extraction/\` or extraction tools). Per [A/B test standard](docs/ab-test-standard.md), extraction quality changes require empirical validation before merge.\n\n**Required before merge:**\n- [ ] A/B test results posted as a PR comment\n- [ ] ≥3 paired runs with both variants\n- [ ] Entity count comparison with acceptable variance\n\nSee the [A/B testing guide](docs/ab-test-standard.md) for details.`
+                body: `## ⚠️ A/B Test Required\n\nThis PR modifies extraction behavior (files in \`templates/extraction/\` or extraction tools). Per [A/B test standard](docs/ab-testing.md), extraction quality changes require empirical validation before merge.\n\n**Required before merge:**\n- [ ] A/B test results posted as a PR comment\n- [ ] ≥3 paired runs with both variants\n- [ ] Entity count comparison with acceptable variance\n\nSee the [A/B testing guide](docs/ab-testing.md) for details.`
               });
             }

--- a/.github/workflows/label-ab-test.yml
+++ b/.github/workflows/label-ab-test.yml
@@ -1,0 +1,42 @@
+name: Label PRs needing A/B test
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'templates/extraction/**'
+      - 'tools/semantic_extraction.py'
+      - 'tools/bootstrap_session.py'
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr_number = context.payload.pull_request.number;
+
+            // Add label
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: pr_number,
+              labels: ['needs-ab-test']
+            });
+
+            // Check if we already commented
+            const comments = await github.rest.issues.listComments({
+              owner, repo, issue_number: pr_number
+            });
+            const botComment = comments.data.find(c =>
+              c.body.includes('This PR modifies extraction behavior')
+            );
+
+            if (!botComment) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: pr_number,
+                body: `## ⚠️ A/B Test Required\n\nThis PR modifies extraction behavior (files in \`templates/extraction/\` or extraction tools). Per [A/B test standard](docs/ab-test-standard.md), extraction quality changes require empirical validation before merge.\n\n**Required before merge:**\n- [ ] A/B test results posted as a PR comment\n- [ ] ≥3 paired runs with both variants\n- [ ] Entity count comparison with acceptable variance\n\nSee the [A/B testing guide](docs/ab-test-standard.md) for details.`
+              });
+            }

--- a/.github/workflows/label-ab-test.yml
+++ b/.github/workflows/label-ab-test.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/github-script@v7
         with:
@@ -20,17 +21,31 @@ jobs:
             const { owner, repo } = context.repo;
             const pr_number = context.payload.pull_request.number;
 
+            // Ensure label exists (handles fresh repos)
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: 'needs-ab-test' });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner, repo, name: 'needs-ab-test',
+                  color: 'D93F0B',
+                  description: 'PR requires A/B test before merge'
+                });
+              }
+            }
+
             // Add label
             await github.rest.issues.addLabels({
               owner, repo, issue_number: pr_number,
               labels: ['needs-ab-test']
             });
 
-            // Check if we already commented
-            const comments = await github.rest.issues.listComments({
-              owner, repo, issue_number: pr_number
-            });
-            const botComment = comments.data.find(c =>
+            // Check if we already commented (paginate to avoid missing on busy PRs)
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: pr_number, per_page: 100 }
+            );
+            const botComment = comments.find(c =>
               c.body.includes('This PR modifies extraction behavior')
             );
 

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -1,0 +1,34 @@
+# A/B Testing Standard
+
+## When Required
+
+A/B testing is required for any PR that modifies extraction behavior:
+- Files under `templates/extraction/`
+- `tools/semantic_extraction.py`
+- `tools/bootstrap_session.py`
+
+## Requirements
+
+1. **Minimum 3 paired runs** per variant (both A and B valid in same run)
+2. **Same model, same turns, same hardware** for both variants
+3. **Results posted as PR comment** with entity count comparison
+
+## Running A/B Tests
+
+Use the orchestrator's AB test adapter or run manually:
+
+```bash
+python saas/orchestrator/scripts/ab_test.py
+```
+
+Environment variables:
+- `AB_TEST_REPO_A` — path to main branch worktree
+- `AB_TEST_REPO_B` — path to variant branch worktree
+- `AB_TEST_BASE_URL_A` / `AB_TEST_BASE_URL_B` — LLM endpoint URLs
+- `AB_TEST_RUNS` — number of runs per variant (default: 3)
+
+## Acceptance Criteria
+
+- No variant produces 0 entities (infra failure)
+- Intra-variant divergence < 20%
+- Results clearly demonstrate the PR's claimed improvement


### PR DESCRIPTION
## Summary

Adds automated detection and labeling for PRs that require A/B testing.

When a PR modifies files under `templates/extraction/`, `tools/semantic_extraction.py`, or `tools/bootstrap_session.py`, a GitHub Actions workflow automatically:
1. Applies the `needs-ab-test` label
2. Posts a comment explaining the A/B testing requirement with checklist

This prevents premature approvals and ensures extraction quality changes go through empirical validation.

Closes #417
