### PR TITLE
fix: correct links and temp-conditional runs in A/B test label comment

### DIFF
--- a/.github/workflows/label-ab-test.yml
+++ b/.github/workflows/label-ab-test.yml
@@ -52,6 +52,6 @@ jobs:
             if (!botComment) {
               await github.rest.issues.createComment({
                 owner, repo, issue_number: pr_number,
-                body: `## ⚠️ A/B Test Required\n\nThis PR modifies extraction behavior (files in \`templates/extraction/\` or extraction tools). Per [A/B test standard](docs/ab-testing.md), extraction quality changes require empirical validation before merge.\n\n**Required before merge:**\n- [ ] A/B test results posted as a PR comment\n- [ ] ≥3 paired runs with both variants\n- [ ] Entity count comparison with acceptable variance\n\nSee the [A/B testing guide](docs/ab-testing.md) for details.`
+                body: `## ⚠️ A/B Test Required\n\nThis PR modifies extraction behavior (files in \`templates/extraction/\` or extraction tools). Per the [A/B test standard](https://github.com/daviburg/narrative-state-engine/blob/main/docs/ab-test-standard.md), extraction quality changes require empirical validation before merge.\n\n**Required before merge:**\n- [ ] A/B test results posted as a PR comment\n- [ ] ≥3 paired runs per variant (only if temperature > 0; 1 run suffices at temp 0)\n- [ ] Entity count comparison with acceptable variance\n\nSee the [A/B test checklist](https://github.com/daviburg/narrative-state-engine/blob/main/docs/ab-test-checklist.md) for details.`
               });
             }

--- a/.github/workflows/label-ab-test.yml
+++ b/.github/workflows/label-ab-test.yml
@@ -50,7 +50,7 @@ jobs:
             );
 
             if (!botComment) {
-              const repoUrl = `https://github.com/${owner}/${repo}/blob/main`;
+              const repoUrl = `${context.payload.repository.html_url}/blob/${context.payload.repository.default_branch}`;
               await github.rest.issues.createComment({
                 owner, repo, issue_number: pr_number,
                 body: `## ⚠️ A/B Test Required\n\nThis PR modifies extraction behavior (files in \`templates/extraction/\` or extraction tools). Per the [A/B test standard](${repoUrl}/docs/ab-test-standard.md), extraction quality changes require empirical validation before merge.\n\n**Required before merge:**\n- [ ] A/B test results posted as a PR comment\n- [ ] ≥3 paired runs per variant (only if temperature > 0; 1 run suffices at temp 0)\n- [ ] Entity count comparison with acceptable variance\n\nSee the [A/B test checklist](${repoUrl}/docs/ab-test-checklist.md) for details.`

--- a/.github/workflows/label-ab-test.yml
+++ b/.github/workflows/label-ab-test.yml
@@ -50,8 +50,9 @@ jobs:
             );
 
             if (!botComment) {
+              const repoUrl = `https://github.com/${owner}/${repo}/blob/main`;
               await github.rest.issues.createComment({
                 owner, repo, issue_number: pr_number,
-                body: `## ⚠️ A/B Test Required\n\nThis PR modifies extraction behavior (files in \`templates/extraction/\` or extraction tools). Per the [A/B test standard](https://github.com/daviburg/narrative-state-engine/blob/main/docs/ab-test-standard.md), extraction quality changes require empirical validation before merge.\n\n**Required before merge:**\n- [ ] A/B test results posted as a PR comment\n- [ ] ≥3 paired runs per variant (only if temperature > 0; 1 run suffices at temp 0)\n- [ ] Entity count comparison with acceptable variance\n\nSee the [A/B test checklist](https://github.com/daviburg/narrative-state-engine/blob/main/docs/ab-test-checklist.md) for details.`
+                body: `## ⚠️ A/B Test Required\n\nThis PR modifies extraction behavior (files in \`templates/extraction/\` or extraction tools). Per the [A/B test standard](${repoUrl}/docs/ab-test-standard.md), extraction quality changes require empirical validation before merge.\n\n**Required before merge:**\n- [ ] A/B test results posted as a PR comment\n- [ ] ≥3 paired runs per variant (only if temperature > 0; 1 run suffices at temp 0)\n- [ ] Entity count comparison with acceptable variance\n\nSee the [A/B test checklist](${repoUrl}/docs/ab-test-checklist.md) for details.`
               });
             }


### PR DESCRIPTION
## Summary

Fix the A/B Test Required bot comment posted by the label-ab-test workflow.

### Issues fixed:
1. **Broken links** — referenced `docs/ab-testing.md` which doesn't exist. Updated to full GitHub URLs pointing to `docs/ab-test-standard.md` and `docs/ab-test-checklist.md`
2. **Unconditional ≥3 runs requirement** — per the A/B test standard (section 1.2), multiple runs are needed due to temperature-induced non-determinism. At temp 0, results are deterministic and 1 run suffices. Updated the checklist item to reflect this.
