### PR TITLE
chore: add .gitignore rules for scratch and temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,54 @@ framework-local/
 tools/framework-test/
 framework-test/
 test-data/
+
+# Scratch/diagnostic scripts (underscore-prefixed)
+_*.py
+_*.txt
+_*.sh
+_*.sql
+_*.json
+_*.log
+_*.pid
+
+# CI output files
+ci-*.json
+ci-*.txt
+checks*.json
+
+# Temp data / debug output
+output.json
+output.txt
+results.json
+status.json
+comments.json
+simple_output.txt
+extraction_output.txt
+
+# PR and diff data
+*.diff
+pr_*.json
+pr[0-9]*.json
+
+# Test output
+pytest-*.txt
+test_output.txt
+test_results.txt
+test_additions.txt
+
+# Temp helper scripts
+add_tests*.py
+fix_*.py
+find_*.py
+
+# Working/scoring directories (orchestrator, A/B, eval)
+score-*/
+framework-ab-*/
+framework-eval-*/
+
+# Misc temp files
+*.bak
+*.tmp
+error.log
+setup_pg.sh
+*.task-prompt.md


### PR DESCRIPTION
## Summary

Adds `.gitignore` rules for the ~200 scratch/temp files that accumulate in the repo root during development. These are the files accidentally committed in PR #435.

## Patterns Added

- Underscore-prefixed scratch: `_*.py`, `_*.txt`, `_*.sh`, `_*.sql`, `_*.json`, `_*.log`, `_*.pid`
- CI output: `ci-*.json`, `ci-*.txt`, `checks*.json`
- Temp data: `output.json`, `results.json`, `status.json`, `comments.json`
- PR/diff data: `*.diff`, `pr_*.json`, `pr[0-9]*.json`
- Test output: `pytest-*.txt`, `test_output.txt`, `test_results.txt`
- Helper scripts: `add_tests*.py`, `fix_*.py`, `find_*.py`
- Working dirs: `score-*/`, `framework-ab-*/`, `framework-eval-*/`
- Misc: `*.bak`, `*.tmp`, `error.log`, `setup_pg.sh`

## Prevention

Defense in depth: even if the developer agent violates the `git add` constraint (PR #437) or worktree requirement (PR #438), these files won't be staged.

## Related

- PR #435 (214 scratch files committed)
- PR #437 (`git add .` safeguard)
- PR #438 (worktree isolation)
