### PR TITLE
docs: make temperature 0 the A/B testing default (1 run); scope 3-run rule to temp>0

### DIFF
--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -22,14 +22,16 @@ This document defines the required A/B testing gate for any PR that modifies ext
 
 ### 1.2 Runs Per Variant
 
-Temperature 0.3 introduces non-determinism. To produce statistically meaningful results:
+**The default A/B testing standard is temperature 0 (deterministic), for which 1 run per variant is sufficient.** At temperature 0 the extraction output is effectively deterministic — reproducible enough that 1 run is the standard, so a single run per variant captures the full signal and no averaging is required.
 
-| Variant | Minimum runs | Recommended runs |
+| Sampling mode | Minimum runs per variant | Recommended runs per variant |
 |---|---|---|
-| A (baseline/main) | 3 | 5 |
-| B (PR branch) | 3 | 5 |
+| **Temperature 0 (deterministic) — default** | 1 | 1 |
+| Temperature > 0 (non-deterministic sampling) | 3 | 5 |
 
-Report **mean ± standard deviation** for all metrics. If any metric's standard deviation exceeds 15% of its mean, increase to 5 runs.
+The **≥3-runs-per-variant** requirement applies **only** when a test is run at temperature > 0 (non-deterministic sampling). In that case, report **mean ± standard deviation** for all metrics, and if any metric's standard deviation exceeds 15% of its mean, increase to 5 runs. At temperature 0, report the single-run values directly (no standard deviation).
+
+> **Rationale:** Variability is not re-introduced without justification. Current policy is temperature 0 until the high-quality outcomes available from the B70 hardware are exhausted; only then would non-deterministic sampling (and the ≥3-runs averaging requirement) be warranted.
 
 ### 1.3 Variant Definitions
 
@@ -270,9 +272,11 @@ Every template-change PR MUST include this section as a PR comment:
 - Model: [model name and quantization]
 - Hardware: [GPU(s) used]
 - Turns: [range]
-- Runs per variant: [N]
+- Runs per variant: [N] (1 at the temperature 0 default; ≥3 only at temperature > 0 — see §1.2)
 - Temperature: [value]
 - Config: `config/llm.json` (unchanged between A/B)
+
+> The `mean ± σ` columns below apply to temperature > 0 runs. At the temperature 0 default, report the single-run value directly (σ omitted).
 
 ### Performance
 
@@ -357,6 +361,8 @@ curl -s http://localhost:8081/v1/models | python -m json.tool
 
 ### 6.2 Run Variant A (Baseline)
 
+> **Note:** The multi-run (run1/run2/run3) commands below illustrate the temperature > 0 workflow, which requires ≥3 runs per variant (see §1.2). Under the **temperature 0 default**, only `run1` is needed per variant — skip `run2`/`run3`.
+
 ```bash
 # From the repo root, on main branch
 git stash  # if needed
@@ -400,6 +406,8 @@ python tools/bootstrap_session.py \
 > **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/_import/session-import-full-transcript.txt` and create the session directory at `sessions/session-import`. These paths are not committed to the repository; see `docs/usage.md` for instructions on setting up a session before running A/B tests.
 
 ### 6.3 Run Variant B (Candidate)
+
+> **Note:** As in §6.2, the multi-run (run1/run2/run3) commands below illustrate the temperature > 0 workflow, which requires ≥3 runs per variant (see §1.2). Under the **temperature 0 default**, only `run1` is needed per variant — skip `run2`/`run3`.
 
 ```bash
 git checkout <pr-branch>

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -9,7 +9,7 @@ A/B testing is required for any PR that modifies extraction behavior:
 
 ## Requirements
 
-1. **Minimum 3 paired runs** per variant (both A and B valid in same run)
+1. **Runs per variant:** 1 run suffices at the temperature 0 default (deterministic); **minimum 3 paired runs** per variant only at temperature > 0 (see ab-test-standard.md §1.2)
 2. **Same model, same turns, same hardware** for both variants
 3. **Results posted as PR comment** with entity count comparison
 
@@ -77,7 +77,7 @@ python tools/submit_ab_test.py \
 --variant-b BRANCH    Branch name for variant B / candidate (required)
 --repo-a PATH         Filesystem path to the variant A repo checkout
 --repo-b PATH         Filesystem path to the variant B repo checkout
---runs INT            Runs per variant (default: orchestrator config, typically 3)
+--runs INT            Runs per variant (default: orchestrator config, typically 3; use 1 at temperature 0)
 --turns RANGE         Turn range to process, e.g. "1-30" or "30"
 --base-url-a URL      LLM endpoint for variant A (default: http://localhost:8080/v1)
 --base-url-b URL      LLM endpoint for variant B (default: http://localhost:8081/v1)


### PR DESCRIPTION
## Summary

Make temperature 0 the documented A/B testing default and scope the >=3-runs-per-variant requirement to temperature > 0 only. Resolves the inconsistency flagged in PR #446 (section 1.2 previously mandated >=3 runs unconditionally).

## Changes
- `docs/ab-test-standard.md` section 1.2: temp 0 (deterministic) default -> 1 run/variant; >=3 runs only at temp > 0, with mean +/- sigma reporting; rationale (no variability re-introduced until B70 high-quality outcomes exhausted)
- `docs/ab-test-standard.md` sections 5.1 / 6.2 / 6.3: reconcile PR template and run examples with the temp-0 default
- `docs/ab-testing.md`: reconcile the sibling doc's unconditional "3 runs" statements with the temp-0 default

Policy confirmed by maintainer: temperature 0 until B70 high-quality outcomes are exhausted; smaller RTX-4070 models are out of scope for now.
