### PR TITLE
docs: establish source-quality-first principle (Rule 10)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,6 +84,17 @@ Do not add hardcoded lists of domain-specific words (body parts, game terms, abs
 - If a PR adds a set or list of more than 5 domain-specific strings used for entity rejection, reject it during review.
 - Existing hardcoded word lists are technical debt — do not extend them; migrate filtering to templates instead.
 
+### 10. Source-Quality First
+
+When an extraction-quality problem appears (missing entities, duplicates, noise), first evaluate whether a **prompt-template change or model selection** can fix it at the source. Only add a post-processing heuristic (filter, sweep, or threshold) when a source fix is infeasible.
+
+- New magic thresholds and sweep parameters are technical debt — they must be justified, documented in `docs/architecture.md`, validated via an A/B entity-retention diff (#448), and recalibrated when the model changes.
+- A heuristic that depends on tuned constants is fragile: it silently degrades when the model, prompt, or campaign changes, and aggressive filters/sweeps can remove valid entities.
+- Evidence: the deduplication experiment showed the coreference-template fix (#443) was the dominant win, while the Python heuristics (cross-catalog gate, interval tuning) added nothing and risked over-deduplication. The smart-compression regression (#394) and stale-sweep regression (#441) are further cautionary cases.
+- This extends Rule 9 (no hardcoded word lists) from word lists to thresholds and sweep parameters. It overlaps with the Rule 9 tech-debt migration (#413) — consolidate where duplicative.
+
+Reference: #447; part of the strategic redirection epic.
+
 ---
 
 ## File Conventions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -348,6 +348,24 @@ The LLM extraction templates (`templates/extraction/*.md`) are the correct place
 
 ---
 
+### Source-Quality First (Prompt and Model Before Heuristics)
+
+When extraction quality is inadequate — missing entities, duplicates, or noise — the first remedy is a **prompt-template change or model selection**, not a new post-processing pass. The post-processing heuristics in the extraction pipeline (orphan thresholds, stale-item sweep, staleness trimming, mention blocklists) are useful safety nets, but each new one is:
+
+- **Fragile** — magic thresholds and sweep windows are calibrated to one model/campaign and silently degrade when either changes
+- **Risky** — aggressive filters and sweeps can remove valid entities (over-deduplication, premature pruning)
+- **Compounding** — heuristics interact unpredictably, making the pipeline harder to reason about
+
+**Policy:**
+
+- Fix quality at the source (template or model) whenever feasible; add a post-processing heuristic only when a source fix is not.
+- A new threshold or sweep parameter MUST be justified, documented here, and validated via an A/B entity-retention diff (#448). Recalibrate when the model changes.
+- Evidence: in the deduplication experiment the coreference-template fix (#443) delivered the dominant gain, while the Python heuristics (cross-catalog gate, interval tuning) added no measurable benefit and risked over-deduplication. The smart-compression regression (#394) and stale-sweep regression (#441) are further cautionary cases.
+
+This principle extends *No Hardcoded Word Lists* from word lists to thresholds and sweep parameters (see #413, #447).
+
+---
+
 ## Design Decisions
 
 ### Why file-based?

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -358,7 +358,7 @@ When extraction quality is inadequate — missing entities, duplicates, or noise
 
 **Policy:**
 
-- Fix quality at the source (template or model) whenever feasible; add a post-processing heuristic only when a source fix is not.
+- Fix quality at the source (template or model) whenever feasible; add a post-processing heuristic only when a source fix is infeasible.
 - A new threshold or sweep parameter MUST be justified, documented here, and validated via an A/B entity-retention diff (#448). Recalibrate when the model changes.
 - Evidence: in the deduplication experiment the coreference-template fix (#443) delivered the dominant gain, while the Python heuristics (cross-catalog gate, interval tuning) added no measurable benefit and risked over-deduplication. The smart-compression regression (#394) and stale-sweep regression (#441) are further cautionary cases.
 


### PR DESCRIPTION
﻿## Summary

Establish a documented "source-quality-first" principle: address extraction-quality problems at the source (prompt template or model selection) before adding post-processing heuristics. Extends Rule 9 (no hardcoded word lists) to magic thresholds and sweep parameters.

## Changes
- `.github/copilot-instructions.md` — new Rule 10: Source-Quality First
- `docs/architecture.md` — principle subsection under Architecture Principles

Cites the dedup experiment (coreference template fix #443 was the dominant win; Python heuristics #1/#3 added nothing) and the regression history (#394 smart compression, #441 stale sweep). Notes overlap with #413.

Part of strategic redirection epic daviburg/narrative-state-engine-private#140

Closes #447
