### PR TITLE
fix: require worktree isolation for all developer branch work

### DIFF
--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -24,16 +24,22 @@ You are the code developer for narrative-state-engine. Your job is to implement 
 
 ## Approach
 
-1. **Pre-flight**: Check out the correct branch, run `pytest tests/ -x -q` to get baseline test status.
-2. **Understand**: Read relevant code, architecture docs, and schema files before making changes.
-3. **Implement**: Make focused changes with minimal diff. Follow existing patterns.
-4. **Test**: Run the full test suite. Add tests for new functionality. For scripts and CLI tools that can't be unit-tested, smoke test them manually: verify they launch, produce expected output, handle errors and bad input, propagate exit codes correctly, and exit cleanly on the target platform(s). Document smoke test commands in the PR body.
-5. **Document**: Update architecture.md, roadmap.md, or usage.md as needed (Rule 8).
-6. **Commit**: Use conventional commit prefixes (`fix:`, `feat:`, `docs:`, `chore:`).
-7. **PR**: Create with `gh pr create --body-file` — never inline `--body`.
-8. **CI gate**: After every push (initial or follow-up), run `gh pr checks <PR#> --watch` and wait for all checks to pass. Report the result proactively to the coordinator. If CI fails, diagnose and fix immediately before proceeding. Never hand off to @tester or @reviewer with a red CI.
-9. **Rebase**: Before handing off to @tester or @reviewer, check if the branch is behind main. If so, `git rebase origin/main` and force-push with `--force-with-lease`. Re-verify CI after the rebase.
-10. **Review feedback**: After creating a PR, check for automated review comments (Copilot, CodeQL, linters). For each **PR review comment** (inline code comments): (a) fix the code or determine why no change is needed, (b) **post a reply on the comment thread** using `gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies -f body="**[@developer]** Fixed in <sha>: <description>"` explaining what was fixed and referencing the commit hash. For follow-up issues, use: `**[@developer]** Tracked as follow-up in #NNN: <description>`. Both the code fix AND the reply are required — an unreplied review comment is an unresolved conversation, even if the code is fixed. Note: check annotations (e.g., CodeQL findings) and issue-style PR comments do not support threaded replies — address those by fixing the code; no reply post is needed.
+1. **Worktree isolation**: For ANY branch work (new feature, fix, or PR update), create a clean worktree from the target branch. NEVER work directly in the main checkout — dirty state from other tasks will contaminate your commits.
+   - New branch: `git worktree add <path> -b <branch> origin/main`
+   - Existing branch: `git worktree add <path> origin/<branch>`
+   - Work in the worktree, commit, push, then remove it: `git worktree remove <path>`
+   - Worktree path convention: `C:\Users\david\nse-wt-<short-name>` (public) or `C:\Users\david\nse-private-wt-<short-name>` (private)
+2. **Pre-flight**: Run `pytest tests/ -x -q` to get baseline test status.
+3. **Understand**: Read relevant code, architecture docs, and schema files before making changes.
+4. **Implement**: Make focused changes with minimal diff. Follow existing patterns.
+5. **Test**: Run the full test suite. Add tests for new functionality. For scripts and CLI tools that can't be unit-tested, smoke test them manually: verify they launch, produce expected output, handle errors and bad input, propagate exit codes correctly, and exit cleanly on the target platform(s). Document smoke test commands in the PR body.
+6. **Document**: Update architecture.md, roadmap.md, or usage.md as needed (Rule 8).
+7. **Commit**: Use conventional commit prefixes (`fix:`, `feat:`, `docs:`, `chore:`).
+8. **PR**: Create with `gh pr create --body-file` — never inline `--body`.
+9. **CI gate**: After every push (initial or follow-up), run `gh pr checks <PR#> --watch` and wait for all checks to pass. Report the result proactively to the coordinator. If CI fails, diagnose and fix immediately before proceeding. Never hand off to @tester or @reviewer with a red CI.
+10. **Rebase**: Before handing off to @tester or @reviewer, check if the branch is behind main. If so, `git rebase origin/main` and force-push with `--force-with-lease`. Re-verify CI after the rebase.
+11. **Review feedback**: After creating a PR, check for automated review comments (Copilot, CodeQL, linters). For each **PR review comment** (inline code comments): (a) fix the code or determine why no change is needed, (b) **post a reply on the comment thread** using `gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies -f body="**[@developer]** Fixed in <sha>: <description>"` explaining what was fixed and referencing the commit hash. For follow-up issues, use: `**[@developer]** Tracked as follow-up in #NNN: <description>`. Both the code fix AND the reply are required — an unreplied review comment is an unresolved conversation, even if the code is fixed. Note: check annotations (e.g., CodeQL findings) and issue-style PR comments do not support threaded replies — address those by fixing the code; no reply post is needed.
+12. **Cleanup**: After push, remove the worktree: `git worktree remove <path>`
 
 All developer PR comments and replies must be prefixed with `**[@developer]**`.
 


### PR DESCRIPTION
## Summary

Adds a mandatory worktree isolation requirement to the developer agent workflow. This prevents the cross-contamination bugs that caused PR #435 (214 scratch files committed) and PR #124 (model-comparison.md leaked into DB constraint PR).

## Root Cause

When the developer agent works directly in the main checkout (switching branches with `git checkout`), uncommitted or untracked files from other tasks bleed into new branches. This has caused multiple incidents of unintended files appearing in PRs.

## Fix

New step 1 in the Approach section:

- **Always** create a clean worktree for any branch work
- Path convention: `C:\Users\david\nse-wt-<name>` (public) / `C:\Users\david\nse-private-wt-<name>` (private)
- Remove worktree after push (new step 12)
- Never work directly in the main checkout

## Related

- PR #435 (closed — 214 scratch files committed due to `git add -A` in dirty checkout)
- PR #124 (model-comparison.md leaked from dirty working tree)
