### PR TITLE
fix: add recency and relationship survival signals to stale-item sweep

### DIFF
--- a/tests/test_pipeline_v3.py
+++ b/tests/test_pipeline_v3.py
@@ -465,32 +465,76 @@ class TestSweepStaleItems:
 
         catalogs = self._base_catalogs()
         # Add a stale item (only 1 event ref, seen at turn-005, current is turn-040)
+        # No other entity references it via relationships, so it is not protected.
         catalogs["items.json"].append(
             {"id": "item-stale-thing", "name": "Stale Thing", "type": "item",
              "first_seen_turn": "turn-005", "relationships": []}
         )
-        # Add a character that references the stale item
+        # Add a character (no relationship to stale item yet — will be added
+        # after sweep to simulate a dangling reference left by external edits)
         catalogs["characters.json"].append(
             {"id": "char-hero", "name": "Hero", "type": "character",
-             "first_seen_turn": "turn-001", "relationships": [
-                 {"target_id": "item-stale-thing", "type": "social", "description": "owns"}
-             ]}
+             "first_seen_turn": "turn-001", "relationships": []}
         )
         events = [
             {"id": "evt-1", "related_entities": ["item-stale-thing"], "turn_id": "turn-005"},
         ]
 
-        # Step 1: sweep removes the stale item
+        # Step 1: sweep removes the stale item (not relationship-protected)
         removed = _sweep_stale_items(catalogs, events, "turn-040", min_event_refs=2, staleness_turns=25)
         assert "item-stale-thing" in removed
 
-        # Step 2: cleanup catches the orphaned relationship
+        # Step 2: simulate a dangling relationship (e.g. from a prior merge)
+        hero = [e for e in catalogs["characters.json"] if e["id"] == "char-hero"][0]
+        hero["relationships"].append(
+            {"target_id": "item-stale-thing", "type": "social", "description": "owns"}
+        )
+
+        # Step 3: cleanup catches the orphaned relationship
         dangling = cleanup_dangling_relationships(catalogs)
         assert "char-hero" in dangling
         assert "item-stale-thing" in dangling["char-hero"]
         # The relationship should now be gone
-        hero = [e for e in catalogs["characters.json"] if e["id"] == "char-hero"][0]
         assert len(hero["relationships"]) == 0
+
+    def test_sweep_protects_relationship_targets(self):
+        """Items referenced by other entities' relationships survive the sweep."""
+        catalogs = self._base_catalogs()
+        # Add an item that would otherwise be stale
+        catalogs["items.json"].append(
+            {"id": "item-protected", "name": "Protected Thing", "type": "item",
+             "first_seen_turn": "turn-005", "relationships": []}
+        )
+        # A character references it — this protects it
+        catalogs["characters.json"].append(
+            {"id": "char-hero", "name": "Hero", "type": "character",
+             "first_seen_turn": "turn-001", "relationships": [
+                 {"target_id": "item-protected", "type": "social", "description": "owns"}
+             ]}
+        )
+        events = [
+            {"id": "evt-1", "related_entities": ["item-protected"], "turn_id": "turn-005"},
+        ]
+
+        removed = _sweep_stale_items(catalogs, events, "turn-040", min_event_refs=2, staleness_turns=25)
+        assert "item-protected" not in removed
+        assert any(e["id"] == "item-protected" for e in catalogs["items.json"])
+
+    def test_sweep_recency_protection(self):
+        """Items with recent last_updated_turn survive even if first_seen is old."""
+        catalogs = self._base_catalogs()
+        catalogs["items.json"].append(
+            {"id": "item-refreshed", "name": "Refreshed Thing", "type": "item",
+             "first_seen_turn": "turn-005", "last_updated_turn": "turn-035",
+             "relationships": []}
+        )
+        events = [
+            {"id": "evt-1", "related_entities": ["item-refreshed"], "turn_id": "turn-005"},
+        ]
+
+        removed = _sweep_stale_items(catalogs, events, "turn-040", min_event_refs=2, staleness_turns=25)
+        assert "item-refreshed" not in removed
+        assert any(e["id"] == "item-refreshed" for e in catalogs["items.json"])
 
 
 # ---------------------------------------------------------------------------

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -4060,9 +4060,10 @@ def _sweep_stale_items(
         # Item is stale — remove it
         name = entity.get("name", eid)
         first_turn = entity.get("first_seen_turn", "?")
+        last_turn = entity.get("last_updated_turn", first_turn)
         print(
             f"  [STALE-ITEM] Removing {eid} ({name}): "
-            f"{ref_count} event refs, first_seen {first_turn}",
+            f"{ref_count} event refs, first_seen {first_turn}, last_updated {last_turn}",
             file=sys.stderr,
         )
         removed_ids.append(eid)

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -3994,13 +3994,14 @@ def _sweep_stale_items(
     min_event_refs: int = _STALE_ITEM_MIN_REFS,
     staleness_turns: int = _STALE_ITEM_WINDOW,
 ) -> list[str]:
-    """Remove items with fewer than *min_event_refs* event references after a staleness window.
+    """Remove items that lack sufficient evidence of narrative relevance.
 
-    An item is considered stale if:
-    1. It has fewer than min_event_refs event references (in related_entities across all events)
-    2. At least staleness_turns have passed since its first_seen_turn
-    3. It's of type "item" (don't touch characters, locations, factions)
+    An item survives (is NOT removed) if ANY of these conditions hold:
+    1. It is recent — fewer than staleness_turns since first_seen_turn or last_updated_turn
+    2. It has at least min_event_refs event references (in related_entities across all events)
+    3. It is a relationship target — referenced by another entity's relationships array
 
+    Only items in items.json are swept (characters, locations, factions are exempt).
     Returns list of removed entity IDs.
     """
     current_num = _parse_turn_number(current_turn)
@@ -4018,6 +4019,15 @@ def _sweep_stale_items(
                 eid = _normalize_entity_id(eid, known_ids)
                 ref_counts[eid] = ref_counts.get(eid, 0) + 1
 
+    # Collect entity IDs that are targets of any relationship
+    relationship_targets: set[str] = set()
+    for catalog_entries in catalogs.values():
+        for entity in catalog_entries:
+            for rel in entity.get("relationships", []):
+                target = rel.get("target_id", "")
+                if target:
+                    relationship_targets.add(target)
+
     items = catalogs.get("items.json", [])
     removed_ids: list[str] = []
     kept: list[dict] = []
@@ -4025,23 +4035,35 @@ def _sweep_stale_items(
     for entity in items:
         eid = entity.get("id", "")
         first_seen = _parse_turn_number(entity.get("first_seen_turn"))
+        last_updated = _parse_turn_number(entity.get("last_updated_turn")) or first_seen
         ref_count = ref_counts.get(eid, 0)
 
-        if (
-            first_seen is not None
-            and (current_num - first_seen) >= staleness_turns
-            and ref_count < min_event_refs
-        ):
-            name = entity.get("name", eid)
-            first_turn = entity.get("first_seen_turn", "?")
-            print(
-                f"  [STALE-ITEM] Removing {eid} ({name}): "
-                f"{ref_count} event refs, first_seen {first_turn}",
-                file=sys.stderr,
-            )
-            removed_ids.append(eid)
-        else:
+        # Survival signal 1: too new (either first seen or last updated recently)
+        age = current_num - first_seen if first_seen is not None else 0
+        recency = current_num - last_updated if last_updated is not None else age
+        if age < staleness_turns or recency < staleness_turns:
             kept.append(entity)
+            continue
+
+        # Survival signal 2: has enough event references
+        if ref_count >= min_event_refs:
+            kept.append(entity)
+            continue
+
+        # Survival signal 3: referenced by other entities' relationships
+        if eid in relationship_targets:
+            kept.append(entity)
+            continue
+
+        # Item is stale — remove it
+        name = entity.get("name", eid)
+        first_turn = entity.get("first_seen_turn", "?")
+        print(
+            f"  [STALE-ITEM] Removing {eid} ({name}): "
+            f"{ref_count} event refs, first_seen {first_turn}",
+            file=sys.stderr,
+        )
+        removed_ids.append(eid)
 
     if removed_ids:
         catalogs["items.json"] = kept

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -4026,7 +4026,7 @@ def _sweep_stale_items(
             for rel in entity.get("relationships", []):
                 target = rel.get("target_id", "")
                 if target:
-                    relationship_targets.add(target)
+                    relationship_targets.add(_normalize_entity_id(target, known_ids))
 
     items = catalogs.get("items.json", [])
     removed_ids: list[str] = []
@@ -4035,7 +4035,9 @@ def _sweep_stale_items(
     for entity in items:
         eid = entity.get("id", "")
         first_seen = _parse_turn_number(entity.get("first_seen_turn"))
-        last_updated = _parse_turn_number(entity.get("last_updated_turn")) or first_seen
+        last_updated = _parse_turn_number(entity.get("last_updated_turn"))
+        if last_updated is None:
+            last_updated = first_seen
         ref_count = ref_counts.get(eid, 0)
 
         # Survival signal 1: too new (either first seen or last updated recently)


### PR DESCRIPTION
﻿## Summary

Fix over-aggressive stale-item sweep that removed 58% of items (11/19) in a 100-turn extraction, including narratively significant items referenced just 23 turns before the end.

## Changes

- Add recency protection: items survive if `last_updated_turn` is within the staleness window (not just `first_seen_turn`)
- Add relationship cross-reference protection: items survive if any other entity references them as a relationship `target_id`
- Update docstring to survival-condition framing
- Add two targeted unit tests for the new survival signals

## Validation

- 1781 tests pass (1 warning, no regressions)
- Bug reproduced in A/B eval: main branch 100-turn extraction on Concord session with Qwen3.6-35B removed 11/19 items
- B test planned post-merge to validate fix reduces false removals

Closes #441
