### PR TITLE
docs: add task submission method to coordinator agent definition

### DIFF
--- a/.github/agents/coordinator.agent.md
+++ b/.github/agents/coordinator.agent.md
@@ -67,14 +67,20 @@ All non-trivial work that runs on remote hosts MUST be submitted through the tas
 - Any work that should appear on the dashboard for visibility
 
 ### Task Submission Method
-Submit tasks using the Python API locally — do NOT SSH into arclight to run raw SQL inserts:
+Submit tasks using the Python API locally — do NOT SSH into arclight to run raw SQL inserts.
+The orchestrator API (`saas/`) lives in **narrative-state-engine-private**, not in this public repo.
+
+From the private repo working directory (`narrative-state-engine-private`):
 ```python
+import os
 from saas.orchestrator.api import OrchestratorAPI
 from saas.orchestrator.models import DatabaseConfig, TaskDefinition
 
-async with OrchestratorAPI(db_config=DatabaseConfig(password="...")) as api:
+async with OrchestratorAPI(db_config=DatabaseConfig(password=os.environ["NSE_ORCH_PASSWORD"])) as api:
     await api.submit_task(TaskDefinition(id="...", name="...", ...))
 ```
+> **Never embed credentials in PRs, chat messages, or prompt files.** Use `NSE_ORCH_PASSWORD` (or the appropriate env var) and keep secrets in your shell environment or a secrets manager.
+
 This connects directly to arclight:5432 over LAN. `TaskDefinition` provides Pydantic validation (ID format, not_before normalization, etc.). Delegate task submission to @developer — it is NOT @b70-optimizer's job unless the task is specifically about B70 hardware administration.
 
 ### Enforcement

--- a/.github/agents/coordinator.agent.md
+++ b/.github/agents/coordinator.agent.md
@@ -66,6 +66,17 @@ All non-trivial work that runs on remote hosts MUST be submitted through the tas
 - Any process that runs >1 minute or produces artifacts others need to see
 - Any work that should appear on the dashboard for visibility
 
+### Task Submission Method
+Submit tasks using the Python API locally — do NOT SSH into arclight to run raw SQL inserts:
+```python
+from saas.orchestrator.api import OrchestratorAPI
+from saas.orchestrator.models import DatabaseConfig, TaskDefinition
+
+async with OrchestratorAPI(db_config=DatabaseConfig(password="...")) as api:
+    await api.submit_task(TaskDefinition(id="...", name="...", ...))
+```
+This connects directly to arclight:5432 over LAN. `TaskDefinition` provides Pydantic validation (ID format, not_before normalization, etc.). Delegate task submission to @developer — it is NOT @b70-optimizer's job unless the task is specifically about B70 hardware administration.
+
 ### Enforcement
 If you (coordinator) catch yourself about to dispatch an agent to run a >1 minute process via raw SSH/nohup, STOP and reframe as a task submission instead. The @process-qa agent audits compliance.
 
@@ -89,6 +100,7 @@ If you (coordinator) catch yourself about to dispatch an agent to run a >1 minut
 | "Restart/stop/start LLM servers on arclight" | @b70-optimizer |
 | "Shut down / reboot arclight" | @b70-optimizer |
 | "Check server health / SSH admin tasks" | @b70-optimizer |
+| "Submit orchestrator task" | @developer (local Python API, not SSH) |
 | "Restart/stop/start LLM servers on RTX box" | @rtx4070-optimizer |
 | "Why is extraction slow / token budget" | @token-economist |
 | "Tune prompt for fewer tokens" | @token-economist + @model-optimizer (quality check) |

--- a/.github/agents/coordinator.agent.md
+++ b/.github/agents/coordinator.agent.md
@@ -77,11 +77,15 @@ from saas.orchestrator.api import OrchestratorAPI
 from saas.orchestrator.models import DatabaseConfig, TaskDefinition
 
 async with OrchestratorAPI(db_config=DatabaseConfig(password=os.environ["NSE_ORCH_PASSWORD"])) as api:
-    await api.submit_task(TaskDefinition(id="...", name="...", ...))
+    await api.submit_task(TaskDefinition(
+        id="eval-run-42",
+        name="Run benchmark",
+        # add remaining TaskDefinition fields here
+    ))
 ```
 > **Never embed credentials in PRs, chat messages, or prompt files.** Use `NSE_ORCH_PASSWORD` (or the appropriate env var) and keep secrets in your shell environment or a secrets manager.
 
-This connects directly to arclight:5432 over LAN. `TaskDefinition` provides Pydantic validation (ID format, not_before normalization, etc.). Delegate task submission to @developer — it is NOT @b70-optimizer's job unless the task is specifically about B70 hardware administration.
+This connects to the orchestrator database over LAN. `TaskDefinition` provides Pydantic validation (ID format, not_before normalization, etc.). Delegate task submission to @developer — it is NOT @b70-optimizer's job unless the task is specifically about B70 hardware administration.
 
 ### Enforcement
 If you (coordinator) catch yourself about to dispatch an agent to run a >1 minute process via raw SSH/nohup, STOP and reframe as a task submission instead. The @process-qa agent audits compliance.

--- a/.github/agents/coordinator.agent.md
+++ b/.github/agents/coordinator.agent.md
@@ -72,16 +72,21 @@ The orchestrator API (`saas/`) lives in **narrative-state-engine-private**, not 
 
 From the private repo working directory (`narrative-state-engine-private`):
 ```python
+import asyncio
 import os
 from saas.orchestrator.api import OrchestratorAPI
 from saas.orchestrator.models import DatabaseConfig, TaskDefinition
 
-async with OrchestratorAPI(db_config=DatabaseConfig(password=os.environ["NSE_ORCH_PASSWORD"])) as api:
-    await api.submit_task(TaskDefinition(
-        id="eval-run-42",
-        name="Run benchmark",
-        # add remaining TaskDefinition fields here
-    ))
+async def main():
+    config = DatabaseConfig(password=os.environ["NSE_ORCH_PASSWORD"])
+    async with OrchestratorAPI(db_config=config) as api:
+        await api.submit_task(TaskDefinition(
+            id="eval-run-42",
+            name="Run benchmark",
+            # add remaining TaskDefinition fields here
+        ))
+
+asyncio.run(main())
 ```
 > **Never embed credentials in PRs, chat messages, or prompt files.** Use `NSE_ORCH_PASSWORD` (or the appropriate env var) and keep secrets in your shell environment or a secrets manager.
 


### PR DESCRIPTION
## Summary

Updates coordinator agent definition with task submission best practices learned from Epic #97 model evaluation work.

## Changes

- **Task Submission Method section**: Explicit instruction to use `OrchestratorAPI.submit_task()` locally over LAN (connects to arclight:5432) instead of SSH-ing into arclight to run raw SQL inserts
- **Decision matrix**: Added "Submit orchestrator task" → @developer (local Python API, not SSH)
- **Clarification**: Task submission is NOT @b70-optimizer's job unless the task is specifically about B70 hardware administration

## Motivation

During Epic #97, the coordinator repeatedly dispatched @b70-optimizer to SSH into arclight and craft raw SQL INSERT statements — when the repo already has a Python API (`saas/orchestrator/api.py`) that connects directly over LAN with Pydantic validation.
