### PR TITLE
feat: add entity-retention diff to A/B test standard

### DIFF
--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -147,7 +147,7 @@ python tools/entity_retention_diff.py -a framework-ab-a-run1 -b framework-ab-b-r
 | Single type count **gain** | Δ ≤ 15% gain | 15–25% gain | > 25% gain (hallucination signal) |
 | Relationship count **loss** | Δ ≤ 10% loss | 10–20% loss | > 20% loss |
 | Relationship count **gain** | Δ ≤ 15% gain | 15–25% gain | > 25% gain (hallucination signal) |
-| Entity **retention** | 0 unexplained removed IDs | removed IDs all explained as dedup/consolidation | unexplained removed IDs |
+| Entity **retention** | no removed IDs | removed IDs all explained as dedup/consolidation | unexplained removed IDs |
 | Schema validity | 100% | — | < 100% |
 | Performance regression | Δ ≤ +10% time | +10–20% time | > +20% time |
 | Performance improvement | Always PASS | — | — |

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -111,7 +111,33 @@ Report:
 - Schema violations (count and list)
 - 100% validity is required for PASS.
 
-### 3.4 Quantitative Regression Thresholds
+### 3.4 Entity Retention Diff
+
+Aggregate entity counts (§3.1) can **mask deletion bugs**: a variant that drops 5 distinct entities while adding 5 new ones shows a net delta of 0, hiding the loss. This is exactly how PR #393 (#394, 27% loss) and the stale-sweep over-removal (#441) went undetected. A per-entity retention diff compares entity **IDs** between variant A and variant B so removals are surfaced explicitly.
+
+Run `tools/entity_retention_diff.py`, comparing one representative variant-A run against one representative variant-B run (use the same run number for both, e.g. `run1`):
+
+```bash
+python tools/entity_retention_diff.py \
+    --variant-a framework-ab-a-run1 \
+    --variant-b framework-ab-b-run1
+```
+
+The tool accepts either a framework directory (containing a `catalogs/` subdir) or a `catalogs/` directory directly. For each entity type (characters, locations, items, factions, events) it reports:
+
+- **retained** — IDs present in both A and B (A ∩ B)
+- **removed** — IDs present in A but missing from B (A − B)
+- **added** — IDs present in B but missing from A (B − A)
+
+It emits a Markdown summary table (default) or JSON (`--json`), and **flags** the run when the total number of removed IDs exceeds the configurable `--threshold` (default `0`, i.e. any removal flags). Pass `--strict` to make the tool exit non-zero when flagged (useful for CI gating):
+
+```bash
+python tools/entity_retention_diff.py -a framework-ab-a-run1 -b framework-ab-b-run1 --threshold 0 --strict
+```
+
+**This diff is a required output** — include the Markdown table in the PR comment (see §5.1) and list any removed entity IDs. Removed IDs are not automatically a BLOCK (B may legitimately consolidate duplicates), but each removed ID MUST be explained in the PR comment.
+
+### 3.5 Quantitative Regression Thresholds
 
 | Metric | PASS | WARN | BLOCK |
 |---|---|---|---|
@@ -121,6 +147,7 @@ Report:
 | Single type count **gain** | Δ ≤ 15% gain | 15–25% gain | > 25% gain (hallucination signal) |
 | Relationship count **loss** | Δ ≤ 10% loss | 10–20% loss | > 20% loss |
 | Relationship count **gain** | Δ ≤ 15% gain | 15–25% gain | > 25% gain (hallucination signal) |
+| Entity **retention** | 0 unexplained removed IDs | removed IDs all explained as dedup/consolidation | unexplained removed IDs |
 | Schema validity | 100% | — | < 100% |
 | Performance regression | Δ ≤ +10% time | +10–20% time | > +20% time |
 | Performance improvement | Always PASS | — | — |
@@ -293,6 +320,21 @@ Every template-change PR MUST include this section as a PR comment:
 | Events | | | | |
 | **Total** | | | | |
 
+### Entity Retention Diff
+
+(Output of `tools/entity_retention_diff.py` for one representative A vs B run pair.)
+
+| Type | A | B | Retained | Removed | Added | Net |
+|---|---|---|---|---|---|---|
+| characters | | | | | | |
+| locations | | | | | | |
+| items | | | | | | |
+| factions | | | | | | |
+| events | | | | | | |
+| **Total** | | | | | | |
+
+Removed entity IDs (explain each): [list, or "none"]
+
 ### Relationships
 
 | Metric | A mean ± σ | B mean ± σ | Δ% | Status |
@@ -329,6 +371,7 @@ Every template-change PR MUST include this section as a PR comment:
 
 - [ ] No BLOCK on any metric
 - [ ] All WARN items have documented justification
+- [ ] Every removed entity ID in the retention diff is explained (dedup/consolidation) or treated as a BLOCK
 - [ ] Ground truth validation passes for B (full-session runs only; skip for `--max-turns 30`)
 ````
 
@@ -340,6 +383,7 @@ The PR is **mergeable** when:
 2. All WARN statuses have written justification explaining why the regression is acceptable.
 3. Ground truth validation (`validate_extraction.py`) exits 0 for variant B (full-session runs only).
 4. Schema validation (`validate.py --framework <dir>`) reports 0 violations for variant B.
+5. Every removed entity ID in the retention diff (§3.4) is explained as intentional dedup/consolidation; unexplained removals are a BLOCK.
 
 ---
 

--- a/tests/test_entity_retention_diff.py
+++ b/tests/test_entity_retention_diff.py
@@ -131,8 +131,8 @@ class TestComputeRetentionDiff:
         report = compute_retention_diff(str(dir_a), str(dir_b), removal_threshold=1)
         # one removal, threshold of 1 -> not flagged (removed > threshold is False)
         assert report["flagged"] is False
-        # flagged_types still records per-type removals regardless of threshold
-        assert report["flagged_types"] == ["characters"]
+        # flagged_types is empty when the flag is not raised
+        assert report["flagged_types"] == []
 
     def test_no_flag_when_only_added(self, tmp_path):
         dir_a = tmp_path / "a"

--- a/tests/test_entity_retention_diff.py
+++ b/tests/test_entity_retention_diff.py
@@ -1,0 +1,263 @@
+"""Tests for entity_retention_diff.py — per-entity retention diff between runs."""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from entity_retention_diff import (
+    compute_retention_diff,
+    diff_id_sets,
+    format_markdown,
+    main,
+)
+
+_TYPE_DIRS = {
+    "char-": "characters",
+    "loc-": "locations",
+    "faction-": "factions",
+    "item-": "items",
+    "creature-": "characters",
+    "concept-": "items",
+}
+
+
+def _write_catalog(base_dir, entity_ids, event_ids=None):
+    """Create a V2 catalogs directory populated with the given entity IDs.
+
+    entity_ids: iterable of entity IDs (prefix determines the type directory).
+    event_ids: optional iterable of event IDs written to events.json.
+    """
+    catalog_dir = os.path.join(base_dir, "catalogs")
+    for entity_id in entity_ids:
+        prefix = next((p for p in _TYPE_DIRS if entity_id.startswith(p)), "char-")
+        dirname = _TYPE_DIRS[prefix]
+        type_dir = os.path.join(catalog_dir, dirname)
+        os.makedirs(type_dir, exist_ok=True)
+        entity = {
+            "id": entity_id,
+            "name": entity_id,
+            "type": dirname[:-1] if dirname.endswith("s") else dirname,
+            "identity": f"{entity_id} identity",
+            "first_seen_turn": "turn-001",
+        }
+        with open(os.path.join(type_dir, f"{entity_id}.json"), "w", encoding="utf-8") as f:
+            json.dump(entity, f)
+
+    if event_ids is not None:
+        os.makedirs(catalog_dir, exist_ok=True)
+        events = [{"id": eid, "summary": eid} for eid in event_ids]
+        with open(os.path.join(catalog_dir, "events.json"), "w", encoding="utf-8") as f:
+            json.dump(events, f)
+
+    return catalog_dir
+
+
+class TestDiffIdSets:
+    def test_retained_removed_added(self):
+        result = diff_id_sets({"a", "b", "c"}, {"b", "c", "d"})
+        assert result["retained"] == ["b", "c"]
+        assert result["removed"] == ["a"]
+        assert result["added"] == ["d"]
+
+    def test_identical_sets(self):
+        result = diff_id_sets({"a", "b"}, {"a", "b"})
+        assert result["retained"] == ["a", "b"]
+        assert result["removed"] == []
+        assert result["added"] == []
+
+    def test_empty_sets(self):
+        result = diff_id_sets(set(), set())
+        assert result == {"retained": [], "removed": [], "added": []}
+
+    def test_results_are_sorted(self):
+        result = diff_id_sets({"c", "a", "b"}, set())
+        assert result["removed"] == ["a", "b", "c"]
+
+
+class TestComputeRetentionDiff:
+    def test_detects_retained_removed_added(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), ["char-alice", "char-bob", "loc-keep"])
+        # bob removed, carol added, keep retained
+        _write_catalog(str(dir_b), ["char-alice", "char-carol", "loc-keep"])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+
+        chars = report["by_type"]["characters"]
+        assert chars["retained"] == ["char-alice"]
+        assert chars["removed"] == ["char-bob"]
+        assert chars["added"] == ["char-carol"]
+
+        locs = report["by_type"]["locations"]
+        assert locs["retained"] == ["loc-keep"]
+        assert locs["removed"] == []
+        assert locs["added"] == []
+
+    def test_totals(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), ["char-alice", "char-bob"])
+        _write_catalog(str(dir_b), ["char-alice", "char-carol", "item-sword"])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        totals = report["totals"]
+        assert totals["a"] == 2
+        assert totals["b"] == 3
+        assert totals["retained"] == 1
+        assert totals["removed"] == 1
+        assert totals["added"] == 2
+        assert totals["net_change"] == 1
+
+    def test_flag_on_removal_default_threshold(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), ["char-alice", "char-bob"])
+        _write_catalog(str(dir_b), ["char-alice"])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        assert report["flagged"] is True
+        assert report["flagged_types"] == ["characters"]
+        assert report["removal_threshold"] == 0
+
+    def test_threshold_suppresses_flag(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), ["char-alice", "char-bob"])
+        _write_catalog(str(dir_b), ["char-alice"])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b), removal_threshold=1)
+        # one removal, threshold of 1 -> not flagged (removed > threshold is False)
+        assert report["flagged"] is False
+        # flagged_types still records per-type removals regardless of threshold
+        assert report["flagged_types"] == ["characters"]
+
+    def test_no_flag_when_only_added(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), ["char-alice"])
+        _write_catalog(str(dir_b), ["char-alice", "char-bob"])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        assert report["flagged"] is False
+        assert report["flagged_types"] == []
+
+    def test_empty_catalogs(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        os.makedirs(dir_a / "catalogs", exist_ok=True)
+        os.makedirs(dir_b / "catalogs", exist_ok=True)
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        assert report["totals"]["a"] == 0
+        assert report["totals"]["b"] == 0
+        assert report["flagged"] is False
+        for entity_type in ("characters", "locations", "items", "factions", "events"):
+            assert report["by_type"][entity_type]["removed"] == []
+
+    def test_missing_type_files(self, tmp_path):
+        # A has characters only; B has locations only (no characters dir).
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), ["char-alice"])
+        _write_catalog(str(dir_b), ["loc-keep"])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        assert report["by_type"]["characters"]["removed"] == ["char-alice"]
+        assert report["by_type"]["locations"]["added"] == ["loc-keep"]
+
+    def test_events_diff(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), [], event_ids=["event-001", "event-002"])
+        _write_catalog(str(dir_b), [], event_ids=["event-001", "event-003"])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        events = report["by_type"]["events"]
+        assert events["retained"] == ["event-001"]
+        assert events["removed"] == ["event-002"]
+        assert events["added"] == ["event-003"]
+
+    def test_accepts_catalogs_dir_directly(self, tmp_path):
+        # Pass the catalogs/ directory itself rather than the framework dir.
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        catalogs_a = _write_catalog(str(dir_a), ["char-alice"])
+        catalogs_b = _write_catalog(str(dir_b), ["char-alice"])
+
+        report = compute_retention_diff(catalogs_a, catalogs_b)
+        assert report["totals"]["retained"] == 1
+
+
+class TestFormatMarkdown:
+    def test_flagged_output_lists_removed_ids(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), ["char-alice", "char-bob"])
+        _write_catalog(str(dir_b), ["char-alice"])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        md = format_markdown(report)
+        assert "FLAGGED" in md
+        assert "char-bob" in md
+        assert "| **Total** |" in md
+
+    def test_clean_output(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), ["char-alice"])
+        _write_catalog(str(dir_b), ["char-alice"])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        md = format_markdown(report)
+        assert "No retention regression" in md
+
+
+class TestMainCli:
+    def test_strict_flagged_exits_1(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), ["char-alice", "char-bob"])
+        _write_catalog(str(dir_b), ["char-alice"])
+
+        rc = main(["-a", str(dir_a), "-b", str(dir_b), "--strict"])
+        assert rc == 1
+
+    def test_strict_clean_exits_0(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), ["char-alice"])
+        _write_catalog(str(dir_b), ["char-alice"])
+
+        rc = main(["-a", str(dir_a), "-b", str(dir_b), "--strict"])
+        assert rc == 0
+
+    def test_flagged_without_strict_exits_0(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), ["char-alice", "char-bob"])
+        _write_catalog(str(dir_b), ["char-alice"])
+
+        rc = main(["-a", str(dir_a), "-b", str(dir_b)])
+        assert rc == 0
+
+    def test_missing_dir_exits_2(self, tmp_path):
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_b), ["char-alice"])
+
+        rc = main(["-a", str(tmp_path / "nope"), "-b", str(dir_b)])
+        assert rc == 2
+
+    def test_json_output(self, tmp_path, capsys):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), ["char-alice"])
+        _write_catalog(str(dir_b), ["char-alice"])
+
+        rc = main(["-a", str(dir_a), "-b", str(dir_b), "--json"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["totals"]["retained"] == 1
+

--- a/tests/test_entity_retention_diff.py
+++ b/tests/test_entity_retention_diff.py
@@ -190,6 +190,27 @@ class TestComputeRetentionDiff:
         report = compute_retention_diff(catalogs_a, catalogs_b)
         assert report["totals"]["retained"] == 1
 
+    def test_negative_threshold_raises(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), ["char-alice"])
+        _write_catalog(str(dir_b), ["char-alice"])
+
+        import pytest
+        with pytest.raises(ValueError, match="removal_threshold must be >= 0"):
+            compute_retention_diff(str(dir_a), str(dir_b), removal_threshold=-1)
+
+    def test_invalid_layout_raises(self, tmp_path):
+        # A directory that exists but has no catalogs/ subdir and is not named catalogs.
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+
+        import pytest
+        with pytest.raises(ValueError, match="Cannot resolve catalog directory"):
+            compute_retention_diff(str(dir_a), str(dir_b))
+
 
 class TestFormatMarkdown:
     def test_flagged_output_lists_removed_ids(self, tmp_path):

--- a/tests/test_entity_retention_diff.py
+++ b/tests/test_entity_retention_diff.py
@@ -171,14 +171,14 @@ class TestComputeRetentionDiff:
     def test_events_diff(self, tmp_path):
         dir_a = tmp_path / "a"
         dir_b = tmp_path / "b"
-        _write_catalog(str(dir_a), [], event_ids=["event-001", "event-002"])
-        _write_catalog(str(dir_b), [], event_ids=["event-001", "event-003"])
+        _write_catalog(str(dir_a), [], event_ids=["evt-001", "evt-002"])
+        _write_catalog(str(dir_b), [], event_ids=["evt-001", "evt-003"])
 
         report = compute_retention_diff(str(dir_a), str(dir_b))
         events = report["by_type"]["events"]
-        assert events["retained"] == ["event-001"]
-        assert events["removed"] == ["event-002"]
-        assert events["added"] == ["event-003"]
+        assert events["retained"] == ["evt-001"]
+        assert events["removed"] == ["evt-002"]
+        assert events["added"] == ["evt-003"]
 
     def test_accepts_catalogs_dir_directly(self, tmp_path):
         # Pass the catalogs/ directory itself rather than the framework dir.
@@ -213,6 +213,17 @@ class TestFormatMarkdown:
         report = compute_retention_diff(str(dir_a), str(dir_b))
         md = format_markdown(report)
         assert "No retention regression" in md
+
+    def test_within_threshold_lists_removed_ids(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_catalog(str(dir_a), ["char-alice", "char-bob"])
+        _write_catalog(str(dir_b), ["char-alice"])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b), removal_threshold=5)
+        md = format_markdown(report)
+        assert "No retention regression" in md
+        assert "char-bob" in md
 
 
 class TestMainCli:

--- a/tools/entity_retention_diff.py
+++ b/tools/entity_retention_diff.py
@@ -118,12 +118,18 @@ def compute_retention_diff(
         dir_a: Variant A directory (framework dir or catalogs dir).
         dir_b: Variant B directory (framework dir or catalogs dir).
         removal_threshold: Maximum number of total removed IDs tolerated before
-            the report is flagged. Defaults to 0 (any removal flags the run).
+            the report is flagged. Must be >= 0. Defaults to 0 (any removal
+            flags the run).
 
     Returns:
         A report dict with ``by_type``, ``totals``, ``removal_threshold``,
         ``flagged``, and ``flagged_types`` keys.
     """
+    if removal_threshold < 0:
+        raise ValueError(
+            f"removal_threshold must be >= 0, got {removal_threshold!r}"
+        )
+
     ids_a = _collect_ids(_resolve_catalog_dir(dir_a))
     ids_b = _collect_ids(_resolve_catalog_dir(dir_b))
 

--- a/tools/entity_retention_diff.py
+++ b/tools/entity_retention_diff.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""entity_retention_diff.py — Per-entity retention diff between two catalog dirs.
+
+Aggregate entity counts (used by the A/B test gate) can mask deletion bugs:
+a variant that drops 5 entities but adds 5 others shows a net delta of 0 while
+silently losing distinct entities. This tool compares entity IDs between two
+extraction outputs (variant A vs variant B) and reports, per entity type:
+
+  - retained: IDs present in both A and B (A ∩ B)
+  - removed:  IDs present in A but missing from B (A − B)
+  - added:    IDs present in B but missing from A (B − A)
+
+A run is *flagged* when the total number of removed IDs exceeds a configurable
+threshold, surfacing deletion regressions such as those seen in #394 (27% loss)
+and #441 (stale-sweep over-removal).
+
+Usage:
+    python tools/entity_retention_diff.py --variant-a DIR_A --variant-b DIR_B
+    python tools/entity_retention_diff.py -a DIR_A -b DIR_B --threshold 3 --json
+    python tools/entity_retention_diff.py -a DIR_A -b DIR_B --strict
+
+DIR may be either a framework directory (containing a ``catalogs/`` subdir) or
+a ``catalogs/`` directory itself; the layout is auto-detected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from catalog_merger import CATALOG_KEYS, load_catalogs, load_events
+
+# Friendly entity-type label for each canonical catalog key, plus events.
+# Order is the report's column/row order.
+_CATALOG_KEY_TO_TYPE = {
+    "characters.json": "characters",
+    "locations.json": "locations",
+    "items.json": "items",
+    "factions.json": "factions",
+}
+_EVENTS_TYPE = "events"
+ENTITY_TYPES = [_CATALOG_KEY_TO_TYPE[k] for k in CATALOG_KEYS] + [_EVENTS_TYPE]
+
+
+def _resolve_catalog_dir(path: str) -> str:
+    """Return the catalogs directory for a framework dir or catalogs dir.
+
+    If ``path`` contains a ``catalogs`` subdirectory, return that; otherwise
+    assume ``path`` is already the catalogs directory.
+    """
+    nested = os.path.join(path, "catalogs")
+    if os.path.isdir(nested):
+        return nested
+    return path
+
+
+def _collect_ids(catalog_dir: str) -> dict[str, set[str]]:
+    """Return a mapping of entity-type label -> set of entity IDs.
+
+    Reads per-entity catalog files (characters/locations/items/factions) and the
+    events array. Entities without an ``id`` field are skipped.
+    """
+    ids: dict[str, set[str]] = {t: set() for t in ENTITY_TYPES}
+
+    catalogs = load_catalogs(catalog_dir)
+    for key, type_label in _CATALOG_KEY_TO_TYPE.items():
+        for entity in catalogs.get(key, []):
+            entity_id = entity.get("id")
+            if entity_id:
+                ids[type_label].add(entity_id)
+
+    for event in load_events(catalog_dir):
+        if isinstance(event, dict):
+            event_id = event.get("id")
+            if event_id:
+                ids[_EVENTS_TYPE].add(event_id)
+
+    return ids
+
+
+def diff_id_sets(ids_a: set[str], ids_b: set[str]) -> dict[str, list[str]]:
+    """Compare two ID sets, returning sorted retained/removed/added lists.
+
+    - retained: present in both A and B
+    - removed:  present in A but not B
+    - added:    present in B but not A
+    """
+    return {
+        "retained": sorted(ids_a & ids_b),
+        "removed": sorted(ids_a - ids_b),
+        "added": sorted(ids_b - ids_a),
+    }
+
+
+def compute_retention_diff(
+    dir_a: str,
+    dir_b: str,
+    removal_threshold: int = 0,
+) -> dict:
+    """Compute the per-entity retention diff between two extraction outputs.
+
+    Args:
+        dir_a: Variant A directory (framework dir or catalogs dir).
+        dir_b: Variant B directory (framework dir or catalogs dir).
+        removal_threshold: Maximum number of total removed IDs tolerated before
+            the report is flagged. Defaults to 0 (any removal flags the run).
+
+    Returns:
+        A report dict with ``by_type``, ``totals``, ``removal_threshold``,
+        ``flagged``, and ``flagged_types`` keys.
+    """
+    ids_a = _collect_ids(_resolve_catalog_dir(dir_a))
+    ids_b = _collect_ids(_resolve_catalog_dir(dir_b))
+
+    by_type: dict[str, dict] = {}
+    flagged_types: list[str] = []
+    total_a = total_b = total_retained = total_removed = total_added = 0
+
+    for entity_type in ENTITY_TYPES:
+        a_set = ids_a[entity_type]
+        b_set = ids_b[entity_type]
+        diff = diff_id_sets(a_set, b_set)
+
+        a_count = len(a_set)
+        b_count = len(b_set)
+        removed = len(diff["removed"])
+        added = len(diff["added"])
+
+        by_type[entity_type] = {
+            "a_count": a_count,
+            "b_count": b_count,
+            "retained": diff["retained"],
+            "removed": diff["removed"],
+            "added": diff["added"],
+            "net_change": b_count - a_count,
+        }
+
+        if removed > 0:
+            flagged_types.append(entity_type)
+
+        total_a += a_count
+        total_b += b_count
+        total_retained += len(diff["retained"])
+        total_removed += removed
+        total_added += added
+
+    return {
+        "by_type": by_type,
+        "totals": {
+            "a": total_a,
+            "b": total_b,
+            "retained": total_retained,
+            "removed": total_removed,
+            "added": total_added,
+            "net_change": total_b - total_a,
+        },
+        "removal_threshold": removal_threshold,
+        "flagged": total_removed > removal_threshold,
+        "flagged_types": flagged_types,
+    }
+
+
+def format_markdown(report: dict) -> str:
+    """Render a retention-diff report as a Markdown summary table."""
+    lines = ["### Entity Retention Diff", ""]
+    lines.append("| Type | A | B | Retained | Removed | Added | Net |")
+    lines.append("|---|---|---|---|---|---|---|")
+    for entity_type in ENTITY_TYPES:
+        row = report["by_type"][entity_type]
+        lines.append(
+            f"| {entity_type} | {row['a_count']} | {row['b_count']} | "
+            f"{len(row['retained'])} | {len(row['removed'])} | "
+            f"{len(row['added'])} | {row['net_change']:+d} |"
+        )
+    totals = report["totals"]
+    lines.append(
+        f"| **Total** | {totals['a']} | {totals['b']} | {totals['retained']} | "
+        f"{totals['removed']} | {totals['added']} | {totals['net_change']:+d} |"
+    )
+    lines.append("")
+
+    if report["flagged"]:
+        lines.append(
+            f"**FLAGGED**: {totals['removed']} entity ID(s) removed "
+            f"(threshold {report['removal_threshold']}). "
+            f"Affected types: {', '.join(report['flagged_types'])}."
+        )
+        for entity_type in report["flagged_types"]:
+            removed = report["by_type"][entity_type]["removed"]
+            lines.append(f"- Removed {entity_type}: {', '.join(removed)}")
+    else:
+        lines.append(
+            f"No retention regression "
+            f"({totals['removed']} removed, threshold {report['removal_threshold']})."
+        )
+
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Per-entity retention diff between two catalog directories."
+    )
+    parser.add_argument(
+        "-a", "--variant-a", required=True,
+        help="Variant A directory (framework dir or catalogs dir).",
+    )
+    parser.add_argument(
+        "-b", "--variant-b", required=True,
+        help="Variant B directory (framework dir or catalogs dir).",
+    )
+    parser.add_argument(
+        "--threshold", type=int, default=0,
+        help="Max total removed IDs tolerated before flagging (default: 0).",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit the full report as JSON instead of a Markdown table.",
+    )
+    parser.add_argument(
+        "--strict", action="store_true",
+        help="Exit with code 1 when the report is flagged.",
+    )
+    args = parser.parse_args(argv)
+
+    for label, path in (("variant-a", args.variant_a), ("variant-b", args.variant_b)):
+        if not os.path.isdir(path):
+            print(f"ERROR: --{label} directory not found: {path}", file=sys.stderr)
+            return 2
+
+    report = compute_retention_diff(
+        args.variant_a, args.variant_b, removal_threshold=args.threshold
+    )
+
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(format_markdown(report))
+
+    if args.strict and report["flagged"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/entity_retention_diff.py
+++ b/tools/entity_retention_diff.py
@@ -54,18 +54,19 @@ def _resolve_catalog_dir(path: str) -> str:
     - A directory whose name is ``catalogs`` (i.e. already the catalogs dir).
 
     Raises:
-        ValueError: If ``path`` is neither a framework dir nor a catalogs dir,
-            to prevent silently producing an all-zero report for an invalid path.
+        ValueError: If ``path`` does not resolve to an existing catalogs
+            directory, to prevent silently producing an all-zero report for an
+            invalid or non-existent path.
     """
     nested = os.path.join(path, "catalogs")
     if os.path.isdir(nested):
         return nested
-    if os.path.basename(os.path.normpath(path)) == "catalogs":
+    if os.path.basename(os.path.normpath(path)) == "catalogs" and os.path.isdir(path):
         return path
     raise ValueError(
         f"Cannot resolve catalog directory from '{path}': "
-        "expected a framework directory containing a 'catalogs/' subdirectory, "
-        "or a directory named 'catalogs'."
+        "expected an existing framework directory containing a 'catalogs/' subdirectory, "
+        "or an existing directory named 'catalogs'."
     )
 
 

--- a/tools/entity_retention_diff.py
+++ b/tools/entity_retention_diff.py
@@ -32,10 +32,10 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from catalog_merger import CATALOG_KEYS, load_catalogs, load_events
+from catalog_merger import load_catalogs, load_events
 
 # Friendly entity-type label for each canonical catalog key, plus events.
-# Order is the report's column/row order.
+# Order matches the documented table order (docs/ab-test-standard.md §3.1/§3.4).
 _CATALOG_KEY_TO_TYPE = {
     "characters.json": "characters",
     "locations.json": "locations",
@@ -43,19 +43,30 @@ _CATALOG_KEY_TO_TYPE = {
     "factions.json": "factions",
 }
 _EVENTS_TYPE = "events"
-ENTITY_TYPES = [_CATALOG_KEY_TO_TYPE[k] for k in CATALOG_KEYS] + [_EVENTS_TYPE]
+ENTITY_TYPES = list(_CATALOG_KEY_TO_TYPE.values()) + [_EVENTS_TYPE]
 
 
 def _resolve_catalog_dir(path: str) -> str:
     """Return the catalogs directory for a framework dir or catalogs dir.
 
-    If ``path`` contains a ``catalogs`` subdirectory, return that; otherwise
-    assume ``path`` is already the catalogs directory.
+    Accepts:
+    - A framework directory that contains a ``catalogs/`` subdirectory.
+    - A directory whose name is ``catalogs`` (i.e. already the catalogs dir).
+
+    Raises:
+        ValueError: If ``path`` is neither a framework dir nor a catalogs dir,
+            to prevent silently producing an all-zero report for an invalid path.
     """
     nested = os.path.join(path, "catalogs")
     if os.path.isdir(nested):
         return nested
-    return path
+    if os.path.basename(os.path.normpath(path)) == "catalogs":
+        return path
+    raise ValueError(
+        f"Cannot resolve catalog directory from '{path}': "
+        "expected a framework directory containing a 'catalogs/' subdirectory, "
+        "or a directory named 'catalogs'."
+    )
 
 
 def _collect_ids(catalog_dir: str) -> dict[str, set[str]]:
@@ -232,9 +243,13 @@ def main(argv: list[str] | None = None) -> int:
             print(f"ERROR: --{label} directory not found: {path}", file=sys.stderr)
             return 2
 
-    report = compute_retention_diff(
-        args.variant_a, args.variant_b, removal_threshold=args.threshold
-    )
+    try:
+        report = compute_retention_diff(
+            args.variant_a, args.variant_b, removal_threshold=args.threshold
+        )
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
 
     if args.json:
         print(json.dumps(report, indent=2, ensure_ascii=False))

--- a/tools/entity_retention_diff.py
+++ b/tools/entity_retention_diff.py
@@ -135,7 +135,6 @@ def compute_retention_diff(
     ids_b = _collect_ids(_resolve_catalog_dir(dir_b))
 
     by_type: dict[str, dict] = {}
-    flagged_types: list[str] = []
     total_a = total_b = total_retained = total_removed = total_added = 0
 
     for entity_type in ENTITY_TYPES:
@@ -157,14 +156,18 @@ def compute_retention_diff(
             "net_change": b_count - a_count,
         }
 
-        if removed > 0:
-            flagged_types.append(entity_type)
-
         total_a += a_count
         total_b += b_count
         total_retained += len(diff["retained"])
         total_removed += removed
         total_added += added
+
+    flagged = total_removed > removal_threshold
+    flagged_types = (
+        [et for et in ENTITY_TYPES if len(by_type[et]["removed"]) > 0]
+        if flagged
+        else []
+    )
 
     return {
         "by_type": by_type,
@@ -177,7 +180,7 @@ def compute_retention_diff(
             "net_change": total_b - total_a,
         },
         "removal_threshold": removal_threshold,
-        "flagged": total_removed > removal_threshold,
+        "flagged": flagged,
         "flagged_types": flagged_types,
     }
 

--- a/tools/entity_retention_diff.py
+++ b/tools/entity_retention_diff.py
@@ -214,6 +214,10 @@ def format_markdown(report: dict) -> str:
             f"No retention regression "
             f"({totals['removed']} removed, threshold {report['removal_threshold']})."
         )
+        for entity_type in ENTITY_TYPES:
+            removed = report["by_type"][entity_type]["removed"]
+            if removed:
+                lines.append(f"- Removed {entity_type}: {', '.join(removed)}")
 
     return "\n".join(lines)
 

--- a/tools/entity_retention_diff.py
+++ b/tools/entity_retention_diff.py
@@ -261,7 +261,7 @@ def main(argv: list[str] | None = None) -> int:
         report = compute_retention_diff(
             args.variant_a, args.variant_b, removal_threshold=args.threshold
         )
-    except ValueError as exc:
+    except (ValueError, json.JSONDecodeError, OSError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 


### PR DESCRIPTION
﻿## Summary

Add a per-entity retention diff to close the A/B gate's blind spot: it previously compared only aggregate entity counts, which masks deletion bugs like #394 (27% loss) and #441 (stale-sweep over-removal).

## Changes
- `tools/entity_retention_diff.py` — reusable `compute_retention_diff(dir_a, dir_b, threshold)` reporting retained (A∩B), removed (A−B), added (B−A) entity IDs per type; CLI with `--json`/`--strict`; reuses `catalog_merger` loaders (no duplication)
- `docs/ab-test-standard.md` — new section documenting retention diff as a required A/B output
- 20 new unit tests

Core logic lives in the public repo (code home); the private orchestrator adapter can shell out to the CLI in a follow-up (no public-to-private import).

Part of strategic redirection epic daviburg/narrative-state-engine-private#140

Closes #448
