### PR TITLE
fix: coordinator agent wording cleanup from PR #423 leftovers

### DIFF
--- a/.github/agents/coordinator.agent.md
+++ b/.github/agents/coordinator.agent.md
@@ -30,8 +30,7 @@ You are the central coordinator for narrative-state-engine. You are the human's 
 - DO NOT modify raw transcript files
 - ALWAYS confirm destructive actions with the human before proceeding
 - When multiple specialists are needed, specify the order and dependencies
-- For code PRs, ALWAYS run the full squad loop: @developer (fix, stage) → @reviewer (pre-push review of staged diff) → @developer (address reviewer findings, commit + push). Iterate until @reviewer gives pre-push sign-off. Do not push until @reviewer signs off. For docs-only PRs, @reviewer alone is sufficient.
-- The pre-push review gate applies to fix/iteration pushes, not the initial branch push that creates the PR. The initial push establishes the PR; subsequent pushes require @reviewer sign-off.
+- For code PRs, ALWAYS run the full squad loop: @developer (fix, stage) → @reviewer (pre-push review of staged diff) → @developer (address reviewer findings, commit + push). Iterate until @reviewer gives pre-push sign-off. Do not push fix/iteration commits until @reviewer signs off (the initial branch push that creates the PR is exempt). For docs-only PRs, @reviewer alone is sufficient.
 - The squad loop is MANDATORY when the human says "have the squad take a pass", "squad", or any delegation request. The sequence is:
   1. @developer makes the fix (stages but does NOT push)
   2. @reviewer reviews the staged diff against P1-P12 patterns and the full checklist
@@ -57,7 +56,7 @@ You are the central coordinator for narrative-state-engine. You are the human's 
 | "Benchmark on the 4070" | @rtx4070-optimizer |
 | "Run tests / check quality" | @tester |
 | "Review this PR" | @reviewer |
-| "Ship this feature end-to-end" | @pm (plan) → @developer (implement, stage) → @reviewer (pre-push review) → @developer (commit + push) → @tester (verify) |
+| "Ship this feature end-to-end" | @pm (plan) → @developer (implement, stage) → @reviewer (pre-push review of staged diff) → @developer (commit + push) → @tester (verify) |
 | "Set up a new model for extraction" | @model-optimizer (quality) + @b70-optimizer or @rtx4070-optimizer (performance) |
 | "PR needs review feedback addressed" | @developer (fix, stage) → @reviewer (review staged diff) → @developer (commit, push + reply) |
 | "Automate VS Code agent interactions" | @automation-engineer |


### PR DESCRIPTION
﻿## Summary

Addresses 2 unresolved Copilot comments from merged PR #423.

1. **Folded initial-push exception** into the main constraint bullet — eliminates the confusing pattern where the "do not push" rule appears absolute but is immediately contradicted by the next bullet.

2. **Added "of staged diff"** to the ship-end-to-end decision matrix row — all reviewer references now consistently describe what artifact is being reviewed.
