### PR TITLE
fix: add safeguard against git-add-all in developer agent

### DIFF
--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -20,6 +20,7 @@ You are the code developer for narrative-state-engine. Your job is to implement 
 - DO NOT add entities, locations, or plot details not in the transcript (Rule 7)
 - DO NOT skip documentation updates when changing tool behavior (Rule 8)
 - ONLY implement what the prompt or issue specifies — no unsolicited refactoring
+- **NEVER use `git add .`, `git add -A`, or `git add --all`** — always stage explicit file paths. Before committing, run `git status` and verify ONLY intended files are staged. If the staged file count exceeds what the task requires, STOP and unstage unexpected files with `git reset`. A commit touching more files than the task specifies is a P1-CRITICAL process violation.
 
 ## Approach
 

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -20,7 +20,7 @@ You are the code developer for narrative-state-engine. Your job is to implement 
 - DO NOT add entities, locations, or plot details not in the transcript (Rule 7)
 - DO NOT skip documentation updates when changing tool behavior (Rule 8)
 - ONLY implement what the prompt or issue specifies — no unsolicited refactoring
-- **NEVER use `git add .`, `git add -A`, or `git add --all`** — always stage explicit file paths. Before committing, run `git status` and verify ONLY intended files are staged. If the staged file count exceeds what the task requires, STOP and unstage unexpected files with `git reset`. A commit touching more files than the task specifies is a P1-CRITICAL process violation.
+- **NEVER use `git add .`, `git add -A`, or `git add --all`** — always stage explicit file paths. Before committing, run `git status` and verify ONLY intended files are staged. If the staged file count exceeds what the task requires, STOP and unstage unexpected files with `git restore --staged <path>` (or `git reset HEAD <path>` on older Git). A commit touching more files than the task specifies is a P1-CRITICAL process violation.
 
 ## Approach
 


### PR DESCRIPTION
## Summary

Adds a hard safeguard rule to the developer agent definition preventing the use of `git add .`, `git add -A`, or `git add --all`. This caused PR #435 to accidentally commit 214 untracked scratch files when only 1 file was intended.

## Root Cause (PR #435 incident)

The developer agent used a broad `git add` command that staged every untracked file in the repo root. Because the initial PR push is exempt from @reviewer pre-push sign-off, nobody caught the 9,068-line diff before it hit remote.

## Safeguard Added

New constraint in `.github/agents/developer.agent.md`:
- **NEVER** use `git add .`, `git add -A`, or `git add --all`
- Always stage explicit file paths
- Run `git status` before committing and verify only intended files are staged
- If staged file count exceeds task scope, STOP and `git reset` unexpected files
- Violation is classified as P1-CRITICAL

## Related

- PR #435 (closed - 214 scratch files committed)
- Issue #122 (dashboard improvements)
