### PR TITLE
docs: fix non-existent transcript path in A/B test checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ python tools/ingest_turn.py \
 If you already have a large transcript, import it in one step:
 
 Put the source text inside a gitignored session's `raw/` directory (for
-example `sessions/session-import/`, which is listed in `.gitignore`) so your
-private transcript is never committed:
+example `sessions/session-import/raw/`; the `sessions/session-import` session
+root is listed in `.gitignore`) so your private transcript is never committed:
 
 ```bash
 mkdir -p sessions/session-import/raw

--- a/README.md
+++ b/README.md
@@ -205,18 +205,20 @@ python tools/ingest_turn.py \
 
 If you already have a large transcript, import it in one step:
 
-Put the source text in a local-only folder that is gitignored:
+Put the source text inside a gitignored session's `raw/` directory (for
+example `sessions/session-import/`, which is listed in `.gitignore`) so your
+private transcript is never committed:
 
 ```bash
-mkdir -p sessions/_import
+mkdir -p sessions/session-import/raw
 # Place your raw transcript text at:
-# sessions/_import/session-001-full-transcript.txt
+# sessions/session-import/raw/full-transcript.md
 ```
 
 ```bash
 python tools/bootstrap_session.py \
-  --session sessions/session-001 \
-  --file sessions/_import/session-001-full-transcript.txt
+  --session sessions/session-import \
+  --file sessions/session-import/raw/full-transcript.md
 ```
 
 Use `--dry-run` first to preview parsed turns and writes.

--- a/docs/ab-test-checklist.md
+++ b/docs/ab-test-checklist.md
@@ -19,21 +19,21 @@ Full standard: [ab-test-standard.md](ab-test-standard.md).
 # Run 1:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-ab-a-run1 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-a>/v1
 
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-ab-a-run2 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-a>/v1
 
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-ab-a-run3 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-a>/v1
 ```
@@ -58,21 +58,21 @@ git checkout <pr-branch>
 # Run 1:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-ab-b-run1 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-b>/v1
 
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-ab-b-run2 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-b>/v1
 
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-ab-b-run3 --max-turns 30 --overwrite --no-resume \
     --base-url http://<server-b>/v1
 ```

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -492,7 +492,7 @@ git pull
 # Run 1:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-ab-a-run1 \
     --max-turns 30 \
     --overwrite \
@@ -502,7 +502,7 @@ python tools/bootstrap_session.py \
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-ab-a-run2 \
     --max-turns 30 \
     --overwrite \
@@ -512,7 +512,7 @@ python tools/bootstrap_session.py \
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-ab-a-run3 \
     --max-turns 30 \
     --overwrite \
@@ -522,7 +522,7 @@ python tools/bootstrap_session.py \
 
 > **Note:** Always specify `--base-url` explicitly to prevent round-robin mixing between A and B variants. Substitute `localhost:8080` / `localhost:8081` with your actual server endpoints from `config/llm.json` `base_urls`.
 >
-> **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/_import/session-import-full-transcript.txt` and create the session directory at `sessions/session-import`. These paths are not committed to the repository; see `docs/usage.md` for instructions on setting up a session before running A/B tests.
+> **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/session-import/raw/full-transcript.md` and create the session directory at `sessions/session-import`. These paths are not committed to the repository; see `docs/usage.md` for instructions on setting up a session before running A/B tests.
 
 ### 6.3 Run Variant B (Candidate)
 
@@ -535,7 +535,7 @@ git checkout <pr-branch>
 # Run 1:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-ab-b-run1 \
     --max-turns 30 \
     --overwrite \
@@ -545,7 +545,7 @@ python tools/bootstrap_session.py \
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-ab-b-run2 \
     --max-turns 30 \
     --overwrite \
@@ -555,7 +555,7 @@ python tools/bootstrap_session.py \
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-ab-b-run3 \
     --max-turns 30 \
     --overwrite \
@@ -573,7 +573,7 @@ The two B70 GPU servers (ports 8080 and 8081 by default — see `tools/submit_ab
 # Terminal 1 — Variant A on GPU 0 (port 8080)
 python tools/bootstrap_session.py `
     --session sessions/session-import `
-    --file sessions/_import/session-import-full-transcript.txt `
+    --file sessions/session-import/raw/full-transcript.md `
     --framework framework-ab-a-run1 `
     --max-turns 30 `
     --base-url http://localhost:8080/v1 `
@@ -583,7 +583,7 @@ python tools/bootstrap_session.py `
 # Terminal 2 — Variant B on GPU 1 (port 8081)
 python tools/bootstrap_session.py `
     --session sessions/session-import `
-    --file sessions/_import/session-import-full-transcript.txt `
+    --file sessions/session-import/raw/full-transcript.md `
     --framework framework-ab-b-run1 `
     --max-turns 30 `
     --base-url http://localhost:8081/v1 `

--- a/docs/ab-test-standard.md
+++ b/docs/ab-test-standard.md
@@ -522,7 +522,7 @@ python tools/bootstrap_session.py \
 
 > **Note:** Always specify `--base-url` explicitly to prevent round-robin mixing between A and B variants. Substitute `localhost:8080` / `localhost:8081` with your actual server endpoints from `config/llm.json` `base_urls`.
 >
-> **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/session-import/raw/full-transcript.md` and create the session directory at `sessions/session-import`. These paths are not committed to the repository; see `docs/usage.md` for instructions on setting up a session before running A/B tests.
+> **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/session-import/raw/full-transcript.md` and create the session directory together with its `raw/` subdirectory (`mkdir -p sessions/session-import/raw`). These paths are not committed to the repository; see `docs/usage.md` for instructions on setting up a session before running A/B tests.
 
 ### 6.3 Run Variant B (Candidate)
 

--- a/docs/model-eval-standard.md
+++ b/docs/model-eval-standard.md
@@ -366,13 +366,13 @@ curl -s http://localhost:8081/v1/models | python -m json.tool
 
 ### 8.2 Run Model A (Baseline)
 
-> **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/_import/session-import-full-transcript.txt` and create the session directory at `sessions/session-import`. The `sessions/session-import` and `sessions/_import/` paths are listed in `.gitignore` and are not committed to the repository; see `docs/usage.md` for instructions on setting up a local session before running evaluations.
+> **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/session-import/raw/full-transcript.md` and create the session directory at `sessions/session-import`. The `sessions/session-import` and `sessions/_import/` paths are listed in `.gitignore` and are not committed to the repository; see `docs/usage.md` for instructions on setting up a local session before running evaluations.
 
 ```bash
 # Run 1:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-eval-a-run1 \
     --max-turns 30 \
     --overwrite \
@@ -383,7 +383,7 @@ python tools/bootstrap_session.py \
 # Run 2:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-eval-a-run2 \
     --max-turns 30 \
     --overwrite \
@@ -394,7 +394,7 @@ python tools/bootstrap_session.py \
 # Run 3:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-eval-a-run3 \
     --max-turns 30 \
     --overwrite \
@@ -409,7 +409,7 @@ python tools/bootstrap_session.py \
 # Run 1:
 python tools/bootstrap_session.py \
     --session sessions/session-import \
-    --file sessions/_import/session-import-full-transcript.txt \
+    --file sessions/session-import/raw/full-transcript.md \
     --framework framework-eval-b-run1 \
     --max-turns 30 \
     --overwrite \

--- a/docs/model-eval-standard.md
+++ b/docs/model-eval-standard.md
@@ -366,7 +366,7 @@ curl -s http://localhost:8081/v1/models | python -m json.tool
 
 ### 8.2 Run Model A (Baseline)
 
-> **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/session-import/raw/full-transcript.md` and create the session directory at `sessions/session-import`. The `sessions/session-import` and `sessions/_import/` paths are listed in `.gitignore` and are not committed to the repository; see `docs/usage.md` for instructions on setting up a local session before running evaluations.
+> **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/session-import/raw/full-transcript.md` and create the session directory at `sessions/session-import`. The `sessions/session-import` path is listed in `.gitignore` and is not committed to the repository; see `docs/usage.md` for instructions on setting up a local session before running evaluations.
 
 ```bash
 # Run 1:

--- a/docs/model-eval-standard.md
+++ b/docs/model-eval-standard.md
@@ -366,7 +366,7 @@ curl -s http://localhost:8081/v1/models | python -m json.tool
 
 ### 8.2 Run Model A (Baseline)
 
-> **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/session-import/raw/full-transcript.md` and create the session directory at `sessions/session-import`. The `sessions/session-import` path is listed in `.gitignore` and is not committed to the repository; see `docs/usage.md` for instructions on setting up a local session before running evaluations.
+> **Note:** The `--session` and `--file` paths refer to a locally prepared import session. Place your transcript at `sessions/session-import/raw/full-transcript.md` and create the session directory together with its `raw/` subdirectory (`mkdir -p sessions/session-import/raw`). The `sessions/session-import` path is listed in `.gitignore` and is not committed to the repository; see `docs/usage.md` for instructions on setting up a local session before running evaluations.
 
 ```bash
 # Run 1:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -757,18 +757,18 @@ python tools/ingest_turn.py \
 
 If you already have a large transcript file, bootstrap a session in one pass:
 
-Use a local-only import folder (gitignored) for raw source text:
+Place the raw source text inside the session's `raw/` directory:
 
 ```bash
-mkdir -p sessions/_import
+mkdir -p sessions/session-001/raw
 # Place your transcript at:
-# sessions/_import/session-001-full-transcript.txt
+# sessions/session-001/raw/full-transcript.md
 ```
 
 ```bash
 python tools/bootstrap_session.py \
   --session sessions/session-001 \
-  --file sessions/_import/session-001-full-transcript.txt
+  --file sessions/session-001/raw/full-transcript.md
 ```
 
 Useful flags:
@@ -876,7 +876,7 @@ When bootstrapping a session, semantic extraction runs automatically over all tu
 ```bash
 python tools/bootstrap_session.py \
   --session sessions/session-001 \
-  --file sessions/_import/session-001-full-transcript.txt
+  --file sessions/session-001/raw/full-transcript.md
 ```
 
 The pipeline processes each turn through four agents:
@@ -1013,7 +1013,7 @@ Explicit segmented extraction command:
 ```bash
 python tools/bootstrap_session.py \
   --session sessions/session-001 \
-  --file sessions/_import/session-001-full-transcript.txt \
+  --file sessions/session-001/raw/full-transcript.md \
   --segment-size 100
 ```
 
@@ -1030,7 +1030,7 @@ Equivalent command relying on the auto-default (>150 turns):
 ```bash
 python tools/bootstrap_session.py \
   --session sessions/session-001 \
-  --file sessions/_import/session-001-full-transcript.txt
+  --file sessions/session-001/raw/full-transcript.md
 ```
 
 Recommended segment sizes:
@@ -1060,7 +1060,7 @@ batch.
 # Batch 1: turns 1-25
 python tools/bootstrap_session.py \
   --session sessions/session-001 \
-  --file sessions/_import/session-001-full-transcript.txt \
+  --file sessions/session-001/raw/full-transcript.md \
   --max-turns 25
 
 # Review wiki pages in framework/catalogs/*/README.md
@@ -1069,7 +1069,7 @@ python tools/bootstrap_session.py \
 # Batch 2: turns 26-50
 python tools/bootstrap_session.py \
   --session sessions/session-001 \
-  --file sessions/_import/session-001-full-transcript.txt \
+  --file sessions/session-001/raw/full-transcript.md \
   --start-turn 26 --max-turns 50
 
 # Review again, then:
@@ -1077,7 +1077,7 @@ python tools/bootstrap_session.py \
 # Batch 3: turns 51-75
 python tools/bootstrap_session.py \
   --session sessions/session-001 \
-  --file sessions/_import/session-001-full-transcript.txt \
+  --file sessions/session-001/raw/full-transcript.md \
   --start-turn 51 --max-turns 75
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -767,15 +767,15 @@ Place the raw source text inside the session's `raw/` directory:
 > under `sessions/<session>/raw/`.
 
 ```bash
-mkdir -p sessions/session-001/raw
+mkdir -p sessions/session-import/raw
 # Place your transcript at:
-# sessions/session-001/raw/full-transcript.md
+# sessions/session-import/raw/full-transcript.md
 ```
 
 ```bash
 python tools/bootstrap_session.py \
-  --session sessions/session-001 \
-  --file sessions/session-001/raw/full-transcript.md
+  --session sessions/session-import \
+  --file sessions/session-import/raw/full-transcript.md
 ```
 
 Useful flags:
@@ -882,8 +882,8 @@ When bootstrapping a session, semantic extraction runs automatically over all tu
 
 ```bash
 python tools/bootstrap_session.py \
-  --session sessions/session-001 \
-  --file sessions/session-001/raw/full-transcript.md
+  --session sessions/session-import \
+  --file sessions/session-import/raw/full-transcript.md
 ```
 
 The pipeline processes each turn through four agents:
@@ -1019,8 +1019,8 @@ Explicit segmented extraction command:
 
 ```bash
 python tools/bootstrap_session.py \
-  --session sessions/session-001 \
-  --file sessions/session-001/raw/full-transcript.md \
+  --session sessions/session-import \
+  --file sessions/session-import/raw/full-transcript.md \
   --segment-size 100
 ```
 
@@ -1036,8 +1036,8 @@ Equivalent command relying on the auto-default (>150 turns):
 
 ```bash
 python tools/bootstrap_session.py \
-  --session sessions/session-001 \
-  --file sessions/session-001/raw/full-transcript.md
+  --session sessions/session-import \
+  --file sessions/session-import/raw/full-transcript.md
 ```
 
 Recommended segment sizes:
@@ -1066,8 +1066,8 @@ batch.
 ```bash
 # Batch 1: turns 1-25
 python tools/bootstrap_session.py \
-  --session sessions/session-001 \
-  --file sessions/session-001/raw/full-transcript.md \
+  --session sessions/session-import \
+  --file sessions/session-import/raw/full-transcript.md \
   --max-turns 25
 
 # Review wiki pages in framework/catalogs/*/README.md
@@ -1075,16 +1075,16 @@ python tools/bootstrap_session.py \
 
 # Batch 2: turns 26-50
 python tools/bootstrap_session.py \
-  --session sessions/session-001 \
-  --file sessions/session-001/raw/full-transcript.md \
+  --session sessions/session-import \
+  --file sessions/session-import/raw/full-transcript.md \
   --start-turn 26 --max-turns 50
 
 # Review again, then:
 
 # Batch 3: turns 51-75
 python tools/bootstrap_session.py \
-  --session sessions/session-001 \
-  --file sessions/session-001/raw/full-transcript.md \
+  --session sessions/session-import \
+  --file sessions/session-import/raw/full-transcript.md \
   --start-turn 51 --max-turns 75
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -759,6 +759,13 @@ If you already have a large transcript file, bootstrap a session in one pass:
 
 Place the raw source text inside the session's `raw/` directory:
 
+> **Warning:** `sessions/session-001/` is tracked as the public example, so
+> placing a real (private) transcript under `sessions/session-001/raw/` risks
+> committing private content. Use a gitignored session directory instead — e.g.
+> `sessions/session-import/` (already listed in `.gitignore`) — or add your
+> chosen `sessions/<session>/` path to `.gitignore` before placing transcripts
+> under `sessions/<session>/raw/`.
+
 ```bash
 mkdir -p sessions/session-001/raw
 # Place your transcript at:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -906,7 +906,7 @@ Use the helper script from the repository root:
 ```powershell
 powershell -ExecutionPolicy Bypass -File tools/start_extraction_detached.ps1 `
   -Session sessions/session-import `
-  -TranscriptFile sessions/_import/session-import-full-transcript.txt `
+  -TranscriptFile sessions/session-import/raw/full-transcript.md `
   -Framework framework-local `
   -PlayerLabel "Fenouille Moonwind" `
   -SegmentSize 100


### PR DESCRIPTION
## Summary

The A/B test checklist's copy-paste run commands pointed `--file` at
`sessions/_import/session-import-full-transcript.txt`, **which does not exist**.
Anyone following the checklist verbatim would hit a missing-file error.

This corrects the `--file` argument to the real transcript used by the extraction
harness, `sessions/session-import/raw/full-transcript.md`, so the documented
A/B run commands work as written, and aligns the surrounding docs on the same
canonical session-import transcript path.

### What changed

- `docs/ab-test-checklist.md` — 6 `--file` occurrences (Run A ×3, Run B ×3)
- `docs/ab-test-standard.md` — 8 `--file` occurrences (Run A/B bash + parallel-GPU PowerShell blocks) plus the setup note that told readers to place the transcript at the wrong path
- `docs/model-eval-standard.md` — setup note + copy/paste commands updated to the canonical `sessions/session-import/raw/full-transcript.md` path
- `docs/usage.md` — bootstrap section updated to the session `raw/` convention, with an added warning to use a gitignored session directory for private transcripts
- `README.md` — bootstrap quick-start updated to the gitignored `sessions/session-import/raw/full-transcript.md` convention

### What did NOT change

- The `--session sessions/session-import` argument was already correct and is left untouched.
- No prose reworded beyond the path strings and the added gitignore safety warning.

Surfaced during PR #468 A/B baseline prep.
