### PR TITLE
docs: add A/B test standard and checklist

### DIFF
--- a/docs/ab-test-checklist.md
+++ b/docs/ab-test-checklist.md
@@ -1,7 +1,7 @@
 # A/B Test Checklist for Template Changes
 
 Embed this checklist in `.prompt.md` files for PRs that modify `templates/extraction/*.md`.
-Full standard: [docs/ab-test-standard.md](docs/ab-test-standard.md).
+Full standard: [ab-test-standard.md](ab-test-standard.md).
 
 ---
 

--- a/docs/ab-test-checklist.md
+++ b/docs/ab-test-checklist.md
@@ -1,0 +1,132 @@
+# A/B Test Checklist for Template Changes
+
+Embed this checklist in `.prompt.md` files for PRs that modify `templates/extraction/*.md`.
+Full standard: [docs/ab-test-standard.md](ab-test-standard.md).
+
+---
+
+## Pre-Flight
+
+- [ ] Both LLM servers reachable (`curl http://localhost:8000/v1/models`, `:8001`)
+- [ ] On `main` branch, pulled latest
+- [ ] `config/llm.json` unchanged between A and B runs
+- [ ] Output directories created: `framework-ab-a`, `framework-ab-b`
+
+## Run A (Baseline — main branch)
+
+```bash
+# Run 1:
+python tools/bootstrap_session.py \
+    --session sessions/session-import \
+    --file sessions/session-import/raw/full-transcript.md \
+    --extract --framework framework-ab-a-run1 --max-turns 30 --overwrite \
+    --base-url http://localhost:8000/v1
+
+# Run 2:
+python tools/bootstrap_session.py \
+    --session sessions/session-import \
+    --file sessions/session-import/raw/full-transcript.md \
+    --extract --framework framework-ab-a-run2 --max-turns 30 --overwrite \
+    --base-url http://localhost:8000/v1
+
+# Run 3:
+python tools/bootstrap_session.py \
+    --session sessions/session-import \
+    --file sessions/session-import/raw/full-transcript.md \
+    --extract --framework framework-ab-a-run3 --max-turns 30 --overwrite \
+    --base-url http://localhost:8000/v1
+```
+
+- [ ] Run A completed ×3 (minimum). Outputs in `framework-ab-a-run{1,2,3}/catalogs`
+
+## Run B (Candidate — PR branch)
+
+```bash
+git checkout <pr-branch>
+
+# Run 1:
+python tools/bootstrap_session.py \
+    --session sessions/session-import \
+    --file sessions/session-import/raw/full-transcript.md \
+    --extract --framework framework-ab-b-run1 --max-turns 30 --overwrite \
+    --base-url http://localhost:8001/v1
+
+# Run 2:
+python tools/bootstrap_session.py \
+    --session sessions/session-import \
+    --file sessions/session-import/raw/full-transcript.md \
+    --extract --framework framework-ab-b-run2 --max-turns 30 --overwrite \
+    --base-url http://localhost:8001/v1
+
+# Run 3:
+python tools/bootstrap_session.py \
+    --session sessions/session-import \
+    --file sessions/session-import/raw/full-transcript.md \
+    --extract --framework framework-ab-b-run3 --max-turns 30 --overwrite \
+    --base-url http://localhost:8001/v1
+```
+
+- [ ] Run B completed ×3 (minimum). Outputs in `framework-ab-b-run{1,2,3}/catalogs`
+
+## Validation (each run)
+
+```bash
+python tools/validate_extraction.py \
+    --catalog-dir framework-ab-{a,b}-run{N}/catalogs \
+    --ground-truth tests/fixtures/extraction-ground-truth-full-session.json
+
+python tools/validate.py
+```
+
+> **Note:** Use the full-session fixture (`extraction-ground-truth-full-session.json`), NOT the turns-1-30 fixture. The turns-1-30 fixture has a different schema and is not compatible with `validate_extraction.py`.
+
+- [ ] `validate_extraction.py` exits 0 for all B runs
+- [ ] `validate.py` reports 0 schema violations for all B runs
+
+## Metrics Collection
+
+- [ ] Entity counts by type (characters, locations, items, factions, events)
+- [ ] Relationship count (total)
+- [ ] Wall-clock time per run
+- [ ] Mean ± σ computed for all metrics across runs
+
+## Thresholds — Automated (Pass/Fail)
+
+| Metric | PASS | WARN | BLOCK |
+|---|---|---|---|
+| Entity count **loss** | Δ ≤ 5% loss | 5–15% loss | > 15% loss |
+| Entity count **gain** | Δ ≤ 10% gain | 10–20% gain | > 20% gain (hallucination signal) |
+| Single type count **loss** | Δ ≤ 10% loss | 10–20% loss | > 20% loss |
+| Single type count **gain** | Δ ≤ 15% gain | 15–25% gain | > 25% gain (hallucination signal) |
+| Relationship count **loss** | Δ ≤ 10% loss | 10–20% loss | > 20% loss |
+| Relationship count **gain** | Δ ≤ 15% gain | 15–25% gain | > 25% gain (hallucination signal) |
+| Performance regression | Δ ≤ +10% time | +10–20% time | > +20% time |
+| Performance improvement | Always PASS | — | — |
+| Schema validity | 100% | ≥ 95% | < 95% |
+| Ground truth validation | 0 FAILs | — | Any FAIL |
+
+## Manual Review (Recommended)
+
+> ⚠️ These checks require human review. They do NOT block merge but SHOULD be performed for major template changes.
+
+| Metric | PASS | WARN | BLOCK |
+|---|---|---|---|
+| Attribute completeness | ≥ 90% | 75–89% | < 75% |
+| Hallucination rate | 0% | ≤ 5% | > 5% |
+
+## PR Report
+
+- [ ] A/B Test Results section added to PR body (see template in `docs/ab-test-standard.md` §5.1)
+- [ ] All tables filled with mean ± σ values
+- [ ] Zero BLOCK statuses
+- [ ] All WARN statuses have written justification
+- [ ] Verdict checkboxes completed
+
+## Exemptions
+
+No A/B test required for:
+- Comment/formatting-only changes to templates
+- Changes to `dm-profile-analyzer.md`
+- New template files not yet wired into extraction pipeline
+
+State exemption reason under "A/B Test Exemption" heading in PR description.

--- a/docs/ab-test-checklist.md
+++ b/docs/ab-test-checklist.md
@@ -1,7 +1,7 @@
 # A/B Test Checklist for Template Changes
 
 Embed this checklist in `.prompt.md` files for PRs that modify `templates/extraction/*.md`.
-Full standard: [docs/ab-test-standard.md](docs/ab-test-standard.md).
+Full standard: [docs/ab-test-standard.md](ab-test-standard.md).
 
 ---
 
@@ -19,21 +19,21 @@ Full standard: [docs/ab-test-standard.md](docs/ab-test-standard.md).
 python tools/bootstrap_session.py \
     --session sessions/session-import \
     --file sessions/_import/full-transcript.md \
-    --framework framework-ab-a-run1 --max-turns 30 --overwrite \
+    --framework framework-ab-a-run1 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-a>/v1
 
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
     --file sessions/_import/full-transcript.md \
-    --framework framework-ab-a-run2 --max-turns 30 --overwrite \
+    --framework framework-ab-a-run2 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-a>/v1
 
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
     --file sessions/_import/full-transcript.md \
-    --framework framework-ab-a-run3 --max-turns 30 --overwrite \
+    --framework framework-ab-a-run3 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-a>/v1
 ```
 
@@ -48,21 +48,21 @@ git checkout <pr-branch>
 python tools/bootstrap_session.py \
     --session sessions/session-import \
     --file sessions/_import/full-transcript.md \
-    --framework framework-ab-b-run1 --max-turns 30 --overwrite \
+    --framework framework-ab-b-run1 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-b>/v1
 
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
     --file sessions/_import/full-transcript.md \
-    --framework framework-ab-b-run2 --max-turns 30 --overwrite \
+    --framework framework-ab-b-run2 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-b>/v1
 
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
     --file sessions/_import/full-transcript.md \
-    --framework framework-ab-b-run3 --max-turns 30 --overwrite \
+    --framework framework-ab-b-run3 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-b>/v1
 ```
 

--- a/docs/ab-test-checklist.md
+++ b/docs/ab-test-checklist.md
@@ -7,7 +7,7 @@ Full standard: [docs/ab-test-standard.md](ab-test-standard.md).
 
 ## Pre-Flight
 
-- [ ] Both LLM servers reachable (`curl http://localhost:8000/v1/models`, `:8001`)
+- [ ] Both LLM servers reachable (`curl http://localhost:8000/v1/models`, `curl http://localhost:8001/v1/models`)
 - [ ] On `main` branch, pulled latest
 - [ ] `config/llm.json` unchanged between A and B runs
 - [ ] Output directories will be created per-run: `framework-ab-a-run{1,2,3}`, `framework-ab-b-run{1,2,3}`

--- a/docs/ab-test-checklist.md
+++ b/docs/ab-test-checklist.md
@@ -71,8 +71,10 @@ python tools/bootstrap_session.py \
 ## Validation (each run)
 
 ```bash
-# Schema validation (always required):
-python tools/validate.py
+# Schema validation (always required — run for each run directory):
+python tools/validate.py --framework framework-ab-a-run1
+python tools/validate.py --framework framework-ab-b-run1
+# ... repeat for all run directories
 
 # Ground truth validation (full-session runs only — requires full-session fixture schema):
 python tools/validate_extraction.py \
@@ -80,10 +82,10 @@ python tools/validate_extraction.py \
     --ground-truth tests/fixtures/extraction-ground-truth-full-session.json
 ```
 
-> **Note:** `validate_extraction.py` requires the full-session fixture (`extraction-ground-truth-full-session.json`) which has a different schema than the turns-1-30 fixture. For turns 1–30 runs, use `validate.py` for schema checks and manually review against `extraction-ground-truth-turns-1-30.json`.
+> **Note:** `validate_extraction.py` requires the full-session fixture (`extraction-ground-truth-full-session.json`) which has a different schema than the turns-1-30 fixture. For turns 1–30 runs, use `validate.py --framework <dir>` for schema checks and manually review against `extraction-ground-truth-turns-1-30.json`.
 
-- [ ] `validate_extraction.py` exits 0 for all B runs
-- [ ] `validate.py` reports 0 schema violations for all B runs
+- [ ] `validate_extraction.py` exits 0 for all B runs (full-session runs only; skip for `--max-turns 30`)
+- [ ] `validate.py --framework <dir>` reports 0 schema violations for all B runs
 
 ## Metrics Collection
 
@@ -118,7 +120,7 @@ python tools/validate_extraction.py \
 
 ## PR Report
 
-- [ ] A/B Test Results section added to PR body (see template in `docs/ab-test-standard.md` §5.1)
+- [ ] A/B Test Results posted as a PR comment (see template in `docs/ab-test-standard.md` §5.1)
 - [ ] All tables filled with mean ± σ values
 - [ ] Zero BLOCK statuses
 - [ ] All WARN statuses have written justification

--- a/docs/ab-test-checklist.md
+++ b/docs/ab-test-checklist.md
@@ -7,7 +7,7 @@ Full standard: [docs/ab-test-standard.md](ab-test-standard.md).
 
 ## Pre-Flight
 
-- [ ] Both LLM servers reachable (`curl http://localhost:8000/v1/models`, `curl http://localhost:8001/v1/models`)
+- [ ] Both LLM servers reachable (`curl http://localhost:8080/v1/models`, `curl http://localhost:8081/v1/models`) — adjust ports to match `config/llm.json`
 - [ ] On `main` branch, pulled latest
 - [ ] `config/llm.json` unchanged between A and B runs
 - [ ] Output directories will be created per-run: `framework-ab-a-run{1,2,3}`, `framework-ab-b-run{1,2,3}`
@@ -20,21 +20,21 @@ python tools/bootstrap_session.py \
     --session sessions/session-import \
     --file sessions/session-import/raw/full-transcript.md \
     --extract --framework framework-ab-a-run1 --max-turns 30 --overwrite \
-    --base-url http://localhost:8000/v1
+    --base-url http://localhost:8080/v1
 
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
     --file sessions/session-import/raw/full-transcript.md \
     --extract --framework framework-ab-a-run2 --max-turns 30 --overwrite \
-    --base-url http://localhost:8000/v1
+    --base-url http://localhost:8080/v1
 
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
     --file sessions/session-import/raw/full-transcript.md \
     --extract --framework framework-ab-a-run3 --max-turns 30 --overwrite \
-    --base-url http://localhost:8000/v1
+    --base-url http://localhost:8080/v1
 ```
 
 - [ ] Run A completed ×3 (minimum). Outputs in `framework-ab-a-run{1,2,3}/catalogs`
@@ -49,21 +49,21 @@ python tools/bootstrap_session.py \
     --session sessions/session-import \
     --file sessions/session-import/raw/full-transcript.md \
     --extract --framework framework-ab-b-run1 --max-turns 30 --overwrite \
-    --base-url http://localhost:8001/v1
+    --base-url http://localhost:8081/v1
 
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
     --file sessions/session-import/raw/full-transcript.md \
     --extract --framework framework-ab-b-run2 --max-turns 30 --overwrite \
-    --base-url http://localhost:8001/v1
+    --base-url http://localhost:8081/v1
 
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
     --file sessions/session-import/raw/full-transcript.md \
     --extract --framework framework-ab-b-run3 --max-turns 30 --overwrite \
-    --base-url http://localhost:8001/v1
+    --base-url http://localhost:8081/v1
 ```
 
 - [ ] Run B completed ×3 (minimum). Outputs in `framework-ab-b-run{1,2,3}/catalogs`
@@ -129,8 +129,7 @@ python tools/validate_extraction.py \
 ## Exemptions
 
 No A/B test required for:
-- Comment/formatting-only changes to templates
-- Changes to `dm-profile-analyzer.md`
+- Changes to templates **outside** `templates/extraction/` (e.g., `dm-profile-analyzer.md`, `dm-*.md`). Extraction templates are loaded verbatim — any text change alters the prompt.
 - New template files not yet wired into extraction pipeline
 
 State exemption reason under "A/B Test Exemption" heading in PR description.

--- a/docs/ab-test-checklist.md
+++ b/docs/ab-test-checklist.md
@@ -7,7 +7,7 @@ Full standard: [docs/ab-test-standard.md](ab-test-standard.md).
 
 ## Pre-Flight
 
-- [ ] Both LLM servers reachable (`curl http://localhost:8080/v1/models`, `curl http://localhost:8081/v1/models`) — adjust ports to match `config/llm.json`
+- [ ] Both LLM servers reachable (`curl http://<server-a>/v1/models`, `curl http://<server-b>/v1/models`) — substitute actual endpoints from `config/llm.json` `base_urls`
 - [ ] On `main` branch, pulled latest
 - [ ] `config/llm.json` unchanged between A and B runs
 - [ ] Output directories will be created per-run: `framework-ab-a-run{1,2,3}`, `framework-ab-b-run{1,2,3}`
@@ -18,23 +18,23 @@ Full standard: [docs/ab-test-standard.md](ab-test-standard.md).
 # Run 1:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/session-import/raw/full-transcript.md \
-    --extract --framework framework-ab-a-run1 --max-turns 30 --overwrite \
-    --base-url http://localhost:8080/v1
+    --file sessions/_import/full-transcript.md \
+    --framework framework-ab-a-run1 --max-turns 30 --overwrite \
+    --base-url http://<server-a>/v1
 
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/session-import/raw/full-transcript.md \
-    --extract --framework framework-ab-a-run2 --max-turns 30 --overwrite \
-    --base-url http://localhost:8080/v1
+    --file sessions/_import/full-transcript.md \
+    --framework framework-ab-a-run2 --max-turns 30 --overwrite \
+    --base-url http://<server-a>/v1
 
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/session-import/raw/full-transcript.md \
-    --extract --framework framework-ab-a-run3 --max-turns 30 --overwrite \
-    --base-url http://localhost:8080/v1
+    --file sessions/_import/full-transcript.md \
+    --framework framework-ab-a-run3 --max-turns 30 --overwrite \
+    --base-url http://<server-a>/v1
 ```
 
 - [ ] Run A completed ×3 (minimum). Outputs in `framework-ab-a-run{1,2,3}/catalogs`
@@ -47,23 +47,23 @@ git checkout <pr-branch>
 # Run 1:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/session-import/raw/full-transcript.md \
-    --extract --framework framework-ab-b-run1 --max-turns 30 --overwrite \
-    --base-url http://localhost:8081/v1
+    --file sessions/_import/full-transcript.md \
+    --framework framework-ab-b-run1 --max-turns 30 --overwrite \
+    --base-url http://<server-b>/v1
 
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/session-import/raw/full-transcript.md \
-    --extract --framework framework-ab-b-run2 --max-turns 30 --overwrite \
-    --base-url http://localhost:8081/v1
+    --file sessions/_import/full-transcript.md \
+    --framework framework-ab-b-run2 --max-turns 30 --overwrite \
+    --base-url http://<server-b>/v1
 
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/session-import/raw/full-transcript.md \
-    --extract --framework framework-ab-b-run3 --max-turns 30 --overwrite \
-    --base-url http://localhost:8081/v1
+    --file sessions/_import/full-transcript.md \
+    --framework framework-ab-b-run3 --max-turns 30 --overwrite \
+    --base-url http://<server-b>/v1
 ```
 
 - [ ] Run B completed ×3 (minimum). Outputs in `framework-ab-b-run{1,2,3}/catalogs`
@@ -78,7 +78,7 @@ python tools/validate.py --framework framework-ab-b-run1
 
 # Ground truth validation (full-session runs only — requires full-session fixture schema):
 python tools/validate_extraction.py \
-    --catalog-dir framework-ab-{a,b}-run{N}/catalogs \
+    --catalog-dir framework-ab-<a|b>-run<N>/catalogs \
     --ground-truth tests/fixtures/extraction-ground-truth-full-session.json
 ```
 
@@ -106,14 +106,14 @@ python tools/validate_extraction.py \
 | Relationship count **gain** | Δ ≤ 15% gain | 15–25% gain | > 25% gain (hallucination signal) |
 | Performance regression | Δ ≤ +10% time | +10–20% time | > +20% time |
 | Performance improvement | Always PASS | — | — |
-| Schema validity | 100% | ≥ 95% | < 95% |
+| Schema validity | 100% | — | < 100% |
 | Ground truth validation | 0 FAILs | — | Any FAIL |
 
 ## Manual Review (Recommended)
 
 > ⚠️ These checks require human review. They do NOT block merge but SHOULD be performed for major template changes.
 
-| Metric | PASS | WARN | BLOCK |
+| Metric | PASS | WARN | NEEDS REVIEW |
 |---|---|---|---|
 | Attribute completeness | ≥ 90% | 75–89% | < 75% |
 | Hallucination rate | 0% | ≤ 5% | > 5% |

--- a/docs/ab-test-checklist.md
+++ b/docs/ab-test-checklist.md
@@ -18,21 +18,21 @@ Full standard: [ab-test-standard.md](ab-test-standard.md).
 # Run 1:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/full-transcript.md \
+    --file sessions/_import/session-import-full-transcript.txt \
     --framework framework-ab-a-run1 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-a>/v1
 
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/full-transcript.md \
+    --file sessions/_import/session-import-full-transcript.txt \
     --framework framework-ab-a-run2 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-a>/v1
 
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/full-transcript.md \
+    --file sessions/_import/session-import-full-transcript.txt \
     --framework framework-ab-a-run3 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-a>/v1
 ```
@@ -47,21 +47,21 @@ git checkout <pr-branch>
 # Run 1:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/full-transcript.md \
+    --file sessions/_import/session-import-full-transcript.txt \
     --framework framework-ab-b-run1 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-b>/v1
 
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/full-transcript.md \
+    --file sessions/_import/session-import-full-transcript.txt \
     --framework framework-ab-b-run2 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-b>/v1
 
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/full-transcript.md \
+    --file sessions/_import/session-import-full-transcript.txt \
     --framework framework-ab-b-run3 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-b>/v1
 ```

--- a/docs/ab-test-checklist.md
+++ b/docs/ab-test-checklist.md
@@ -1,7 +1,7 @@
 # A/B Test Checklist for Template Changes
 
 Embed this checklist in `.prompt.md` files for PRs that modify `templates/extraction/*.md`.
-Full standard: [docs/ab-test-standard.md](ab-test-standard.md).
+Full standard: [docs/ab-test-standard.md](docs/ab-test-standard.md).
 
 ---
 

--- a/docs/ab-test-checklist.md
+++ b/docs/ab-test-checklist.md
@@ -1,7 +1,7 @@
 # A/B Test Checklist for Template Changes
 
 Embed this checklist in `.prompt.md` files for PRs that modify `templates/extraction/*.md`.
-Full standard: [ab-test-standard.md](ab-test-standard.md).
+Full standard: [ab-test-standard.md](docs/ab-test-standard.md).
 
 ---
 

--- a/docs/ab-test-checklist.md
+++ b/docs/ab-test-checklist.md
@@ -10,7 +10,7 @@ Full standard: [docs/ab-test-standard.md](ab-test-standard.md).
 - [ ] Both LLM servers reachable (`curl http://localhost:8000/v1/models`, `:8001`)
 - [ ] On `main` branch, pulled latest
 - [ ] `config/llm.json` unchanged between A and B runs
-- [ ] Output directories created: `framework-ab-a`, `framework-ab-b`
+- [ ] Output directories will be created per-run: `framework-ab-a-run{1,2,3}`, `framework-ab-b-run{1,2,3}`
 
 ## Run A (Baseline — main branch)
 
@@ -71,14 +71,16 @@ python tools/bootstrap_session.py \
 ## Validation (each run)
 
 ```bash
+# Schema validation (always required):
+python tools/validate.py
+
+# Ground truth validation (full-session runs only — requires full-session fixture schema):
 python tools/validate_extraction.py \
     --catalog-dir framework-ab-{a,b}-run{N}/catalogs \
     --ground-truth tests/fixtures/extraction-ground-truth-full-session.json
-
-python tools/validate.py
 ```
 
-> **Note:** Use the full-session fixture (`extraction-ground-truth-full-session.json`), NOT the turns-1-30 fixture. The turns-1-30 fixture has a different schema and is not compatible with `validate_extraction.py`.
+> **Note:** `validate_extraction.py` requires the full-session fixture (`extraction-ground-truth-full-session.json`) which has a different schema than the turns-1-30 fixture. For turns 1–30 runs, use `validate.py` for schema checks and manually review against `extraction-ground-truth-turns-1-30.json`.
 
 - [ ] `validate_extraction.py` exits 0 for all B runs
 - [ ] `validate.py` reports 0 schema violations for all B runs

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -2,7 +2,7 @@
 
 This document defines the required A/B testing gate for any PR that modifies extraction prompt templates (`templates/extraction/*.md`). It was introduced after PR #393 (smart compression) caused 27% entity loss that was not detected until manual testing.
 
-**Scope:** Any PR that adds, removes, or modifies files under `templates/extraction/` MUST include an A/B test report in the PR description before merging.
+**Scope:** Any PR that adds, removes, or modifies files under `templates/extraction/` MUST include an A/B test report posted as a PR comment before merging.
 
 ---
 
@@ -33,8 +33,8 @@ Report **mean ± standard deviation** for all metrics. If any metric's standard 
 
 ### 1.3 Variant Definitions
 
-- **Variant A (baseline):** Templates from `main` branch HEAD. Use `--framework framework-ab-a` output directory.
-- **Variant B (candidate):** Templates from the PR branch. Use `--framework framework-ab-b` output directory.
+- **Variant A (baseline):** Templates from `main` branch HEAD. Use `--framework framework-ab-a-runN` output directory (one per run, e.g. `framework-ab-a-run1`, `framework-ab-a-run2`, etc.).
+- **Variant B (candidate):** Templates from the PR branch. Use `--framework framework-ab-b-runN` output directory (one per run, e.g. `framework-ab-b-run1`, `framework-ab-b-run2`, etc.).
 - Both variants MUST use identical `config/llm.json`, identical model, and identical hardware.
 
 ---
@@ -47,7 +47,7 @@ Report **mean ± standard deviation** for all metrics. If any metric's standard 
 |---|---|---|
 | Wall-clock time per turn | Timestamp delta from extraction log | seconds |
 | Total extraction time | Start-to-finish wall clock | minutes |
-| LLM calls per turn | Count of API calls across all 5 extraction phases | count |
+| LLM calls per turn | Count of API calls across all 5 extraction phases (entity-discovery, entity-detail, relationship, event, and plot-thread; optional phases like temporal are excluded from this count) | count |
 
 ### 2.2 Derived Metrics
 
@@ -131,7 +131,10 @@ Two ground truth fixtures exist:
 - **`extraction-ground-truth-full-session.json`** — uses the tool-compatible schema (`expected_independent_characters`, `expected_pc_aliases`, `must_not_merge`, `coreference_groups`, etc.). This is the fixture `validate_extraction.py` expects.
 - **`extraction-ground-truth-turns-1-30.json`** — uses entity-level keys (`expected_characters`, `expected_locations`, etc.) for manual semantic review. This fixture is **NOT compatible** with `validate_extraction.py`.
 
-Run `tools/validate_extraction.py` against each extraction output using the **full-session** fixture:
+Run `tools/validate_extraction.py` against each extraction output using the fixture that matches the turn range:
+
+- **Turns 1–30 runs** (`--max-turns 30`): Validate with `extraction-ground-truth-turns-1-30.json` for entity-level manual review. Note: this fixture is **NOT compatible** with `validate_extraction.py` (different schema) — use it for manual spot-checks only.
+- **Full-session runs** (all turns): Validate with `extraction-ground-truth-full-session.json` using `validate_extraction.py`:
 
 ```bash
 python tools/validate_extraction.py \
@@ -139,7 +142,7 @@ python tools/validate_extraction.py \
     --ground-truth tests/fixtures/extraction-ground-truth-full-session.json
 ```
 
-> **Note:** Still run extraction on turns 1–30 minimum (via `--max-turns 30`), but validate with the full-session fixture which has the schema `validate_extraction.py` requires.
+> **Note:** `validate_extraction.py` requires the full-session fixture schema (`expected_independent_characters`, `must_not_merge`, etc.). If you ran extraction on turns 1–30 only, use schema validation (`validate.py`) and manual review against the turns-1-30 fixture instead.
 
 The validation tool checks:
 
@@ -249,9 +252,9 @@ For turns beyond the ground truth range (31–345), apply these automated heuris
 
 ## 5. Reporting Format
 
-### 5.1 PR Description Template
+### 5.1 PR Comment Template
 
-Every template-change PR MUST include this section in the PR body:
+Every template-change PR MUST include this section as a PR comment:
 
 ````markdown
 ## A/B Test Results
@@ -435,7 +438,7 @@ python tools/bootstrap_session.py `
     --session sessions/session-import `
     --file sessions/session-import/raw/full-transcript.md `
     --extract `
-    --framework framework-ab-a `
+    --framework framework-ab-a-run1 `
     --max-turns 30 `
     --base-url http://localhost:8000/v1 `
     --overwrite
@@ -445,7 +448,7 @@ python tools/bootstrap_session.py `
     --session sessions/session-import `
     --file sessions/session-import/raw/full-transcript.md `
     --extract `
-    --framework framework-ab-b `
+    --framework framework-ab-b-run1 `
     --max-turns 30 `
     --base-url http://localhost:8001/v1 `
     --overwrite
@@ -458,7 +461,11 @@ python tools/bootstrap_session.py `
 After all runs complete:
 
 ```bash
-# Ground truth validation — each run (use full-session fixture)
+# Schema validation (always required)
+python tools/validate.py
+
+# Ground truth validation — only for full-session runs (not --max-turns 30)
+# The full-session fixture is NOT compatible with turns-1-30 extractions.
 python tools/validate_extraction.py \
     --catalog-dir framework-ab-a-run1/catalogs \
     --ground-truth tests/fixtures/extraction-ground-truth-full-session.json
@@ -466,10 +473,9 @@ python tools/validate_extraction.py \
 python tools/validate_extraction.py \
     --catalog-dir framework-ab-b-run1/catalogs \
     --ground-truth tests/fixtures/extraction-ground-truth-full-session.json
-
-# Schema validation
-python tools/validate.py
 ```
+
+> **Note:** If using `--max-turns 30`, use schema validation (`validate.py`) and manual review against `extraction-ground-truth-turns-1-30.json` instead of `validate_extraction.py`.
 
 ### 6.6 Collecting Metrics
 

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -47,7 +47,7 @@ Report **mean ± standard deviation** for all metrics. If any metric's standard 
 |---|---|---|
 | Wall-clock time per turn | `elapsed_ms / 1000` from extraction log (per-turn field logged by the extraction pipeline) | seconds |
 | Total extraction time | Start-to-finish wall clock | minutes |
-| LLM calls per turn | Sum of `prompt_metrics.<phase>.calls` across phases recorded in `extraction-log.jsonl` for each turn: `discovery`, `entity_detail`, `relationship_mapper`, `event_extractor`. PC detail is processed as an additional `entity_detail` call (there is no distinct `pc-extraction` phase counter); it is included in the `entity_detail` call count automatically. `temporal_signals` is optional and excluded from default call counts. | count |
+| LLM calls per turn | Sum of `prompt_metrics.<phase>.calls` across phases recorded in `extraction-log.jsonl` for each turn: `discovery`, `entity_detail`, `relationship_mapper`, `event_extractor`. PC detail is processed as an additional `entity_detail` call (there is no distinct `pc-extraction` phase counter); it is included in the `entity_detail` call count automatically. Note: `temporal_signals` extraction calls are **not** recorded in `prompt_metrics` and are excluded from this count; if your change affects temporal extraction, track those calls separately via the extraction log's `temporal_signals` entries. | count |
 
 ### 2.2 Derived Metrics
 
@@ -80,7 +80,7 @@ Count entities by type in each extraction output:
 | Locations | `catalogs/locations/` | File count (excluding `index.json`) |
 | Items | `catalogs/items/` | File count (excluding `index.json`) |
 | Factions | `catalogs/factions/` | File count (excluding `index.json`) |
-| Events | `catalogs/events.json` | Array length (`jq length` or `python -c "import json; print(len(json.load(open(...))))"`) |
+| Events | `catalogs/events.json` | Array length (`jq length` or `python -c "import json; print(len(json.load(open(..., encoding='utf-8-sig'))))"`) |
 
 Report as a table:
 
@@ -499,7 +499,7 @@ for run in framework-ab-a-run1 framework-ab-a-run2 framework-ab-a-run3 \
   for type in locations items factions; do
     echo "$type: $(ls $run/catalogs/$type/*.json 2>/dev/null | grep -v 'index\.json' | wc -l)"
   done
-  _evcount=$(python -c 'import json,sys; print(len(json.load(open(sys.argv[1]))))' \
+  _evcount=$(python -c 'import json,sys; print(len(json.load(open(sys.argv[1], encoding="utf-8-sig"))))' \
     "$run/catalogs/events.json" 2>/dev/null || echo 0)
   echo "events: $_evcount"
 done
@@ -540,7 +540,7 @@ for run in framework-ab-a-run1 framework-ab-a-run2 framework-ab-a-run3 \
 import json, glob
 total = 0
 for f in glob.glob('$run/catalogs/**/*.json', recursive=True):
-    d = json.load(open(f))
+    d = json.load(open(f, encoding="utf-8-sig"))
     if isinstance(d, dict):
         total += len(d.get('relationships', []))
 print(f'relationships: {total}')

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -76,10 +76,10 @@ Count entities by type in each extraction output:
 
 | Type | Catalog directory | Count method |
 |---|---|---|
-| Characters | `catalogs/characters/` | File count (excluding `char-player.json` and `index.json`) |
-| Locations | `catalogs/locations/` | File count (excluding `index.json`) |
-| Items | `catalogs/items/` | File count (excluding `index.json`) |
-| Factions | `catalogs/factions/` | File count (excluding `index.json`) |
+| Characters | `catalogs/characters/` | File count (excluding `char-player.json`, `index.json`, `*.arcs.json`, `*.synthesis.json`) |
+| Locations | `catalogs/locations/` | File count (excluding `index.json`, `*.arcs.json`, `*.synthesis.json`) |
+| Items | `catalogs/items/` | File count (excluding `index.json`, `*.arcs.json`, `*.synthesis.json`) |
+| Factions | `catalogs/factions/` | File count (excluding `index.json`, `*.arcs.json`, `*.synthesis.json`) |
 | Events | `catalogs/events.json` | Array length (`jq length` or `python -c "import json; print(len(json.load(open(..., encoding='utf-8-sig'))))"`) |
 
 Report as a table:
@@ -238,7 +238,7 @@ Check for phantom/duplicate entities:
 
 1. **Name overlap:** No two entities of the same type should share >50% of name tokens.
 2. **ID stem overlap:** No two entity IDs should share the same stem after removing turn suffixes (e.g., `char-shaman-turn-082` and `char-shaman`).
-3. Run `python tools/dedup_audit.py --framework <framework-dir>` to detect duplicates automatically.
+3. Run `python tools/dedup_audit.py --catalog-dir <framework-dir>/catalogs` to detect duplicates automatically.
 
 Report count of suspected duplicates per variant.
 
@@ -312,8 +312,8 @@ Every template-change PR MUST include this section as a PR comment:
 | Staleness | | |
 | Dangling Relationships | | |
 | Duplicate Relationships | | |
-| Locations | | |
-| Factions | | |
+| Locations (late-game) | | |
+| Factions (late-game) | | |
 
 ### Semantic Quality
 
@@ -504,10 +504,10 @@ python tools/validate_extraction.py \
 for run in framework-ab-a-run1 framework-ab-a-run2 framework-ab-a-run3 \
            framework-ab-b-run1 framework-ab-b-run2 framework-ab-b-run3; do
   echo "=== $run ==="
-  # Characters: exclude char-player.json and index.json
-  echo "characters: $(ls $run/catalogs/characters/*.json 2>/dev/null | grep -v 'char-player\.json' | grep -v 'index\.json' | wc -l)"
+  # Characters: exclude char-player.json, index.json, and sidecar files
+  echo "characters: $(ls $run/catalogs/characters/*.json 2>/dev/null | grep -v 'char-player\.json' | grep -v 'index\.json' | grep -v '\.arcs\.json' | grep -v '\.synthesis\.json' | wc -l)"
   for type in locations items factions; do
-    echo "$type: $(ls $run/catalogs/$type/*.json 2>/dev/null | grep -v 'index\.json' | wc -l)"
+    echo "$type: $(ls $run/catalogs/$type/*.json 2>/dev/null | grep -v 'index\.json' | grep -v '\.arcs\.json' | grep -v '\.synthesis\.json' | wc -l)"
   done
   _evcount=$(python -c 'import json,sys; print(len(json.load(open(sys.argv[1], encoding="utf-8-sig"))))' \
     "$run/catalogs/events.json" 2>/dev/null || echo 0)
@@ -522,13 +522,13 @@ foreach ($run in @(
     "framework-ab-a-run1", "framework-ab-a-run2", "framework-ab-a-run3",
     "framework-ab-b-run1", "framework-ab-b-run2", "framework-ab-b-run3")) {
     Write-Output "=== $run ==="
-    # Characters: exclude char-player.json and index.json
+    # Characters: exclude char-player.json, index.json, and sidecar files
     $charCount = (Get-ChildItem "$run/catalogs/characters/*.json" -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -ne "char-player.json" -and $_.Name -ne "index.json" }).Count
+        Where-Object { $_.Name -ne "char-player.json" -and $_.Name -ne "index.json" -and $_.Name -notlike "*.arcs.json" -and $_.Name -notlike "*.synthesis.json" }).Count
     Write-Output "characters: $charCount"
     foreach ($type in @("locations", "items", "factions")) {
         $count = (Get-ChildItem "$run/catalogs/$type/*.json" -ErrorAction SilentlyContinue |
-            Where-Object { $_.Name -ne "index.json" }).Count
+            Where-Object { $_.Name -ne "index.json" -and $_.Name -notlike "*.arcs.json" -and $_.Name -notlike "*.synthesis.json" }).Count
         Write-Output "${type}: $count"
     }
     $eventsFile = "$run/catalogs/events.json"

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -47,7 +47,7 @@ Report **mean ± standard deviation** for all metrics. If any metric's standard 
 |---|---|---|
 | Wall-clock time per turn | `elapsed_ms / 1000` from extraction log (per-turn field logged by the extraction pipeline) | seconds |
 | Total extraction time | Start-to-finish wall clock | minutes |
-| LLM calls per turn | Sum of `prompt_metrics.<phase>.calls` across phases recorded in `extraction-log.jsonl` for each turn: `discovery`, `entity_detail`, `relationship_mapper`, `event_extractor`. PC detail is processed as an additional `entity_detail` call (there is no distinct `pc-extraction` phase counter); it is included in the `entity_detail` call count automatically. Note: `temporal_signals` extraction calls are **not** recorded in `prompt_metrics` and are excluded from this count; if your change affects temporal extraction, track those calls separately via the extraction log's `temporal_signals` entries. | count |
+| LLM calls per turn | Sum of `prompt_metrics.<phase>.calls` across phases recorded in `extraction-log.jsonl` for each turn: `discovery`, `entity_detail`, `relationship_mapper`, `event_extractor`. PC detail is processed as an additional `entity_detail` call (there is no distinct `pc-extraction` phase counter); it is included in the `entity_detail` call count automatically. Note: `temporal_signals` extraction calls are **not** recorded in `prompt_metrics` and are excluded from this count; if your change affects temporal extraction, track those calls separately via the extraction log's `temporal_ms` / `new_temporal_signals` fields and the timeline file. | count |
 
 ### 2.2 Derived Metrics
 
@@ -238,7 +238,7 @@ Check for phantom/duplicate entities:
 
 1. **Name overlap:** No two entities of the same type should share >50% of name tokens.
 2. **ID stem overlap:** No two entity IDs should share the same stem after removing turn suffixes (e.g., `char-shaman-turn-082` and `char-shaman`).
-3. Run `python tools/dedup_audit.py` if available, or manually inspect.
+3. Run `python tools/dedup_audit.py --framework <framework-dir>` to detect duplicates automatically.
 
 Report count of suspected duplicates per variant.
 
@@ -253,7 +253,7 @@ For turns beyond the ground truth range (31–345), apply these manual heuristic
 1. **Monotonic growth:** Entity count should not decrease between extraction checkpoints.
 2. **No empty identity:** Every entity should have a non-empty `identity` field (the `identity` top-level string holds the stable description).
 3. **Turn coverage:** Every DM turn in the range should produce at least one discovery or update (check extraction log).
-4. **Relationship reciprocity:** If A→B relationship exists, B should have a corresponding entry (check via `relationship-index.json`).
+4. **Relationship reciprocity:** If A→B relationship exists, `relationship-index.json` should contain an inferred reverse edge from B→A (note: this checks the index's inferred edges, not necessarily a mirrored relationship entry in B's catalog file).
 
 ---
 
@@ -371,6 +371,7 @@ python tools/bootstrap_session.py \
     --framework framework-ab-a-run1 \
     --max-turns 30 \
     --overwrite \
+    --no-resume \
     --base-url http://localhost:8080/v1
 
 # Run 2:
@@ -380,6 +381,7 @@ python tools/bootstrap_session.py \
     --framework framework-ab-a-run2 \
     --max-turns 30 \
     --overwrite \
+    --no-resume \
     --base-url http://localhost:8080/v1
 
 # Run 3:
@@ -389,12 +391,15 @@ python tools/bootstrap_session.py \
     --framework framework-ab-a-run3 \
     --max-turns 30 \
     --overwrite \
+    --no-resume \
     --base-url http://localhost:8080/v1
 ```
 
 > **Note:** Always specify `--base-url` explicitly to prevent round-robin mixing between A and B variants. Substitute `localhost:8080` / `localhost:8081` with your actual server endpoints from `config/llm.json` `base_urls`.
 >
 > **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/_import/full-transcript.md` and create the session directory at `sessions/session-import`. These paths are not committed to the repository; see `docs/usage.md` for instructions on setting up a session before running A/B tests.
+
+### 6.3 Run Variant B (Candidate)
 
 ```bash
 git checkout <pr-branch>
@@ -407,6 +412,7 @@ python tools/bootstrap_session.py \
     --framework framework-ab-b-run1 \
     --max-turns 30 \
     --overwrite \
+    --no-resume \
     --base-url http://localhost:8081/v1
 
 # Run 2:
@@ -416,6 +422,7 @@ python tools/bootstrap_session.py \
     --framework framework-ab-b-run2 \
     --max-turns 30 \
     --overwrite \
+    --no-resume \
     --base-url http://localhost:8081/v1
 
 # Run 3:
@@ -425,6 +432,7 @@ python tools/bootstrap_session.py \
     --framework framework-ab-b-run3 \
     --max-turns 30 \
     --overwrite \
+    --no-resume \
     --base-url http://localhost:8081/v1
 ```
 
@@ -442,7 +450,8 @@ python tools/bootstrap_session.py `
     --framework framework-ab-a-run1 `
     --max-turns 30 `
     --base-url http://localhost:8080/v1 `
-    --overwrite
+    --overwrite `
+    --no-resume
 
 # Terminal 2 — Variant B on GPU 1 (port 8081)
 python tools/bootstrap_session.py `
@@ -451,7 +460,8 @@ python tools/bootstrap_session.py `
     --framework framework-ab-b-run1 `
     --max-turns 30 `
     --base-url http://localhost:8081/v1 `
-    --overwrite
+    --overwrite `
+    --no-resume
 ```
 
 > **Note:** When running parallel A/B, each variant must use a separate `--base-url` to avoid round-robin mixing. Do NOT rely on the default round-robin in `config/llm.json` — it would mix responses across A/B runs.

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -76,9 +76,9 @@ Count entities by type in each extraction output:
 
 | Type | Catalog directory | Count method |
 |---|---|---|
-| Characters | `catalogs/characters/` | File count (excluding `char-player.json`, `index.json`, `*.arcs.json`, `*.synthesis.json`) |
+| Characters | `catalogs/characters/` | File count (excluding `char-player.json`, `index.json`, `*.arcs.json`, `*.synthesis.json`). **Note:** `creature`-type entities are stored here too (IDs prefixed `creature-`); their files are included in this count. |
 | Locations | `catalogs/locations/` | File count (excluding `index.json`, `*.arcs.json`, `*.synthesis.json`) |
-| Items | `catalogs/items/` | File count (excluding `index.json`, `*.arcs.json`, `*.synthesis.json`) |
+| Items | `catalogs/items/` | File count (excluding `index.json`, `*.arcs.json`, `*.synthesis.json`). **Note:** `concept`-type entities are stored here too (IDs prefixed `concept-`); their files are included in this count. |
 | Factions | `catalogs/factions/` | File count (excluding `index.json`, `*.arcs.json`, `*.synthesis.json`) |
 | Events | `catalogs/events.json` | Array length (`jq length` or `python -c "import json; print(len(json.load(open(..., encoding='utf-8-sig'))))"`) |
 

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -47,7 +47,7 @@ Report **mean ± standard deviation** for all metrics. If any metric's standard 
 |---|---|---|
 | Wall-clock time per turn | Timestamp delta from extraction log | seconds |
 | Total extraction time | Start-to-finish wall clock | minutes |
-| LLM calls per turn | Count of API calls across all 5 extraction phases (entity-discovery, entity-detail, relationship, event, and plot-thread; optional phases like temporal are excluded from this count) | count |
+| LLM calls per turn | Count of API calls across all 4 core extraction phases (entity-discovery, entity-detail, relationship-mapper, event-extractor; temporal-signals is optional and excluded from default call counts) | count |
 
 ### 2.2 Derived Metrics
 
@@ -80,7 +80,7 @@ Count entities by type in each extraction output:
 | Locations | `catalogs/locations/` | File count |
 | Items | `catalogs/items/` | File count |
 | Factions | `catalogs/factions/` | File count |
-| Events | `catalogs/events/` | File count |
+| Events | `catalogs/events.json` | Array length (`jq length` or `python -c "import json; print(len(json.load(open(...))))"`) |
 
 Report as a table:
 
@@ -98,7 +98,14 @@ Count total relationships across all entity files. Report by relationship type i
 
 ### 3.3 JSON Schema Validity
 
-Run `python tools/validate.py` on each extraction output. Report:
+Run `python tools/validate.py --framework <dir>` on each extraction output. For example:
+
+```bash
+python tools/validate.py --framework framework-ab-a-run1
+python tools/validate.py --framework framework-ab-b-run1
+```
+
+Report:
 
 - Total entities validated
 - Schema violations (count and list)
@@ -292,8 +299,9 @@ Every template-change PR MUST include this section as a PR comment:
 |---|---|---|---|---|
 | Total relationships | | | | |
 
-### Ground Truth Validation (turns 1–30)
+### Ground Truth Validation (full-session runs only)
 
+> **Note:** This section applies only to full-session runs using `validate_extraction.py` with `extraction-ground-truth-full-session.json`. For turns 1–30 runs, use schema validation (`validate.py --framework <dir>`) and manual review against `extraction-ground-truth-turns-1-30.json`.
 | Check | A | B |
 |---|---|---|
 | Independent Characters | | |
@@ -329,8 +337,8 @@ The PR is **mergeable** when:
 
 1. Zero BLOCK statuses across all metrics.
 2. All WARN statuses have written justification explaining why the regression is acceptable.
-3. Ground truth validation (`validate_extraction.py`) exits 0 for variant B.
-4. Schema validation (`validate.py`) reports 0 violations for variant B.
+3. Ground truth validation (`validate_extraction.py`) exits 0 for variant B (full-session runs only).
+4. Schema validation (`validate.py --framework <dir>`) reports 0 violations for variant B.
 
 ---
 
@@ -461,8 +469,11 @@ python tools/bootstrap_session.py `
 After all runs complete:
 
 ```bash
-# Schema validation (always required)
-python tools/validate.py
+# Schema validation (always required — run for each run directory)
+for run in framework-ab-a-run1 framework-ab-a-run2 framework-ab-a-run3 \
+           framework-ab-b-run1 framework-ab-b-run2 framework-ab-b-run3; do
+    python tools/validate.py --framework "$run"
+done
 
 # Ground truth validation — only for full-session runs (not --max-turns 30)
 # The full-session fixture is NOT compatible with turns-1-30 extractions.
@@ -482,31 +493,45 @@ python tools/validate_extraction.py \
 #### Entity Counts
 
 ```bash
-# Count entities per type in a catalog directory
-for type in characters locations items factions events; do
-    echo "$type: $(ls framework-ab-a/catalogs/$type/*.json 2>/dev/null | wc -l)"
+# Count entities per type in a catalog directory (per-run)
+for run in framework-ab-a-run1 framework-ab-a-run2 framework-ab-a-run3; do
+  echo "=== $run ==="
+  for type in characters locations items factions; do
+    echo "$type: $(ls $run/catalogs/$type/*.json 2>/dev/null | wc -l)"
+  done
+  echo "events: $(python -c "import json; print(len(json.load(open('$run/catalogs/events.json'))))" 2>/dev/null || echo 0)"
 done
 ```
 
 PowerShell equivalent:
 
 ```powershell
-foreach ($type in @("characters", "locations", "items", "factions", "events")) {
-    $count = (Get-ChildItem "framework-ab-a/catalogs/$type/*.json" -ErrorAction SilentlyContinue).Count
-    Write-Output "${type}: $count"
+foreach ($run in @("framework-ab-a-run1", "framework-ab-a-run2", "framework-ab-a-run3")) {
+    Write-Output "=== $run ==="
+    foreach ($type in @("characters", "locations", "items", "factions")) {
+        $count = (Get-ChildItem "$run/catalogs/$type/*.json" -ErrorAction SilentlyContinue).Count
+        Write-Output "${type}: $count"
+    }
+    $eventsFile = "$run/catalogs/events.json"
+    if (Test-Path $eventsFile) {
+        $events = (Get-Content $eventsFile -Raw | ConvertFrom-Json)
+        Write-Output "events: $($events.Count)"
+    } else { Write-Output "events: 0" }
 }
 ```
 
 #### Relationship Counts
 
 ```powershell
-# Count total relationships across all entity files
-$total = 0
-Get-ChildItem framework-ab-a/catalogs/*/  -Filter *.json -Recurse | ForEach-Object {
-    $json = Get-Content $_ -Raw | ConvertFrom-Json
-    if ($json.relationships) { $total += $json.relationships.Count }
+# Count total relationships across all entity files (per-run)
+foreach ($run in @("framework-ab-a-run1", "framework-ab-a-run2", "framework-ab-a-run3")) {
+    $total = 0
+    Get-ChildItem "$run/catalogs/" -Filter *.json -Recurse | ForEach-Object {
+        $json = Get-Content $_ -Raw | ConvertFrom-Json
+        if ($json.relationships) { $total += $json.relationships.Count }
+    }
+    Write-Output "${run} relationships: $total"
 }
-Write-Output "Total relationships: $total"
 ```
 
 #### Wall-Clock Time

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -537,8 +537,10 @@ foreach ($run in @(
 #### Relationship Counts
 
 ```powershell
-# Count total relationships across all entity files (per-run)
-foreach ($run in @("framework-ab-a-run1", "framework-ab-a-run2", "framework-ab-a-run3")) {
+# Count total relationships across all entity files (per-run, both variants)
+foreach ($run in @(
+    "framework-ab-a-run1", "framework-ab-a-run2", "framework-ab-a-run3",
+    "framework-ab-b-run1", "framework-ab-b-run2", "framework-ab-b-run3")) {
     $total = 0
     Get-ChildItem "$run/catalogs/" -Filter *.json -Recurse | ForEach-Object {
         $json = Get-Content $_ -Raw | ConvertFrom-Json

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -1,0 +1,554 @@
+# A/B Testing Standard for Template Changes
+
+This document defines the required A/B testing gate for any PR that modifies extraction prompt templates (`templates/extraction/*.md`). It was introduced after PR #393 (smart compression) caused 27% entity loss that was not detected until manual testing.
+
+**Scope:** Any PR that adds, removes, or modifies files under `templates/extraction/` MUST include an A/B test report in the PR description before merging.
+
+---
+
+## 1. Test Scope
+
+### 1.1 Turn Selection
+
+| Parameter | Minimum | Recommended |
+|---|---|---|
+| Ground truth range | Turns 1–30 | Turns 1–30 |
+| Extended range | — | Turns 1–50 |
+| Full session | — | Turns 1–345 (for major changes) |
+
+- **Turns 1–30** are always required. Ground truth fixtures exist at `tests/fixtures/extraction-ground-truth-turns-1-30.json` and provide entity-level validation.
+- **Turns 1–50** are recommended for changes affecting relationship or event extraction.
+- **Full session** (turns 1–345) should be used for structural changes to entity-discovery or entity-detail templates. Use `tests/fixtures/extraction-ground-truth-full-session.json` for validation.
+
+### 1.2 Runs Per Variant
+
+Temperature 0.3 introduces non-determinism. To produce statistically meaningful results:
+
+| Variant | Minimum runs | Recommended runs |
+|---|---|---|
+| A (baseline/main) | 3 | 5 |
+| B (PR branch) | 3 | 5 |
+
+Report **mean ± standard deviation** for all metrics. If any metric's standard deviation exceeds 15% of its mean, increase to 5 runs.
+
+### 1.3 Variant Definitions
+
+- **Variant A (baseline):** Templates from `main` branch HEAD. Use `--framework framework-ab-a` output directory.
+- **Variant B (candidate):** Templates from the PR branch. Use `--framework framework-ab-b` output directory.
+- Both variants MUST use identical `config/llm.json`, identical model, and identical hardware.
+
+---
+
+## 2. Performance Metrics
+
+### 2.1 Required Metrics
+
+| Metric | Source | Unit |
+|---|---|---|
+| Wall-clock time per turn | Timestamp delta from extraction log | seconds |
+| Total extraction time | Start-to-finish wall clock | minutes |
+| LLM calls per turn | Count of API calls across all 5 extraction phases | count |
+
+### 2.2 Derived Metrics
+
+| Metric | Formula |
+|---|---|
+| Mean time per turn | total_time / turn_count |
+| Throughput | turns / minute |
+| Time delta vs baseline | (B_mean - A_mean) / A_mean × 100% |
+
+### 2.3 Performance Regression Thresholds
+
+| Threshold | Action |
+|---|---|
+| ≤ +10% wall-clock time | PASS — no performance concern |
+| +10% to +20% wall-clock time | WARN — acceptable if quality improves; document justification |
+| > +20% wall-clock time | BLOCK — must optimize before merge |
+| Any performance improvement | Always PASS — no upper bound on speed gains |
+
+---
+
+## 3. Quality Metrics — Quantitative
+
+### 3.1 Entity Counts
+
+Count entities by type in each extraction output:
+
+| Type | Catalog directory | Count method |
+|---|---|---|
+| Characters | `catalogs/characters/` | File count (excluding `char-player.json`) |
+| Locations | `catalogs/locations/` | File count |
+| Items | `catalogs/items/` | File count |
+| Factions | `catalogs/factions/` | File count |
+| Events | `catalogs/events/` | File count |
+
+Report as a table:
+
+```
+| Type       | A mean ± σ | B mean ± σ | Δ%     | Status |
+|------------|-----------|-----------|--------|--------|
+| Characters | 12.0 ± 0.0 | 11.3 ± 0.6 | -5.8% | WARN   |
+| Locations  | 8.3 ± 0.6 | 8.7 ± 0.6 | +4.8%  | PASS   |
+| ...        | ...       | ...       | ...    | ...    |
+```
+
+### 3.2 Relationship Counts
+
+Count total relationships across all entity files. Report by relationship type if available (ally, enemy, kinship, etc.).
+
+### 3.3 JSON Schema Validity
+
+Run `python tools/validate.py` on each extraction output. Report:
+
+- Total entities validated
+- Schema violations (count and list)
+- 100% validity is required for PASS.
+
+### 3.4 Quantitative Regression Thresholds
+
+| Metric | PASS | WARN | BLOCK |
+|---|---|---|---|
+| Entity count **loss** | Δ ≤ 5% loss | 5–15% loss | > 15% loss |
+| Entity count **gain** | Δ ≤ 10% gain | 10–20% gain | > 20% gain (hallucination signal) |
+| Single type count **loss** | Δ ≤ 10% loss | 10–20% loss | > 20% loss |
+| Single type count **gain** | Δ ≤ 15% gain | 15–25% gain | > 25% gain (hallucination signal) |
+| Relationship count **loss** | Δ ≤ 10% loss | 10–20% loss | > 20% loss |
+| Relationship count **gain** | Δ ≤ 15% gain | 15–25% gain | > 25% gain (hallucination signal) |
+| Schema validity | 100% | ≥ 95% | < 95% |
+| Performance regression | Δ ≤ +10% time | +10–20% time | > +20% time |
+| Performance improvement | Always PASS | — | — |
+
+A single BLOCK on any metric blocks the PR. WARN requires documented justification.
+
+---
+
+## 4. Quality Metrics — Semantic
+
+### 4.1 Ground Truth Validation
+
+Two ground truth fixtures exist:
+
+- **`extraction-ground-truth-full-session.json`** — uses the tool-compatible schema (`expected_independent_characters`, `expected_pc_aliases`, `must_not_merge`, `coreference_groups`, etc.). This is the fixture `validate_extraction.py` expects.
+- **`extraction-ground-truth-turns-1-30.json`** — uses entity-level keys (`expected_characters`, `expected_locations`, etc.) for manual semantic review. This fixture is **NOT compatible** with `validate_extraction.py`.
+
+Run `tools/validate_extraction.py` against each extraction output using the **full-session** fixture:
+
+```bash
+python tools/validate_extraction.py \
+    --catalog-dir framework-ab-a-run1/catalogs \
+    --ground-truth tests/fixtures/extraction-ground-truth-full-session.json
+```
+
+> **Note:** Still run extraction on turns 1–30 minimum (via `--max-turns 30`), but validate with the full-session fixture which has the schema `validate_extraction.py` requires.
+
+The validation tool checks:
+
+| Check | What it validates |
+|---|---|
+| Independent Characters | All expected characters exist as separate entities |
+| PC Aliases | Player character aliases are correctly merged |
+| Must-Not-Merge | Distinct characters are not falsely merged |
+| Coreference Groups | Shared-identity entities are properly consolidated |
+| Staleness | Entities have recent `last_updated_turn` values |
+| Dangling Relationships | No relationships point to nonexistent entities |
+| Duplicate Relationships | No redundant relationship entries |
+| Locations | Expected locations exist with correct types |
+| Factions | Expected factions exist with correct types |
+
+**Report format:** Include the full validation scorecard for both A and B:
+
+```
+| Check                  | A: PASS/WARN/FAIL | B: PASS/WARN/FAIL |
+|------------------------|--------------------|--------------------|
+| Independent Characters | PASS (5/5)         | PASS (5/5)         |
+| PC Aliases             | PASS               | PASS               |
+| Must-Not-Merge         | PASS               | WARN (1 issue)     |
+| ...                    | ...                | ...                |
+```
+
+### 4.2 Entity Description Accuracy (Turns 1–30)
+
+> ⚠️ **MANUAL — not yet automated**
+>
+> These checks require human review. They do NOT block merge but SHOULD be performed for major template changes. See §8 for planned automation.
+
+For each expected entity in the ground truth fixture, verify:
+
+1. **Attribute presence:** Check that `expected_attributes` (e.g., `appearance`, `role`) are populated (non-empty) in the extracted entity.
+2. **First-seen turn range:** The entity's `first_seen_turn` falls within the ground truth's `first_seen_turn_range`.
+3. **Type correctness:** The entity's type matches the expected type (not misclassified as a different entity type).
+
+Score: `attributes_present / attributes_expected` across all ground truth entities.
+
+| Score | Status |
+|---|---|
+| ≥ 90% | PASS |
+| 75–89% | WARN |
+| < 75% | BLOCK |
+
+### 4.3 Relationship Correctness (Turns 1–30)
+
+> ⚠️ **MANUAL — not yet automated**
+>
+> These checks require human review. They do NOT block merge but SHOULD be performed for major template changes. See §8 for planned automation.
+
+Using the ground truth `coreference_checks`:
+
+1. **Faction membership:** Both captors share faction membership (expected: 1 faction for captors).
+2. **Identity consolidation:** Authority-leader described differently across turns is ONE character entry.
+3. **Type correctness:** Encampment/fire-gathering are typed as `location`, not `character` or `faction`.
+
+All coreference checks must PASS. Any FAIL blocks the PR.
+
+### 4.4 Hallucination Detection
+
+> ⚠️ **MANUAL — not yet automated**
+>
+> These checks require human review. They do NOT block merge but SHOULD be performed for major template changes. See §8 for planned automation.
+
+For each extraction output, identify entities that cannot be traced to the transcript:
+
+1. List all entity IDs in the extraction output.
+2. For entities with `first_seen_turn`, verify the entity name or a recognizable alias appears in that turn's transcript text.
+3. Entities failing this check are **potential hallucinations**.
+
+| Hallucination rate | Status |
+|---|---|
+| 0% | PASS |
+| ≤ 5% | WARN |
+| > 5% | BLOCK |
+
+### 4.5 Dedup Quality
+
+> ⚠️ **MANUAL — not yet automated**
+>
+> These checks require human review. They do NOT block merge but SHOULD be performed for major template changes. See §8 for planned automation.
+
+Check for phantom/duplicate entities:
+
+1. **Name overlap:** No two entities of the same type should share >50% of name tokens.
+2. **ID stem overlap:** No two entity IDs should share the same stem after removing turn suffixes (e.g., `char-shaman-turn-082` and `char-shaman`).
+3. Run `python tools/dedup_audit.py` if available, or manually inspect.
+
+Report count of suspected duplicates per variant.
+
+### 4.6 Heuristic Checks (Beyond Ground Truth)
+
+> ⚠️ **MANUAL — not yet automated**
+>
+> These checks require human review. They do NOT block merge but SHOULD be performed for major template changes. See §8 for planned automation.
+
+For turns beyond the ground truth range (31–345), apply these automated heuristics:
+
+1. **Monotonic growth:** Entity count should not decrease between extraction checkpoints.
+2. **No empty descriptions:** Every entity should have a non-empty `description` or `appearance`.
+3. **Turn coverage:** Every DM turn in the range should produce at least one discovery or update (check extraction log).
+4. **Relationship reciprocity:** If A→B relationship exists, B should have a corresponding entry (check via `relationship-index.json`).
+
+---
+
+## 5. Reporting Format
+
+### 5.1 PR Description Template
+
+Every template-change PR MUST include this section in the PR body:
+
+````markdown
+## A/B Test Results
+
+### Configuration
+- Model: [model name and quantization]
+- Hardware: [GPU(s) used]
+- Turns: [range]
+- Runs per variant: [N]
+- Temperature: [value]
+- Config: `config/llm.json` (unchanged between A/B)
+
+### Performance
+
+| Metric | A (main) mean ± σ | B (branch) mean ± σ | Δ% | Status |
+|---|---|---|---|---|
+| Wall-clock time (total) | | | | |
+| Time per turn | | | | |
+| LLM calls per turn | | | | |
+
+### Entity Counts
+
+| Type | A mean ± σ | B mean ± σ | Δ% | Status |
+|---|---|---|---|---|
+| Characters | | | | |
+| Locations | | | | |
+| Items | | | | |
+| Factions | | | | |
+| Events | | | | |
+| **Total** | | | | |
+
+### Relationships
+
+| Metric | A mean ± σ | B mean ± σ | Δ% | Status |
+|---|---|---|---|---|
+| Total relationships | | | | |
+
+### Ground Truth Validation (turns 1–30)
+
+| Check | A | B |
+|---|---|---|
+| Independent Characters | | |
+| PC Aliases | | |
+| Must-Not-Merge | | |
+| Coreference Groups | | |
+| Staleness | | |
+| Dangling Relationships | | |
+| Duplicate Relationships | | |
+| Locations | | |
+| Factions | | |
+
+### Semantic Quality
+
+| Metric | A | B | Status |
+|---|---|---|---|
+| Attribute completeness | | | |
+| First-seen accuracy | | | |
+| Hallucination rate | | | |
+| Schema validity | | | |
+| Suspected duplicates | | | |
+
+### Verdict
+
+- [ ] No BLOCK on any metric
+- [ ] All WARN items have documented justification
+- [ ] Ground truth validation passes for B
+````
+
+### 5.2 Pass/Fail Summary
+
+The PR is **mergeable** when:
+
+1. Zero BLOCK statuses across all metrics.
+2. All WARN statuses have written justification explaining why the regression is acceptable.
+3. Ground truth validation (`validate_extraction.py`) exits 0 for variant B.
+4. Schema validation (`validate.py`) reports 0 violations for variant B.
+
+---
+
+## 6. Execution Instructions
+
+### 6.1 Environment Setup
+
+Ensure `config/llm.json` is configured and both LLM servers are running:
+
+```bash
+# Verify servers are reachable
+curl -s http://localhost:8000/v1/models | python -m json.tool
+curl -s http://localhost:8001/v1/models | python -m json.tool
+```
+
+### 6.2 Run Variant A (Baseline)
+
+```bash
+# From the repo root, on main branch
+git stash  # if needed
+git checkout main
+git pull
+
+# Run extraction — turns 1-30, separate --framework per run
+# Run 1:
+python tools/bootstrap_session.py \
+    --session sessions/session-import \
+    --file sessions/session-import/raw/full-transcript.md \
+    --extract \
+    --framework framework-ab-a-run1 \
+    --max-turns 30 \
+    --overwrite \
+    --base-url http://localhost:8000/v1
+
+# Run 2:
+python tools/bootstrap_session.py \
+    --session sessions/session-import \
+    --file sessions/session-import/raw/full-transcript.md \
+    --extract \
+    --framework framework-ab-a-run2 \
+    --max-turns 30 \
+    --overwrite \
+    --base-url http://localhost:8000/v1
+
+# Run 3:
+python tools/bootstrap_session.py \
+    --session sessions/session-import \
+    --file sessions/session-import/raw/full-transcript.md \
+    --extract \
+    --framework framework-ab-a-run3 \
+    --max-turns 30 \
+    --overwrite \
+    --base-url http://localhost:8000/v1
+```
+
+> **Note:** Always specify `--base-url` explicitly to prevent round-robin mixing between A and B variants.
+
+### 6.3 Run Variant B (PR Branch)
+
+```bash
+git checkout <pr-branch>
+
+# Run extraction — same parameters, different output dir, separate --framework per run
+# Run 1:
+python tools/bootstrap_session.py \
+    --session sessions/session-import \
+    --file sessions/session-import/raw/full-transcript.md \
+    --extract \
+    --framework framework-ab-b-run1 \
+    --max-turns 30 \
+    --overwrite \
+    --base-url http://localhost:8001/v1
+
+# Run 2:
+python tools/bootstrap_session.py \
+    --session sessions/session-import \
+    --file sessions/session-import/raw/full-transcript.md \
+    --extract \
+    --framework framework-ab-b-run2 \
+    --max-turns 30 \
+    --overwrite \
+    --base-url http://localhost:8001/v1
+
+# Run 3:
+python tools/bootstrap_session.py \
+    --session sessions/session-import \
+    --file sessions/session-import/raw/full-transcript.md \
+    --extract \
+    --framework framework-ab-b-run3 \
+    --max-turns 30 \
+    --overwrite \
+    --base-url http://localhost:8001/v1
+```
+
+> **Note:** Always specify `--base-url` explicitly to prevent round-robin mixing between A and B variants.
+
+### 6.4 Parallel A/B Using Two GPUs
+
+The two B70 GPU servers (ports 8000 and 8001) can run A and B simultaneously:
+
+```powershell
+# Terminal 1 — Variant A on GPU 0 (port 8000)
+$env:NSE_LLM_BASE_URL = "http://localhost:8000/v1"
+python tools/bootstrap_session.py `
+    --session sessions/session-import `
+    --file sessions/session-import/raw/full-transcript.md `
+    --extract `
+    --framework framework-ab-a `
+    --max-turns 30 `
+    --base-url http://localhost:8000/v1 `
+    --overwrite
+
+# Terminal 2 — Variant B on GPU 1 (port 8001)
+python tools/bootstrap_session.py `
+    --session sessions/session-import `
+    --file sessions/session-import/raw/full-transcript.md `
+    --extract `
+    --framework framework-ab-b `
+    --max-turns 30 `
+    --base-url http://localhost:8001/v1 `
+    --overwrite
+```
+
+> **Note:** When running parallel A/B, each variant must use a separate `--base-url` to avoid round-robin mixing. Do NOT rely on the default round-robin in `config/llm.json` — it would mix responses across A/B runs.
+
+### 6.5 Validation
+
+After all runs complete:
+
+```bash
+# Ground truth validation — each run (use full-session fixture)
+python tools/validate_extraction.py \
+    --catalog-dir framework-ab-a-run1/catalogs \
+    --ground-truth tests/fixtures/extraction-ground-truth-full-session.json
+
+python tools/validate_extraction.py \
+    --catalog-dir framework-ab-b-run1/catalogs \
+    --ground-truth tests/fixtures/extraction-ground-truth-full-session.json
+
+# Schema validation
+python tools/validate.py
+```
+
+### 6.6 Collecting Metrics
+
+#### Entity Counts
+
+```bash
+# Count entities per type in a catalog directory
+for type in characters locations items factions events; do
+    echo "$type: $(ls framework-ab-a/catalogs/$type/*.json 2>/dev/null | wc -l)"
+done
+```
+
+PowerShell equivalent:
+
+```powershell
+foreach ($type in @("characters", "locations", "items", "factions", "events")) {
+    $count = (Get-ChildItem "framework-ab-a/catalogs/$type/*.json" -ErrorAction SilentlyContinue).Count
+    Write-Output "${type}: $count"
+}
+```
+
+#### Relationship Counts
+
+```powershell
+# Count total relationships across all entity files
+$total = 0
+Get-ChildItem framework-ab-a/catalogs/*/  -Filter *.json -Recurse | ForEach-Object {
+    $json = Get-Content $_ -Raw | ConvertFrom-Json
+    if ($json.relationships) { $total += $json.relationships.Count }
+}
+Write-Output "Total relationships: $total"
+```
+
+#### Wall-Clock Time
+
+Record timestamps before and after each extraction run. The extraction pipeline logs per-turn timing to stdout — capture it:
+
+```powershell
+$start = Get-Date
+python tools/bootstrap_session.py ... 2>&1 | Tee-Object -FilePath "ab-a-run1.log"
+$elapsed = (Get-Date) - $start
+Write-Output "Total time: $($elapsed.TotalMinutes) minutes"
+```
+
+### 6.7 Computing Statistics
+
+For N runs of each variant, compute mean and standard deviation:
+
+```python
+import statistics
+# Example: entity counts from 3 runs
+a_counts = [45, 47, 46]
+b_counts = [42, 43, 41]
+print(f"A: {statistics.mean(a_counts):.1f} ± {statistics.stdev(a_counts):.1f}")
+print(f"B: {statistics.mean(b_counts):.1f} ± {statistics.stdev(b_counts):.1f}")
+delta_pct = (statistics.mean(b_counts) - statistics.mean(a_counts)) / statistics.mean(a_counts) * 100
+print(f"Δ: {delta_pct:+.1f}%")
+```
+
+---
+
+## 7. Exemptions
+
+The following changes do NOT require A/B testing:
+
+- Documentation-only changes to template files (comments, formatting, no prompt content changes)
+- Changes to `dm-profile-analyzer.md` (does not affect entity extraction)
+- New template files that are not yet wired into the extraction pipeline
+
+To claim an exemption, state the reason in the PR description under an "A/B Test Exemption" heading.
+
+---
+
+## 8. Future Improvements
+
+When tooling matures, the following should be automated:
+
+- [ ] `tools/ab_test.py` — orchestrates multi-run extraction, collects metrics, generates report
+- [ ] CI integration — run A/B on every template-change PR via GitHub Actions
+- [ ] Statistical significance testing (paired t-test or Wilcoxon) for metric deltas
+- [ ] Token-level tracking (input/output tokens per LLM call) once extraction logging supports it
+- [ ] Automated hallucination detection against transcript text

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -328,7 +328,7 @@ Every template-change PR MUST include this section as a PR comment:
 
 - [ ] No BLOCK on any metric
 - [ ] All WARN items have documented justification
-- [ ] Ground truth validation passes for B
+- [ ] Ground truth validation passes for B (full-session runs only; skip for `--max-turns 30`)
 ````
 
 ### 5.2 Pass/Fail Summary
@@ -466,17 +466,24 @@ python tools/bootstrap_session.py `
 
 ### 6.5 Validation
 
-After all runs complete:
+#### Turns 1–30 runs (default)
+
+Schema validation is always required. After all runs complete:
 
 ```bash
-# Schema validation (always required — run for each run directory)
 for run in framework-ab-a-run1 framework-ab-a-run2 framework-ab-a-run3 \
            framework-ab-b-run1 framework-ab-b-run2 framework-ab-b-run3; do
     python tools/validate.py --framework "$run"
 done
+```
 
-# Ground truth validation — only for full-session runs (not --max-turns 30)
-# The full-session fixture is NOT compatible with turns-1-30 extractions.
+For semantic review, compare extraction output against `tests/fixtures/extraction-ground-truth-turns-1-30.json` manually. The turns-1-30 fixture uses entity-level keys (`expected_characters`, `expected_locations`, etc.) and is **not compatible** with `validate_extraction.py`.
+
+#### Full-session runs only
+
+In addition to schema validation above, run ground truth validation using `validate_extraction.py` with the full-session fixture:
+
+```bash
 python tools/validate_extraction.py \
     --catalog-dir framework-ab-a-run1/catalogs \
     --ground-truth tests/fixtures/extraction-ground-truth-full-session.json
@@ -485,8 +492,6 @@ python tools/validate_extraction.py \
     --catalog-dir framework-ab-b-run1/catalogs \
     --ground-truth tests/fixtures/extraction-ground-truth-full-session.json
 ```
-
-> **Note:** If using `--max-turns 30`, use schema validation (`validate.py`) and manual review against `extraction-ground-truth-turns-1-30.json` instead of `validate_extraction.py`.
 
 ### 6.6 Collecting Metrics
 

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -302,6 +302,7 @@ Every template-change PR MUST include this section as a PR comment:
 ### Ground Truth Validation (full-session runs only)
 
 > **Note:** This section applies only to full-session runs using `validate_extraction.py` with `extraction-ground-truth-full-session.json`. For turns 1–30 runs, use schema validation (`validate.py --framework <dir>`) and manual review against `extraction-ground-truth-turns-1-30.json`.
+
 | Check | A | B |
 |---|---|---|
 | Independent Characters | | |
@@ -536,6 +537,24 @@ foreach ($run in @(
 ```
 
 #### Relationship Counts
+
+```bash
+# Count total relationships across all entity files (per-run, both variants)
+for run in framework-ab-a-run1 framework-ab-a-run2 framework-ab-a-run3 \
+           framework-ab-b-run1 framework-ab-b-run2 framework-ab-b-run3; do
+  echo "=== $run ==="
+  python -c "
+import json, os, sys, glob
+total = 0
+for f in glob.glob('$run/catalogs/**/*.json', recursive=True):
+    d = json.load(open(f))
+    total += len(d.get('relationships', []))
+print(f'relationships: {total}')
+"
+done
+```
+
+PowerShell equivalent:
 
 ```powershell
 # Count total relationships across all entity files (per-run, both variants)

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -47,7 +47,7 @@ Report **mean ± standard deviation** for all metrics. If any metric's standard 
 |---|---|---|
 | Wall-clock time per turn | `elapsed_ms / 1000` from extraction log (per-turn field logged by the extraction pipeline) | seconds |
 | Total extraction time | Start-to-finish wall clock | minutes |
-| LLM calls per turn | Count of API calls across all 5 core extraction phases (entity-discovery, entity-detail, pc-extraction, relationship-mapper, event-extractor; temporal-signals is optional and excluded from default call counts). Note: pc-extraction uses the entity-detail template applied specifically to the player character entity and is tracked as a separate call in the pipeline. | count |
+| LLM calls per turn | Sum of `prompt_metrics.<phase>.calls` across phases recorded in `extraction-log.jsonl` for each turn: `discovery`, `entity_detail`, `relationship_mapper`, `event_extractor`. PC detail is processed as an additional `entity_detail` call (there is no distinct `pc-extraction` phase counter); it is included in the `entity_detail` call count automatically. `temporal_signals` is optional and excluded from default call counts. | count |
 
 ### 2.2 Derived Metrics
 

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -367,7 +367,7 @@ git pull
 # Run 1:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/full-transcript.md \
+    --file sessions/_import/session-import-full-transcript.txt \
     --framework framework-ab-a-run1 \
     --max-turns 30 \
     --overwrite \
@@ -377,7 +377,7 @@ python tools/bootstrap_session.py \
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/full-transcript.md \
+    --file sessions/_import/session-import-full-transcript.txt \
     --framework framework-ab-a-run2 \
     --max-turns 30 \
     --overwrite \
@@ -387,7 +387,7 @@ python tools/bootstrap_session.py \
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/full-transcript.md \
+    --file sessions/_import/session-import-full-transcript.txt \
     --framework framework-ab-a-run3 \
     --max-turns 30 \
     --overwrite \
@@ -397,7 +397,7 @@ python tools/bootstrap_session.py \
 
 > **Note:** Always specify `--base-url` explicitly to prevent round-robin mixing between A and B variants. Substitute `localhost:8080` / `localhost:8081` with your actual server endpoints from `config/llm.json` `base_urls`.
 >
-> **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/_import/full-transcript.md` and create the session directory at `sessions/session-import`. These paths are not committed to the repository; see `docs/usage.md` for instructions on setting up a session before running A/B tests.
+> **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/_import/session-import-full-transcript.txt` and create the session directory at `sessions/session-import`. These paths are not committed to the repository; see `docs/usage.md` for instructions on setting up a session before running A/B tests.
 
 ### 6.3 Run Variant B (Candidate)
 
@@ -408,7 +408,7 @@ git checkout <pr-branch>
 # Run 1:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/full-transcript.md \
+    --file sessions/_import/session-import-full-transcript.txt \
     --framework framework-ab-b-run1 \
     --max-turns 30 \
     --overwrite \
@@ -418,7 +418,7 @@ python tools/bootstrap_session.py \
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/full-transcript.md \
+    --file sessions/_import/session-import-full-transcript.txt \
     --framework framework-ab-b-run2 \
     --max-turns 30 \
     --overwrite \
@@ -428,7 +428,7 @@ python tools/bootstrap_session.py \
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/full-transcript.md \
+    --file sessions/_import/session-import-full-transcript.txt \
     --framework framework-ab-b-run3 \
     --max-turns 30 \
     --overwrite \
@@ -446,7 +446,7 @@ The two B70 GPU servers (ports 8080 and 8081 by default — see `tools/submit_ab
 # Terminal 1 — Variant A on GPU 0 (port 8080)
 python tools/bootstrap_session.py `
     --session sessions/session-import `
-    --file sessions/_import/full-transcript.md `
+    --file sessions/_import/session-import-full-transcript.txt `
     --framework framework-ab-a-run1 `
     --max-turns 30 `
     --base-url http://localhost:8080/v1 `
@@ -456,7 +456,7 @@ python tools/bootstrap_session.py `
 # Terminal 2 — Variant B on GPU 1 (port 8081)
 python tools/bootstrap_session.py `
     --session sessions/session-import `
-    --file sessions/_import/full-transcript.md `
+    --file sessions/_import/session-import-full-transcript.txt `
     --framework framework-ab-b-run1 `
     --max-turns 30 `
     --base-url http://localhost:8081/v1 `

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -138,7 +138,7 @@ Two ground truth fixtures exist:
 - **`extraction-ground-truth-full-session.json`** — uses the tool-compatible schema (`expected_independent_characters`, `expected_pc_aliases`, `must_not_merge`, `coreference_groups`, etc.). This is the fixture `validate_extraction.py` expects.
 - **`extraction-ground-truth-turns-1-30.json`** — uses entity-level keys (`expected_characters`, `expected_locations`, etc.) for manual semantic review. This fixture is **NOT compatible** with `validate_extraction.py`.
 
-Run `tools/validate_extraction.py` against each extraction output using the fixture that matches the turn range:
+Choose the validation approach based on the turn range used:
 
 - **Turns 1–30 runs** (`--max-turns 30`): Validate with `extraction-ground-truth-turns-1-30.json` for entity-level manual review. Note: this fixture is **NOT compatible** with `validate_extraction.py` (different schema) — use it for manual spot-checks only.
 - **Full-session runs** (all turns): Validate with `extraction-ground-truth-full-session.json` using `validate_extraction.py`:
@@ -493,22 +493,31 @@ python tools/validate_extraction.py \
 #### Entity Counts
 
 ```bash
-# Count entities per type in a catalog directory (per-run)
-for run in framework-ab-a-run1 framework-ab-a-run2 framework-ab-a-run3; do
+# Count entities per type in a catalog directory (per-run, both variants)
+for run in framework-ab-a-run1 framework-ab-a-run2 framework-ab-a-run3 \
+           framework-ab-b-run1 framework-ab-b-run2 framework-ab-b-run3; do
   echo "=== $run ==="
-  for type in characters locations items factions; do
+  # Characters: exclude char-player.json
+  echo "characters: $(ls $run/catalogs/characters/*.json 2>/dev/null | grep -v 'char-player\.json' | wc -l)"
+  for type in locations items factions; do
     echo "$type: $(ls $run/catalogs/$type/*.json 2>/dev/null | wc -l)"
   done
-  echo "events: $(python -c "import json; print(len(json.load(open('$run/catalogs/events.json'))))" 2>/dev/null || echo 0)"
+  echo "events: $(python -c 'import json,sys; print(len(json.load(open(sys.argv[1]))))' "$run/catalogs/events.json" 2>/dev/null || echo 0)"
 done
 ```
 
 PowerShell equivalent:
 
 ```powershell
-foreach ($run in @("framework-ab-a-run1", "framework-ab-a-run2", "framework-ab-a-run3")) {
+foreach ($run in @(
+    "framework-ab-a-run1", "framework-ab-a-run2", "framework-ab-a-run3",
+    "framework-ab-b-run1", "framework-ab-b-run2", "framework-ab-b-run3")) {
     Write-Output "=== $run ==="
-    foreach ($type in @("characters", "locations", "items", "factions")) {
+    # Characters: exclude char-player.json
+    $charCount = (Get-ChildItem "$run/catalogs/characters/*.json" -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ne "char-player.json" }).Count
+    Write-Output "characters: $charCount"
+    foreach ($type in @("locations", "items", "factions")) {
         $count = (Get-ChildItem "$run/catalogs/$type/*.json" -ErrorAction SilentlyContinue).Count
         Write-Output "${type}: $count"
     }

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -94,7 +94,7 @@ Report as a table:
 
 ### 3.2 Relationship Counts
 
-Count total relationships across all entity files. Report by relationship type if available (ally, enemy, kinship, etc.).
+Count total relationships across all entity files. Report by relationship type if available using the canonical `category` values from `schemas/entity.schema.json`: `kinship`, `partnership`, `mentorship`, `political`, `factional`, `social`, `adversarial`, `romantic`, `spatial`, `other`.
 
 ### 3.3 JSON Schema Validity
 
@@ -194,7 +194,7 @@ Score: `attributes_present / attributes_expected` across all ground truth entiti
 |---|---|
 | ≥ 90% | PASS |
 | 75–89% | WARN |
-| < 75% | BLOCK |
+| < 75% | BLOCK (advisory — requires written justification; does not auto-prevent merge) |
 
 ### 4.3 Relationship Correctness (Turns 1–30)
 
@@ -208,7 +208,7 @@ Using the ground truth `coreference_checks`:
 2. **Identity consolidation:** Authority-leader described differently across turns is ONE character entry.
 3. **Type correctness:** Encampment/fire-gathering are typed as `location`, not `character` or `faction`.
 
-All coreference checks must PASS. Any FAIL blocks the PR.
+All coreference checks must PASS. Any FAIL warrants written justification before merge (advisory — does not auto-block, but SHOULD be resolved or documented).
 
 ### 4.4 Hallucination Detection
 
@@ -226,7 +226,7 @@ For each extraction output, identify entities that cannot be traced to the trans
 |---|---|
 | 0% | PASS |
 | ≤ 5% | WARN |
-| > 5% | BLOCK |
+| > 5% | BLOCK (advisory — requires written justification; does not auto-prevent merge) |
 
 ### 4.5 Dedup Quality
 
@@ -248,10 +248,10 @@ Report count of suspected duplicates per variant.
 >
 > These checks require human review. They do NOT block merge but SHOULD be performed for major template changes. See §8 for planned automation.
 
-For turns beyond the ground truth range (31–345), apply these automated heuristics:
+For turns beyond the ground truth range (31–345), apply these manual heuristics:
 
 1. **Monotonic growth:** Entity count should not decrease between extraction checkpoints.
-2. **No empty descriptions:** Every entity should have a non-empty `description` or `appearance`.
+2. **No empty identity:** Every entity should have a non-empty `identity` field (the `identity` top-level string holds the stable description).
 3. **Turn coverage:** Every DM turn in the range should produce at least one discovery or update (check extraction log).
 4. **Relationship reciprocity:** If A→B relationship exists, B should have a corresponding entry (check via `relationship-index.json`).
 
@@ -349,9 +349,9 @@ The PR is **mergeable** when:
 Ensure `config/llm.json` is configured and both LLM servers are running:
 
 ```bash
-# Verify servers are reachable
-curl -s http://localhost:8000/v1/models | python -m json.tool
-curl -s http://localhost:8001/v1/models | python -m json.tool
+# Verify servers are reachable (default ports — adjust to match your config/llm.json)
+curl -s http://localhost:8080/v1/models | python -m json.tool
+curl -s http://localhost:8081/v1/models | python -m json.tool
 ```
 
 ### 6.2 Run Variant A (Baseline)
@@ -371,7 +371,7 @@ python tools/bootstrap_session.py \
     --framework framework-ab-a-run1 \
     --max-turns 30 \
     --overwrite \
-    --base-url http://localhost:8000/v1
+    --base-url http://localhost:8080/v1
 
 # Run 2:
 python tools/bootstrap_session.py \
@@ -381,7 +381,7 @@ python tools/bootstrap_session.py \
     --framework framework-ab-a-run2 \
     --max-turns 30 \
     --overwrite \
-    --base-url http://localhost:8000/v1
+    --base-url http://localhost:8080/v1
 
 # Run 3:
 python tools/bootstrap_session.py \
@@ -391,7 +391,7 @@ python tools/bootstrap_session.py \
     --framework framework-ab-a-run3 \
     --max-turns 30 \
     --overwrite \
-    --base-url http://localhost:8000/v1
+    --base-url http://localhost:8080/v1
 ```
 
 > **Note:** Always specify `--base-url` explicitly to prevent round-robin mixing between A and B variants.
@@ -410,7 +410,7 @@ python tools/bootstrap_session.py \
     --framework framework-ab-b-run1 \
     --max-turns 30 \
     --overwrite \
-    --base-url http://localhost:8001/v1
+    --base-url http://localhost:8081/v1
 
 # Run 2:
 python tools/bootstrap_session.py \
@@ -420,7 +420,7 @@ python tools/bootstrap_session.py \
     --framework framework-ab-b-run2 \
     --max-turns 30 \
     --overwrite \
-    --base-url http://localhost:8001/v1
+    --base-url http://localhost:8081/v1
 
 # Run 3:
 python tools/bootstrap_session.py \
@@ -430,35 +430,34 @@ python tools/bootstrap_session.py \
     --framework framework-ab-b-run3 \
     --max-turns 30 \
     --overwrite \
-    --base-url http://localhost:8001/v1
+    --base-url http://localhost:8081/v1
 ```
 
 > **Note:** Always specify `--base-url` explicitly to prevent round-robin mixing between A and B variants.
 
 ### 6.4 Parallel A/B Using Two GPUs
 
-The two B70 GPU servers (ports 8000 and 8001) can run A and B simultaneously:
+The two B70 GPU servers (ports 8080 and 8081 by default — see `tools/submit_ab_test.py`) can run A and B simultaneously:
 
 ```powershell
-# Terminal 1 — Variant A on GPU 0 (port 8000)
-$env:NSE_LLM_BASE_URL = "http://localhost:8000/v1"
+# Terminal 1 — Variant A on GPU 0 (port 8080)
 python tools/bootstrap_session.py `
     --session sessions/session-import `
     --file sessions/session-import/raw/full-transcript.md `
     --extract `
     --framework framework-ab-a-run1 `
     --max-turns 30 `
-    --base-url http://localhost:8000/v1 `
+    --base-url http://localhost:8080/v1 `
     --overwrite
 
-# Terminal 2 — Variant B on GPU 1 (port 8001)
+# Terminal 2 — Variant B on GPU 1 (port 8081)
 python tools/bootstrap_session.py `
     --session sessions/session-import `
     --file sessions/session-import/raw/full-transcript.md `
     --extract `
     --framework framework-ab-b-run1 `
     --max-turns 30 `
-    --base-url http://localhost:8001/v1 `
+    --base-url http://localhost:8081/v1 `
     --overwrite
 ```
 
@@ -507,7 +506,9 @@ for run in framework-ab-a-run1 framework-ab-a-run2 framework-ab-a-run3 \
   for type in locations items factions; do
     echo "$type: $(ls $run/catalogs/$type/*.json 2>/dev/null | wc -l)"
   done
-  echo "events: $(python -c 'import json,sys; print(len(json.load(open(sys.argv[1]))))' "$run/catalogs/events.json" 2>/dev/null || echo 0)"
+  _evcount=$(python -c 'import json,sys; print(len(json.load(open(sys.argv[1]))))' \
+    "$run/catalogs/events.json" 2>/dev/null || echo 0)
+  echo "events: $_evcount"
 done
 ```
 
@@ -582,9 +583,8 @@ print(f"Δ: {delta_pct:+.1f}%")
 
 The following changes do NOT require A/B testing:
 
-- Documentation-only changes to template files (comments, formatting, no prompt content changes)
-- Changes to `dm-profile-analyzer.md` (does not affect entity extraction)
-- New template files that are not yet wired into the extraction pipeline
+- Changes to templates **outside** `templates/extraction/` (e.g., `dm-profile-analyzer.md`, `dm-*.md`). Note: extraction templates are loaded verbatim by the pipeline — any text change, including formatting or comments, alters the prompt and requires A/B testing.
+- New template files not yet wired into the extraction pipeline
 
 To claim an exemption, state the reason in the PR description under an "A/B Test Exemption" heading.
 

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -45,9 +45,9 @@ Report **mean ± standard deviation** for all metrics. If any metric's standard 
 
 | Metric | Source | Unit |
 |---|---|---|
-| Wall-clock time per turn | Timestamp delta from extraction log | seconds |
+| Wall-clock time per turn | `elapsed_ms / 1000` from extraction log (per-turn field logged by the extraction pipeline) | seconds |
 | Total extraction time | Start-to-finish wall clock | minutes |
-| LLM calls per turn | Count of API calls across all 4 core extraction phases (entity-discovery, entity-detail, relationship-mapper, event-extractor; temporal-signals is optional and excluded from default call counts) | count |
+| LLM calls per turn | Count of API calls across all 5 core extraction phases (entity-discovery, entity-detail, pc-extraction, relationship-mapper, event-extractor; temporal-signals is optional and excluded from default call counts). Note: pc-extraction uses the entity-detail template applied specifically to the player character entity and is tracked as a separate call in the pipeline. | count |
 
 ### 2.2 Derived Metrics
 
@@ -76,10 +76,10 @@ Count entities by type in each extraction output:
 
 | Type | Catalog directory | Count method |
 |---|---|---|
-| Characters | `catalogs/characters/` | File count (excluding `char-player.json`) |
-| Locations | `catalogs/locations/` | File count |
-| Items | `catalogs/items/` | File count |
-| Factions | `catalogs/factions/` | File count |
+| Characters | `catalogs/characters/` | File count (excluding `char-player.json` and `index.json`) |
+| Locations | `catalogs/locations/` | File count (excluding `index.json`) |
+| Items | `catalogs/items/` | File count (excluding `index.json`) |
+| Factions | `catalogs/factions/` | File count (excluding `index.json`) |
 | Events | `catalogs/events.json` | Array length (`jq length` or `python -c "import json; print(len(json.load(open(...))))"`) |
 
 Report as a table:
@@ -94,7 +94,7 @@ Report as a table:
 
 ### 3.2 Relationship Counts
 
-Count total relationships across all entity files. Report by relationship type if available using the canonical `category` values from `schemas/entity.schema.json`: `kinship`, `partnership`, `mentorship`, `political`, `factional`, `social`, `adversarial`, `romantic`, `spatial`, `other`.
+Count total relationships across all entity files. Report by relationship `type` if available using the canonical `type` enum values from `schemas/entity.schema.json`: `kinship`, `partnership`, `mentorship`, `political`, `factional`, `social`, `adversarial`, `romantic`, `spatial`, `other`.
 
 ### 3.3 JSON Schema Validity
 
@@ -121,7 +121,7 @@ Report:
 | Single type count **gain** | Δ ≤ 15% gain | 15–25% gain | > 25% gain (hallucination signal) |
 | Relationship count **loss** | Δ ≤ 10% loss | 10–20% loss | > 20% loss |
 | Relationship count **gain** | Δ ≤ 15% gain | 15–25% gain | > 25% gain (hallucination signal) |
-| Schema validity | 100% | ≥ 95% | < 95% |
+| Schema validity | 100% | — | < 100% |
 | Performance regression | Δ ≤ +10% time | +10–20% time | > +20% time |
 | Performance improvement | Always PASS | — | — |
 
@@ -194,7 +194,7 @@ Score: `attributes_present / attributes_expected` across all ground truth entiti
 |---|---|
 | ≥ 90% | PASS |
 | 75–89% | WARN |
-| < 75% | BLOCK (advisory — requires written justification; does not auto-prevent merge) |
+| < 75% | NEEDS REVIEW (advisory — requires written justification; does not auto-prevent merge) |
 
 ### 4.3 Relationship Correctness (Turns 1–30)
 
@@ -226,7 +226,7 @@ For each extraction output, identify entities that cannot be traced to the trans
 |---|---|
 | 0% | PASS |
 | ≤ 5% | WARN |
-| > 5% | BLOCK (advisory — requires written justification; does not auto-prevent merge) |
+| > 5% | NEEDS REVIEW (advisory — requires written justification; does not auto-prevent merge) |
 
 ### 4.5 Dedup Quality
 
@@ -367,8 +367,7 @@ git pull
 # Run 1:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/session-import/raw/full-transcript.md \
-    --extract \
+    --file sessions/_import/full-transcript.md \
     --framework framework-ab-a-run1 \
     --max-turns 30 \
     --overwrite \
@@ -377,8 +376,7 @@ python tools/bootstrap_session.py \
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/session-import/raw/full-transcript.md \
-    --extract \
+    --file sessions/_import/full-transcript.md \
     --framework framework-ab-a-run2 \
     --max-turns 30 \
     --overwrite \
@@ -387,17 +385,16 @@ python tools/bootstrap_session.py \
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/session-import/raw/full-transcript.md \
-    --extract \
+    --file sessions/_import/full-transcript.md \
     --framework framework-ab-a-run3 \
     --max-turns 30 \
     --overwrite \
     --base-url http://localhost:8080/v1
 ```
 
-> **Note:** Always specify `--base-url` explicitly to prevent round-robin mixing between A and B variants.
-
-### 6.3 Run Variant B (PR Branch)
+> **Note:** Always specify `--base-url` explicitly to prevent round-robin mixing between A and B variants. Substitute `localhost:8080` / `localhost:8081` with your actual server endpoints from `config/llm.json` `base_urls`.
+>
+> **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/_import/full-transcript.md` and create the session directory at `sessions/session-import`. These paths are not committed to the repository; see `docs/usage.md` for instructions on setting up a session before running A/B tests.
 
 ```bash
 git checkout <pr-branch>
@@ -406,8 +403,7 @@ git checkout <pr-branch>
 # Run 1:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/session-import/raw/full-transcript.md \
-    --extract \
+    --file sessions/_import/full-transcript.md \
     --framework framework-ab-b-run1 \
     --max-turns 30 \
     --overwrite \
@@ -416,8 +412,7 @@ python tools/bootstrap_session.py \
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/session-import/raw/full-transcript.md \
-    --extract \
+    --file sessions/_import/full-transcript.md \
     --framework framework-ab-b-run2 \
     --max-turns 30 \
     --overwrite \
@@ -426,8 +421,7 @@ python tools/bootstrap_session.py \
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/session-import/raw/full-transcript.md \
-    --extract \
+    --file sessions/_import/full-transcript.md \
     --framework framework-ab-b-run3 \
     --max-turns 30 \
     --overwrite \
@@ -444,8 +438,7 @@ The two B70 GPU servers (ports 8080 and 8081 by default — see `tools/submit_ab
 # Terminal 1 — Variant A on GPU 0 (port 8080)
 python tools/bootstrap_session.py `
     --session sessions/session-import `
-    --file sessions/session-import/raw/full-transcript.md `
-    --extract `
+    --file sessions/_import/full-transcript.md `
     --framework framework-ab-a-run1 `
     --max-turns 30 `
     --base-url http://localhost:8080/v1 `
@@ -454,8 +447,7 @@ python tools/bootstrap_session.py `
 # Terminal 2 — Variant B on GPU 1 (port 8081)
 python tools/bootstrap_session.py `
     --session sessions/session-import `
-    --file sessions/session-import/raw/full-transcript.md `
-    --extract `
+    --file sessions/_import/full-transcript.md `
     --framework framework-ab-b-run1 `
     --max-turns 30 `
     --base-url http://localhost:8081/v1 `
@@ -502,10 +494,10 @@ python tools/validate_extraction.py \
 for run in framework-ab-a-run1 framework-ab-a-run2 framework-ab-a-run3 \
            framework-ab-b-run1 framework-ab-b-run2 framework-ab-b-run3; do
   echo "=== $run ==="
-  # Characters: exclude char-player.json
-  echo "characters: $(ls $run/catalogs/characters/*.json 2>/dev/null | grep -v 'char-player\.json' | wc -l)"
+  # Characters: exclude char-player.json and index.json
+  echo "characters: $(ls $run/catalogs/characters/*.json 2>/dev/null | grep -v 'char-player\.json' | grep -v 'index\.json' | wc -l)"
   for type in locations items factions; do
-    echo "$type: $(ls $run/catalogs/$type/*.json 2>/dev/null | wc -l)"
+    echo "$type: $(ls $run/catalogs/$type/*.json 2>/dev/null | grep -v 'index\.json' | wc -l)"
   done
   _evcount=$(python -c 'import json,sys; print(len(json.load(open(sys.argv[1]))))' \
     "$run/catalogs/events.json" 2>/dev/null || echo 0)
@@ -520,12 +512,13 @@ foreach ($run in @(
     "framework-ab-a-run1", "framework-ab-a-run2", "framework-ab-a-run3",
     "framework-ab-b-run1", "framework-ab-b-run2", "framework-ab-b-run3")) {
     Write-Output "=== $run ==="
-    # Characters: exclude char-player.json
+    # Characters: exclude char-player.json and index.json
     $charCount = (Get-ChildItem "$run/catalogs/characters/*.json" -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -ne "char-player.json" }).Count
+        Where-Object { $_.Name -ne "char-player.json" -and $_.Name -ne "index.json" }).Count
     Write-Output "characters: $charCount"
     foreach ($type in @("locations", "items", "factions")) {
-        $count = (Get-ChildItem "$run/catalogs/$type/*.json" -ErrorAction SilentlyContinue).Count
+        $count = (Get-ChildItem "$run/catalogs/$type/*.json" -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -ne "index.json" }).Count
         Write-Output "${type}: $count"
     }
     $eventsFile = "$run/catalogs/events.json"
@@ -544,11 +537,12 @@ for run in framework-ab-a-run1 framework-ab-a-run2 framework-ab-a-run3 \
            framework-ab-b-run1 framework-ab-b-run2 framework-ab-b-run3; do
   echo "=== $run ==="
   python -c "
-import json, os, sys, glob
+import json, glob
 total = 0
 for f in glob.glob('$run/catalogs/**/*.json', recursive=True):
     d = json.load(open(f))
-    total += len(d.get('relationships', []))
+    if isinstance(d, dict):
+        total += len(d.get('relationships', []))
 print(f'relationships: {total}')
 "
 done
@@ -562,10 +556,14 @@ foreach ($run in @(
     "framework-ab-a-run1", "framework-ab-a-run2", "framework-ab-a-run3",
     "framework-ab-b-run1", "framework-ab-b-run2", "framework-ab-b-run3")) {
     $total = 0
-    Get-ChildItem "$run/catalogs/" -Filter *.json -Recurse | ForEach-Object {
-        $json = Get-Content $_ -Raw | ConvertFrom-Json
-        if ($json.relationships) { $total += $json.relationships.Count }
-    }
+    Get-ChildItem "$run/catalogs/" -Filter *.json -Recurse |
+        Where-Object { $_.Name -ne "index.json" -and $_.Name -ne "events.json" } |
+        ForEach-Object {
+            $json = Get-Content $_ -Raw | ConvertFrom-Json
+            if ($json -is [PSCustomObject] -and $json.relationships) {
+                $total += $json.relationships.Count
+            }
+        }
     Write-Output "${run} relationships: $total"
 }
 ```


### PR DESCRIPTION
## Summary

Adds two documentation files that define quantitative pass/warn/block thresholds for A/B tests on extraction template changes:

- **`docs/ab-test-standard.md`** — Full statistical standard covering metrics, sample sizes, significance thresholds, and reporting format
- **`docs/ab-test-checklist.md`** — Embeddable per-PR checklist for template change PRs, designed to be included in `.prompt.md` files

These complement the existing `docs/ab-testing.md` usage guide by providing concrete decision criteria and a quick-reference checklist.

No code changes — documentation only.
