### PR TITLE
feat: add coreference resolution examples to entity-discovery template

### DIFF
--- a/docs/dedup-improvement-design.md
+++ b/docs/dedup-improvement-design.md
@@ -26,6 +26,13 @@
   - Descriptor shifts: "the hooded figure" → "Zara" (identity revealed)
 - **Why**: The model produces duplicates when surface forms change between turns; explicit examples in the template teach it to use `existing_id` instead of creating new entries
 - **Expected impact**: 20-40% fewer duplicate discoveries at source
+- **Status**: ✅ Implemented in PR #443. Six coreference patterns are now documented in the template's rules section:
+  - Title/rank changes (e.g. "the guard" → "Captain Harland")
+  - Identity reveals (e.g. "the hooded figure" → "Zara")
+  - Location aliases (e.g. "the tavern" → "The Rusty Nail" → "the inn")
+  - Group vs. subset (e.g. "the kobolds" faction → "three kobold scouts")
+  - Shortened names (e.g. "the elder shaman" → "the elder" → "the shaman")
+  - Definite descriptions referring to a previously catalogued place
 
 ### 3. Reduce Periodic Dedup Interval (50 → 25 turns)
 

--- a/docs/semantic-extraction-design.md
+++ b/docs/semantic-extraction-design.md
@@ -496,6 +496,19 @@ The agent returns:
 
 The Entity Detail Extractor then adds "The Shaman" as an alias and optionally proposes renaming the display `name` field to "The Shaman" (the script layer handles renaming while preserving the stable `id`).
 
+The discovery template in `templates/extraction/entity-discovery.md` provides explicit coreference guidance covering the most common RPG surface-form variation patterns:
+
+| Pattern | Example |
+|---|---|
+| Title/rank change | "the guard" in turn 5 → "Captain Harland" in turn 12 |
+| Identity reveal | "the hooded figure" → "Zara" once unmasked |
+| Location alias | "the tavern" → "The Rusty Nail" → "the inn" |
+| Group vs. subset | "the kobolds" (faction) → "three kobold scouts" |
+| Shortened name | "the elder shaman" → "the elder" → "the shaman" |
+| Definite description | "the cave" in turn 20 referring to the cave from turn 15 |
+
+In all cases the agent sets `is_new: false` and supplies the `existing_id` from the known-entities list instead of creating a duplicate entry. This guidance was added in PR #443 as part of the deduplication improvement plan (see `docs/dedup-improvement-design.md`).
+
 ---
 
 ## 8. Module Structure

--- a/templates/extraction/entity-discovery.md
+++ b/templates/extraction/entity-discovery.md
@@ -82,7 +82,7 @@ Rules:
 - Coreference: match mentions to known entities by name, alias, role, or ID stem. Set is_new=false with existing_id.
 - **Coreference examples** — common RPG patterns where the SAME entity appears with different surface forms across turns. In each case, use existing_id to match:
   - Title/rank changes: "the guard" in turn 5 → "Captain Harland" in turn 12 = same person. Use existing_id.
-  - Identity reveals: "the hooded figure" → "Zara" when identity is revealed = same character. Use existing_id; update description with revealed name.
+  - Identity reveals: "the hooded figure" → "Zara" when identity is revealed = same character. Use existing_id only; the entity-detail phase updates the catalog name/identity.
   - Location aliases: "the tavern" → "The Rusty Nail" → "the inn" = same place. Use existing_id of the first occurrence.
   - Group vs. subset: "the kobolds" (faction) → "three kobold scouts" (subset) = reference to existing faction, NOT a new entity.
   - Shortened names: "the elder shaman" → "the elder" → "the shaman" in later turns = same character. Use existing_id.

--- a/templates/extraction/entity-discovery.md
+++ b/templates/extraction/entity-discovery.md
@@ -80,6 +80,13 @@ Rules:
 - Omit generic background elements unless they act as a faction.
 - Confidence below 0.5 = too vague to catalog.
 - Coreference: match mentions to known entities by name, alias, role, or ID stem. Set is_new=false with existing_id.
+- **Coreference examples** — common RPG patterns where the SAME entity appears with different surface forms across turns. In each case, use existing_id to match:
+  - Title/rank changes: "the guard" in turn 5 → "Captain Harland" in turn 12 = same person. Use existing_id.
+  - Identity reveals: "the hooded figure" → "Zara" when identity is revealed = same character. Use existing_id; update description with revealed name.
+  - Location aliases: "the tavern" → "The Rusty Nail" → "the inn" = same place. Use existing_id of the first occurrence.
+  - Group vs. subset: "the kobolds" (faction) → "three kobold scouts" (subset) = reference to existing faction, NOT a new entity.
+  - Shortened names: "the elder shaman" → "the elder" → "the shaman" in later turns = same character. Use existing_id.
+  - Definite descriptions: "the cave" in turn 20 likely refers to the same cave from turn 15 if context hasn't shifted location. Check known entities before creating a new one.
 - NEVER create entities for pronouns (he/she/they/it). Resolve to known entity or skip.
 - Items: match shorter names to known items (e.g., "the spear" → existing "crude wood-hafted spear").
 - proposed_id and existing_id are mutually exclusive.

--- a/tests/test_template_content.py
+++ b/tests/test_template_content.py
@@ -28,3 +28,22 @@ class TestEntityDiscoveryTemplate:
     def test_compound_term_warning(self):
         content = _load_template("entity-discovery.md")
         assert "compound term" in content.lower() or "SUBSTRING" in content
+
+    def test_coreference_examples_present(self):
+        """Coreference examples must stay in the template to guide dedup behaviour."""
+        content = _load_template("entity-discovery.md")
+        assert "Coreference examples" in content, (
+            "entity-discovery.md is missing the 'Coreference examples' section"
+        )
+
+    def test_coreference_identity_reveal_example(self):
+        content = _load_template("entity-discovery.md")
+        assert "Identity reveals" in content or "identity reveal" in content.lower(), (
+            "entity-discovery.md is missing the identity-reveal coreference example"
+        )
+
+    def test_coreference_location_alias_example(self):
+        content = _load_template("entity-discovery.md")
+        assert "Location aliases" in content or "location alias" in content.lower(), (
+            "entity-discovery.md is missing the location-alias coreference example"
+        )


### PR DESCRIPTION
﻿## Summary

Adds 6 concrete coreference resolution examples to `templates/extraction/entity-discovery.md` to teach the LLM to match entity mentions across turns instead of creating duplicates.

## Changes

- Added **Coreference examples** section after the existing one-line coreference rule
- 6 RPG-specific patterns: title changes, identity reveals, location aliases, group subsets, shortened names, definite descriptions

## A/B Test Results (100 turns, temp=0, Qwen3.6-35B-A3B)

| Metric | Baseline | With Examples | Delta |
|--------|----------|---------------|-------|
| Characters | 14 | 13 | -1 (removed vague duplicates) |
| Locations | 6 | 5 | -1 (consolidated aliases) |
| Items | 6 | 8 | +2 (more specific names) |
| Factions | 2 | 2 | 0 |
| Events | 45 | 51 | +6 (+13%) |
| Dedup candidates | 2 | 1 | -1 (cleaner) |
| False merges | 0 | 0 | 0 |
| Runtime | 1h31m | 1h08m | -23min |

Key wins:
- Fixed the `char-older-figure` / `char-elder` dedup failure (the #1 quality gap from the 30-turn eval)
- Removed vague entities (`special-someone`, `unknown-captors`) that shouldn't be cataloged
- Improved item/location naming specificity

Ref #337
