### PR TITLE
fix: make entity_retention_diff name/alias-aware (phantom ID-scheme churn)

### DIFF
--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -115,7 +115,7 @@ Report:
 
 ### 3.4 Entity Retention Diff
 
-Aggregate entity counts (§3.1) can **mask deletion bugs**: a variant that drops 5 distinct entities while adding 5 new ones shows a net delta of 0, hiding the loss. This is exactly how PR #393 (#394, 27% loss) and the stale-sweep over-removal (#441) went undetected. A per-entity retention diff compares entity **IDs** between variant A and variant B so removals are surfaced explicitly.
+Aggregate entity counts (§3.1) can **mask deletion bugs**: a variant that drops 5 distinct entities while adding 5 new ones shows a net delta of 0, hiding the loss. This is exactly how PR #393 (#394, 27% loss) and the stale-sweep over-removal (#441) went undetected. A per-entity retention diff compares entities between variant A and variant B — matching by ID and, when IDs differ across branches, by name/alias — so genuine removals are surfaced explicitly and ID-scheme renames are not mistaken for churn.
 
 Run `tools/entity_retention_diff.py`, comparing one representative variant-A run against one representative variant-B run (use the same run number for both, e.g. `run1`):
 
@@ -127,11 +127,14 @@ python tools/entity_retention_diff.py \
 
 The tool accepts either a framework directory (containing a `catalogs/` subdir) or a `catalogs/` directory directly. For each entity type (characters, locations, items, factions, events) it reports:
 
-- **retained** — IDs present in both A and B (A ∩ B)
-- **removed** — IDs present in A but missing from B (A − B)
-- **added** — IDs present in B but missing from A (B − A)
+- **retained** — entities matched between A and B with the *same* ID
+- **renamed** — entities matched by name/alias but with a *different* ID (an ID-scheme rename, e.g. `char-elder` → `char-elder-001`)
+- **removed** — entities in A with no ID *or* name/alias match in B (TRUE removal)
+- **added** — entities in B with no ID *or* name/alias match in A (TRUE addition)
 
-It emits a Markdown summary table (default) or JSON (`--json`), and **flags** the run when the total number of removed IDs exceeds the configurable `--threshold` (default `0`, i.e. any removal flags). Pass `--strict` to make the tool exit non-zero when flagged (useful for CI gating):
+By default (`--match-by auto`) the tool first pairs entities by exact ID, then falls back to a normalized name + alias match (within the same catalog type) for any leftovers. This prevents **phantom churn** when two branches use different ID schemes for the same entity (e.g. main's bare slug `char-elder` vs the compression branch's `char-elder-001`): the entity is reported as a **rename**, not as one removal plus one addition. Use `--match-by id` to restore the legacy exact-ID-only behavior, or `--match-by name` to pair purely on name/alias.
+
+It emits a Markdown summary table (default) or JSON (`--json`), and **flags** the run when the total number of TRUE removed entities exceeds the configurable `--threshold` (default `0`, i.e. any removal flags). ID renames never count toward the threshold. Pass `--strict` to make the tool exit non-zero when flagged (useful for CI gating):
 
 ```bash
 python tools/entity_retention_diff.py -a framework-ab-a-run1 -b framework-ab-b-run1 --threshold 0 --strict

--- a/tests/test_entity_retention_diff.py
+++ b/tests/test_entity_retention_diff.py
@@ -11,6 +11,7 @@ from entity_retention_diff import (
     diff_id_sets,
     format_markdown,
     main,
+    match_entities,
 )
 
 _TYPE_DIRS = {
@@ -51,6 +52,35 @@ def _write_catalog(base_dir, entity_ids, event_ids=None):
         with open(os.path.join(catalog_dir, "events.json"), "w", encoding="utf-8") as f:
             json.dump(events, f)
 
+    return catalog_dir
+
+
+def _write_named_catalog(base_dir, entities):
+    """Create a V2 catalogs dir from explicit entity specs.
+
+    entities: iterable of dicts with keys ``id`` and ``name`` and an optional
+    ``aliases`` list (stored under ``stable_attributes.aliases.value``).
+    The ID prefix determines the type directory.
+    """
+    catalog_dir = os.path.join(base_dir, "catalogs")
+    for spec in entities:
+        entity_id = spec["id"]
+        prefix = next((p for p in _TYPE_DIRS if entity_id.startswith(p)), "char-")
+        dirname = _TYPE_DIRS[prefix]
+        type_dir = os.path.join(catalog_dir, dirname)
+        os.makedirs(type_dir, exist_ok=True)
+        entity = {
+            "id": entity_id,
+            "name": spec["name"],
+            "type": dirname[:-1] if dirname.endswith("s") else dirname,
+            "identity": f"{entity_id} identity",
+            "first_seen_turn": "turn-001",
+        }
+        aliases = spec.get("aliases")
+        if aliases:
+            entity["stable_attributes"] = {"aliases": {"value": list(aliases)}}
+        with open(os.path.join(type_dir, f"{entity_id}.json"), "w", encoding="utf-8") as f:
+            json.dump(entity, f)
     return catalog_dir
 
 
@@ -292,4 +322,226 @@ class TestMainCli:
         assert rc == 0
         payload = json.loads(capsys.readouterr().out)
         assert payload["totals"]["retained"] == 1
+
+
+class TestMatchEntities:
+    def test_id_mode_exact_only(self):
+        a = [{"id": "char-elder", "name_keys": {"elder"}}]
+        b = [{"id": "char-elder-001", "name_keys": {"elder"}}]
+        result = match_entities(a, b, match_by="id")
+        assert result["removed"] == ["char-elder"]
+        assert result["added"] == ["char-elder-001"]
+        assert result["renamed"] == []
+
+    def test_auto_name_rename(self):
+        a = [{"id": "char-elder", "name_keys": {"elder"}}]
+        b = [{"id": "char-elder-001", "name_keys": {"elder"}}]
+        result = match_entities(a, b, match_by="auto")
+        assert result["removed"] == []
+        assert result["added"] == []
+        assert result["renamed"] == [
+            {"old_id": "char-elder", "new_id": "char-elder-001"}
+        ]
+
+    def test_auto_exact_id_retained(self):
+        a = [{"id": "char-elder", "name_keys": {"elder"}}]
+        b = [{"id": "char-elder", "name_keys": {"elder"}}]
+        result = match_entities(a, b, match_by="auto")
+        assert result["retained"] == ["char-elder"]
+        assert result["renamed"] == []
+
+    def test_name_mode_same_id_retained(self):
+        a = [{"id": "char-elder", "name_keys": {"elder"}}]
+        b = [{"id": "char-elder", "name_keys": {"elder"}}]
+        result = match_entities(a, b, match_by="name")
+        assert result["retained"] == ["char-elder"]
+        assert result["removed"] == []
+        assert result["renamed"] == []
+
+    def test_no_name_keys_only_id_matches(self):
+        # Entities without name keys (e.g. events) can only match by ID.
+        a = [{"id": "evt-001", "name_keys": set()}, {"id": "evt-002", "name_keys": set()}]
+        b = [{"id": "evt-001", "name_keys": set()}, {"id": "evt-003", "name_keys": set()}]
+        result = match_entities(a, b, match_by="auto")
+        assert result["retained"] == ["evt-001"]
+        assert result["removed"] == ["evt-002"]
+        assert result["added"] == ["evt-003"]
+        assert result["renamed"] == []
+
+
+class TestMatchByAuto:
+    def test_identical_ids_zero_churn(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_named_catalog(str(dir_a), [{"id": "char-elder", "name": "Elder"}])
+        _write_named_catalog(str(dir_b), [{"id": "char-elder", "name": "Elder"}])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        assert report["totals"]["removed"] == 0
+        assert report["totals"]["added"] == 0
+        assert report["totals"]["renamed"] == 0
+        assert report["totals"]["retained"] == 1
+        assert report["flagged"] is False
+
+    def test_suffix_rename_is_not_churn(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        # main's bare slug vs compression branch's numeric-suffixed ID, same name.
+        _write_named_catalog(str(dir_a), [{"id": "char-elder", "name": "Elder"}])
+        _write_named_catalog(str(dir_b), [{"id": "char-elder-001", "name": "Elder"}])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        assert report["totals"]["removed"] == 0
+        assert report["totals"]["added"] == 0
+        assert report["totals"]["renamed"] == 1
+        assert report["by_type"]["characters"]["renamed"] == [
+            {"old_id": "char-elder", "new_id": "char-elder-001"}
+        ]
+        assert report["flagged"] is False
+
+    def test_suffix_rename_is_churn_under_match_by_id(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_named_catalog(str(dir_a), [{"id": "char-elder", "name": "Elder"}])
+        _write_named_catalog(str(dir_b), [{"id": "char-elder-001", "name": "Elder"}])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b), match_by="id")
+        assert report["by_type"]["characters"]["removed"] == ["char-elder"]
+        assert report["by_type"]["characters"]["added"] == ["char-elder-001"]
+        assert report["totals"]["renamed"] == 0
+        assert report["flagged"] is True
+
+    def test_genuine_removal_is_true_removed(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_named_catalog(
+            str(dir_a),
+            [{"id": "char-elder", "name": "Elder"}, {"id": "char-mara", "name": "Mara"}],
+        )
+        _write_named_catalog(str(dir_b), [{"id": "char-elder", "name": "Elder"}])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        assert report["by_type"]["characters"]["removed"] == ["char-mara"]
+        assert report["totals"]["renamed"] == 0
+        assert report["flagged"] is True
+
+    def test_genuine_addition_is_true_added(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_named_catalog(str(dir_a), [{"id": "char-elder", "name": "Elder"}])
+        _write_named_catalog(
+            str(dir_b),
+            [{"id": "char-elder", "name": "Elder"}, {"id": "char-new", "name": "Newbie"}],
+        )
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        assert report["by_type"]["characters"]["added"] == ["char-new"]
+        assert report["totals"]["removed"] == 0
+        assert report["totals"]["renamed"] == 0
+        assert report["flagged"] is False
+
+    def test_alias_match_is_rename_not_removal(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_named_catalog(str(dir_a), [{"id": "char-elder", "name": "Elder"}])
+        # B's name differs, but "Elder" appears as an alias -> matched.
+        _write_named_catalog(
+            str(dir_b),
+            [{"id": "char-sage", "name": "The Sage", "aliases": ["Elder"]}],
+        )
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        assert report["totals"]["removed"] == 0
+        assert report["totals"]["added"] == 0
+        assert report["totals"]["renamed"] == 1
+        assert report["by_type"]["characters"]["renamed"] == [
+            {"old_id": "char-elder", "new_id": "char-sage"}
+        ]
+
+    def test_same_name_different_type_not_matched(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        # Same display name "Relic" but one is a character, one an item.
+        _write_named_catalog(str(dir_a), [{"id": "char-relic", "name": "Relic"}])
+        _write_named_catalog(str(dir_b), [{"id": "item-relic", "name": "Relic"}])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        assert report["by_type"]["characters"]["removed"] == ["char-relic"]
+        assert report["by_type"]["items"]["added"] == ["item-relic"]
+        assert report["totals"]["renamed"] == 0
+        assert report["totals"]["removed"] == 1
+        assert report["totals"]["added"] == 1
+
+    def test_strict_rename_only_exits_zero(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_named_catalog(str(dir_a), [{"id": "char-elder", "name": "Elder"}])
+        _write_named_catalog(str(dir_b), [{"id": "char-elder-001", "name": "Elder"}])
+
+        rc = main(["-a", str(dir_a), "-b", str(dir_b), "--strict"])
+        assert rc == 0
+
+    def test_strict_true_removal_exits_one(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_named_catalog(
+            str(dir_a),
+            [{"id": "char-elder", "name": "Elder"}, {"id": "char-mara", "name": "Mara"}],
+        )
+        _write_named_catalog(str(dir_b), [{"id": "char-elder", "name": "Elder"}])
+
+        rc = main(["-a", str(dir_a), "-b", str(dir_b), "--strict"])
+        assert rc == 1
+
+    def test_invalid_match_by_raises(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_named_catalog(str(dir_a), [{"id": "char-elder", "name": "Elder"}])
+        _write_named_catalog(str(dir_b), [{"id": "char-elder", "name": "Elder"}])
+
+        import pytest
+        with pytest.raises(ValueError, match="match_by must be one of"):
+            compute_retention_diff(str(dir_a), str(dir_b), match_by="bogus")
+
+    def test_json_includes_renamed(self, tmp_path, capsys):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_named_catalog(str(dir_a), [{"id": "char-elder", "name": "Elder"}])
+        _write_named_catalog(str(dir_b), [{"id": "char-elder-001", "name": "Elder"}])
+
+        rc = main(["-a", str(dir_a), "-b", str(dir_b), "--json"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["match_by"] == "auto"
+        assert payload["totals"]["renamed"] == 1
+        assert payload["by_type"]["characters"]["renamed"] == [
+            {"old_id": "char-elder", "new_id": "char-elder-001"}
+        ]
+
+    def test_cli_match_by_id_reports_churn(self, tmp_path, capsys):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_named_catalog(str(dir_a), [{"id": "char-elder", "name": "Elder"}])
+        _write_named_catalog(str(dir_b), [{"id": "char-elder-001", "name": "Elder"}])
+
+        rc = main(["-a", str(dir_a), "-b", str(dir_b), "--match-by", "id", "--json"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["match_by"] == "id"
+        assert payload["totals"]["removed"] == 1
+        assert payload["totals"]["added"] == 1
+        assert payload["totals"]["renamed"] == 0
+
+    def test_markdown_shows_rename_section(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        _write_named_catalog(str(dir_a), [{"id": "char-elder", "name": "Elder"}])
+        _write_named_catalog(str(dir_b), [{"id": "char-elder-001", "name": "Elder"}])
+
+        report = compute_retention_diff(str(dir_a), str(dir_b))
+        md = format_markdown(report)
+        assert "ID renames" in md
+        assert "char-elder -> char-elder-001" in md
+        assert "No retention regression" in md
+
 

--- a/tools/entity_retention_diff.py
+++ b/tools/entity_retention_diff.py
@@ -3,21 +3,36 @@
 
 Aggregate entity counts (used by the A/B test gate) can mask deletion bugs:
 a variant that drops 5 entities but adds 5 others shows a net delta of 0 while
-silently losing distinct entities. This tool compares entity IDs between two
+silently losing distinct entities. This tool compares entities between two
 extraction outputs (variant A vs variant B) and reports, per entity type:
 
-  - retained: IDs present in both A and B (A ∩ B)
-  - removed:  IDs present in A but missing from B (A − B)
-  - added:    IDs present in B but missing from A (B − A)
+  - retained:  entities matched between A and B with the *same* ID
+  - renamed:   entities matched by name/alias but with a *different* ID
+               (an ID-scheme rename, e.g. ``char-elder`` -> ``char-elder-001``)
+  - removed:   entities in A with no ID *or* name/alias match in B (TRUE removal)
+  - added:     entities in B with no ID *or* name/alias match in A (TRUE addition)
 
-A run is *flagged* when the total number of removed IDs exceeds a configurable
-threshold, surfacing deletion regressions such as those seen in #394 (27% loss)
-and #441 (stale-sweep over-removal).
+Pure ID matching produces phantom churn when two branches use different ID
+schemes for the same entity (e.g. main's bare slug ``char-elder`` vs the
+compression branch's ``char-elder-001``): the entity looks both removed and
+added even though it is the same character. The ``--match-by`` flag controls how
+entities are paired:
+
+  - ``id``:   exact ID only (legacy/fast path).
+  - ``name``: normalized name + aliases (within the same catalog type).
+  - ``auto``: exact ID first, then a name/alias fallback for entities left
+              unmatched (default). Same-name pairs with differing IDs are
+              reported as renames, not as churn.
+
+A run is *flagged* when the total number of TRUE removed entities exceeds a
+configurable threshold, surfacing deletion regressions such as those seen in
+#394 (27% loss) and #441 (stale-sweep over-removal). ID renames never flag.
 
 Usage:
     python tools/entity_retention_diff.py --variant-a DIR_A --variant-b DIR_B
     python tools/entity_retention_diff.py -a DIR_A -b DIR_B --threshold 3 --json
     python tools/entity_retention_diff.py -a DIR_A -b DIR_B --strict
+    python tools/entity_retention_diff.py -a DIR_A -b DIR_B --match-by id
 
 DIR may be either a framework directory (containing a ``catalogs/`` subdir) or
 a ``catalogs/`` directory itself; the layout is auto-detected.
@@ -28,6 +43,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
@@ -70,28 +86,73 @@ def _resolve_catalog_dir(path: str) -> str:
     )
 
 
-def _collect_ids(catalog_dir: str) -> dict[str, set[str]]:
-    """Return a mapping of entity-type label -> set of entity IDs.
+def _normalize_name(name: str) -> str:
+    """Normalize a display name for cross-variant comparison.
 
-    Reads per-entity catalog files (characters/locations/items/factions) and the
-    events array. Entities without an ``id`` field are skipped.
+    Lowercases, replaces any run of non-alphanumeric characters with a single
+    space, and trims. This makes matching robust to punctuation and whitespace
+    differences (e.g. "The Elder" vs "the  elder"). It intentionally does NOT
+    use any domain-specific word lists (Rule 9) — only structural normalization.
     """
-    ids: dict[str, set[str]] = {t: set() for t in ENTITY_TYPES}
+    return " ".join(re.sub(r"[^a-z0-9]+", " ", name.lower()).split())
+
+
+def _entity_name_keys(entity: dict) -> set[str]:
+    """Return the set of normalized name + alias keys for an entity.
+
+    Pulls the ``name`` field and any aliases stored under
+    ``stable_attributes.aliases`` (string, list, or ``{"value": ...}`` shapes).
+    Entities without a name (e.g. events) yield an empty set, which means they
+    can only ever be matched by ID.
+    """
+    keys: set[str] = set()
+    name = entity.get("name")
+    if isinstance(name, str) and name.strip():
+        norm = _normalize_name(name)
+        if norm:
+            keys.add(norm)
+
+    sa = entity.get("stable_attributes")
+    aliases = sa.get("aliases") if isinstance(sa, dict) else None
+    if aliases is not None:
+        val = aliases.get("value") if isinstance(aliases, dict) else aliases
+        candidates = val if isinstance(val, list) else [val]
+        for cand in candidates:
+            if isinstance(cand, str) and cand.strip():
+                norm = _normalize_name(cand)
+                if norm:
+                    keys.add(norm)
+
+    return keys
+
+
+def _collect_entities(catalog_dir: str) -> dict[str, list[dict]]:
+    """Return a mapping of entity-type label -> list of entity records.
+
+    Each record has ``id`` and ``name_keys`` (set of normalized name/alias
+    strings). Reads per-entity catalog files (characters/locations/items/
+    factions) and the events array. Entities without an ``id`` are skipped.
+    """
+    by_type: dict[str, list[dict]] = {t: [] for t in ENTITY_TYPES}
 
     catalogs = load_catalogs(catalog_dir)
     for key, type_label in _CATALOG_KEY_TO_TYPE.items():
         for entity in catalogs.get(key, []):
             entity_id = entity.get("id")
             if entity_id:
-                ids[type_label].add(entity_id)
+                by_type[type_label].append(
+                    {"id": entity_id, "name_keys": _entity_name_keys(entity)}
+                )
 
     for event in load_events(catalog_dir):
         if isinstance(event, dict):
             event_id = event.get("id")
             if event_id:
-                ids[_EVENTS_TYPE].add(event_id)
+                by_type[_EVENTS_TYPE].append(
+                    {"id": event_id, "name_keys": _entity_name_keys(event)}
+                )
 
-    return ids
+    return by_type
 
 
 def diff_id_sets(ids_a: set[str], ids_b: set[str]) -> dict[str, list[str]]:
@@ -108,59 +169,147 @@ def diff_id_sets(ids_a: set[str], ids_b: set[str]) -> dict[str, list[str]]:
     }
 
 
+def match_entities(
+    entities_a: list[dict],
+    entities_b: list[dict],
+    match_by: str = "auto",
+) -> dict:
+    """Pair entities of one type between variant A and B.
+
+    Args:
+        entities_a: Records (``{"id", "name_keys"}``) from variant A.
+        entities_b: Records from variant B.
+        match_by: ``"id"`` (exact ID only), ``"name"`` (name/alias only), or
+            ``"auto"`` (exact ID first, then a name/alias fallback).
+
+    Returns:
+        A dict with sorted ``retained`` and ``removed``/``added`` ID lists plus
+        a ``renamed`` list of ``{"old_id", "new_id"}`` pairs (entities matched
+        by name/alias but with a different ID).
+    """
+    a_by_id = {e["id"]: e for e in entities_a}
+    b_by_id = {e["id"]: e for e in entities_b}
+
+    if match_by == "id":
+        a_ids = set(a_by_id)
+        b_ids = set(b_by_id)
+        return {
+            "retained": sorted(a_ids & b_ids),
+            "removed": sorted(a_ids - b_ids),
+            "added": sorted(b_ids - a_ids),
+            "renamed": [],
+        }
+
+    matched_a: set[str] = set()
+    matched_b: set[str] = set()
+    retained: list[str] = []
+    renamed: list[dict] = []
+
+    # Phase 1 (auto only): exact-ID match — the fast path.
+    if match_by == "auto":
+        for entity_id in a_by_id:
+            if entity_id in b_by_id:
+                retained.append(entity_id)
+                matched_a.add(entity_id)
+                matched_b.add(entity_id)
+
+    # Phase 2: name/alias fallback for still-unmatched entities. Matching is
+    # confined to a single catalog type (the caller iterates per type), so a
+    # name collision across types (e.g. a character and an item) never matches.
+    for a_id in sorted(a_by_id):
+        if a_id in matched_a:
+            continue
+        a_keys = a_by_id[a_id]["name_keys"]
+        if not a_keys:
+            continue
+        for b_id in sorted(b_by_id):
+            if b_id in matched_b:
+                continue
+            if a_keys & b_by_id[b_id]["name_keys"]:
+                matched_a.add(a_id)
+                matched_b.add(b_id)
+                if b_id == a_id:
+                    retained.append(a_id)
+                else:
+                    renamed.append({"old_id": a_id, "new_id": b_id})
+                break
+
+    removed = sorted(set(a_by_id) - matched_a)
+    added = sorted(set(b_by_id) - matched_b)
+    return {
+        "retained": sorted(retained),
+        "removed": removed,
+        "added": added,
+        "renamed": renamed,
+    }
+
+
+
 def compute_retention_diff(
     dir_a: str,
     dir_b: str,
     removal_threshold: int = 0,
+    match_by: str = "auto",
 ) -> dict:
     """Compute the per-entity retention diff between two extraction outputs.
 
     Args:
         dir_a: Variant A directory (framework dir or catalogs dir).
         dir_b: Variant B directory (framework dir or catalogs dir).
-        removal_threshold: Maximum number of total removed IDs tolerated before
-            the report is flagged. Must be >= 0. Defaults to 0 (any removal
-            flags the run).
+        removal_threshold: Maximum number of total TRUE removed entities
+            tolerated before the report is flagged. Must be >= 0. Defaults to 0
+            (any TRUE removal flags the run). ID renames never count toward this.
+        match_by: Entity pairing strategy — ``"id"`` (exact ID only, legacy),
+            ``"name"`` (name/alias only), or ``"auto"`` (exact ID then a
+            name/alias fallback). Defaults to ``"auto"``.
 
     Returns:
-        A report dict with ``by_type``, ``totals``, ``removal_threshold``,
-        ``flagged``, and ``flagged_types`` keys.
+        A report dict with ``by_type``, ``totals``, ``match_by``,
+        ``removal_threshold``, ``flagged``, and ``flagged_types`` keys.
     """
     if removal_threshold < 0:
         raise ValueError(
             f"removal_threshold must be >= 0, got {removal_threshold!r}"
         )
+    if match_by not in ("id", "name", "auto"):
+        raise ValueError(
+            f"match_by must be one of 'id', 'name', 'auto', got {match_by!r}"
+        )
 
-    ids_a = _collect_ids(_resolve_catalog_dir(dir_a))
-    ids_b = _collect_ids(_resolve_catalog_dir(dir_b))
+    entities_a = _collect_entities(_resolve_catalog_dir(dir_a))
+    entities_b = _collect_entities(_resolve_catalog_dir(dir_b))
 
     by_type: dict[str, dict] = {}
     total_a = total_b = total_retained = total_removed = total_added = 0
+    total_renamed = 0
 
     for entity_type in ENTITY_TYPES:
-        a_set = ids_a[entity_type]
-        b_set = ids_b[entity_type]
-        diff = diff_id_sets(a_set, b_set)
+        a_list = entities_a[entity_type]
+        b_list = entities_b[entity_type]
+        result = match_entities(a_list, b_list, match_by=match_by)
 
-        a_count = len(a_set)
-        b_count = len(b_set)
-        removed = len(diff["removed"])
-        added = len(diff["added"])
+        a_count = len(a_list)
+        b_count = len(b_list)
+        removed = len(result["removed"])
+        added = len(result["added"])
+        renamed = len(result["renamed"])
 
         by_type[entity_type] = {
             "a_count": a_count,
             "b_count": b_count,
-            "retained": diff["retained"],
-            "removed": diff["removed"],
-            "added": diff["added"],
+            "retained": result["retained"],
+            "renamed": result["renamed"],
+            "removed": result["removed"],
+            "added": result["added"],
             "net_change": b_count - a_count,
         }
 
         total_a += a_count
         total_b += b_count
-        total_retained += len(diff["retained"])
+        total_retained += len(result["retained"])
         total_removed += removed
         total_added += added
+        total_renamed += renamed
 
     flagged = total_removed > removal_threshold
     flagged_types = (
@@ -175,38 +324,57 @@ def compute_retention_diff(
             "a": total_a,
             "b": total_b,
             "retained": total_retained,
+            "renamed": total_renamed,
             "removed": total_removed,
             "added": total_added,
             "net_change": total_b - total_a,
         },
+        "match_by": match_by,
         "removal_threshold": removal_threshold,
         "flagged": flagged,
         "flagged_types": flagged_types,
     }
 
 
+
 def format_markdown(report: dict) -> str:
     """Render a retention-diff report as a Markdown summary table."""
     lines = ["### Entity Retention Diff", ""]
-    lines.append("| Type | A | B | Retained | Removed | Added | Net |")
-    lines.append("|---|---|---|---|---|---|---|")
+    lines.append(f"Match strategy: `{report.get('match_by', 'auto')}`")
+    lines.append("")
+    lines.append("| Type | A | B | Retained | Renamed | Removed | Added | Net |")
+    lines.append("|---|---|---|---|---|---|---|---|")
     for entity_type in ENTITY_TYPES:
         row = report["by_type"][entity_type]
         lines.append(
             f"| {entity_type} | {row['a_count']} | {row['b_count']} | "
-            f"{len(row['retained'])} | {len(row['removed'])} | "
-            f"{len(row['added'])} | {row['net_change']:+d} |"
+            f"{len(row['retained'])} | {len(row['renamed'])} | "
+            f"{len(row['removed'])} | {len(row['added'])} | "
+            f"{row['net_change']:+d} |"
         )
     totals = report["totals"]
     lines.append(
         f"| **Total** | {totals['a']} | {totals['b']} | {totals['retained']} | "
-        f"{totals['removed']} | {totals['added']} | {totals['net_change']:+d} |"
+        f"{totals['renamed']} | {totals['removed']} | {totals['added']} | "
+        f"{totals['net_change']:+d} |"
     )
     lines.append("")
 
+    # ID renames are NOT churn; surface them separately so they are not
+    # mistaken for removals/additions.
+    if totals["renamed"]:
+        lines.append(
+            f"ID renames (matched by name/alias, different ID): {totals['renamed']}."
+        )
+        for entity_type in ENTITY_TYPES:
+            for pair in report["by_type"][entity_type]["renamed"]:
+                lines.append(
+                    f"- Renamed {entity_type}: {pair['old_id']} -> {pair['new_id']}"
+                )
+
     if report["flagged"]:
         lines.append(
-            f"**FLAGGED**: {totals['removed']} entity ID(s) removed "
+            f"**FLAGGED**: {totals['removed']} entity(ies) removed "
             f"(threshold {report['removal_threshold']}). "
             f"Affected types: {', '.join(report['flagged_types'])}."
         )
@@ -243,6 +411,15 @@ def main(argv: list[str] | None = None) -> int:
         help="Max total removed IDs tolerated before flagging (default: 0).",
     )
     parser.add_argument(
+        "--match-by", choices=("id", "name", "auto"), default="auto",
+        help=(
+            "Entity pairing strategy: 'id' (exact ID only, legacy), "
+            "'name' (normalized name/alias), or 'auto' (exact ID then a "
+            "name/alias fallback; default). 'auto' reports ID-scheme renames "
+            "separately instead of as removed+added churn."
+        ),
+    )
+    parser.add_argument(
         "--json", action="store_true",
         help="Emit the full report as JSON instead of a Markdown table.",
     )
@@ -259,7 +436,9 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         report = compute_retention_diff(
-            args.variant_a, args.variant_b, removal_threshold=args.threshold
+            args.variant_a, args.variant_b,
+            removal_threshold=args.threshold,
+            match_by=args.match_by,
         )
     except (ValueError, json.JSONDecodeError, OSError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)


### PR DESCRIPTION
## Summary

`tools/entity_retention_diff.py` was name-blind: it compared catalogs purely by entity ID. When two branches use different ID schemes for the same entity (e.g. `main` uses `char-elder` while the compression branch uses `char-elder-001`), the tool reported the entity as both **removed** (from the old scheme) and **added** (in the new scheme). This phantom churn made the entity-retention gate untrustworthy — it could fail an A/B comparison purely on cosmetic ID-scheme differences with zero actual entity loss. (blocks #460, relates #448)

## Changes

- Add `--match-by {id,name,auto}` (default `auto`):
  - **exact-ID fast path** — same id in both catalogs ⇒ retained.
  - **normalized name+alias fallback** within the same catalog type — an entity matched by name/alias under a different id is reported as **RENAMED**, not removed+added.
  - no match in either pass ⇒ **TRUE** removed / added.
- `--strict` / `--threshold` now gate on **TRUE removals only** (renames are excluded).
- JSON and Markdown reports gain a `renamed` field.
- Legacy exact-ID-only behavior preserved via `--match-by id`.

## Why it matters

The PR #393 / #460 A/B comparison reported ~12 of 27 "removed" entities that were in fact `-001` ID renames, not real losses. This fix lets the #460 retention gate count real entity losses only, restoring trust in the gate.

## Testing

- `tests/test_entity_retention_diff.py`: 23 → 41 tests (18 new) covering suffix-rename detection, genuine removal/addition, alias match, same-name-different-type (no false match), strict exit codes, and legacy `--match-by id`.
- Full suite: 1822 passed.

## Docs

- `docs/ab-test-standard.md` §3.4 updated for the new default match mode and the `renamed` report row.

## Compatibility

- Output keys are additive (`renamed` added; existing keys unchanged).
- The private A/B harness (`ab_test.py`) calls the tool with `--json` and is unaffected.
- The default flip to `auto` is the intended behavioral fix.

Closes #461
