### PR TITLE
feat: add --extract-only mode to ingest_turn.py

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,9 @@ tools/analyze_next_move.py
 Semantic extraction is triggered automatically during `bootstrap_session.py` (batch)
 or via the `--extract` flag on `ingest_turn.py` (incremental). It requires an LLM
 endpoint configured in `config/llm.json` and gracefully degrades if unavailable.
+The `--extract-only` flag on `ingest_turn.py` re-runs extraction against an existing
+turn file (given via `--file`) without creating a new turn or modifying the raw
+transcript, for re-extraction after a template or model change.
 
 Planning layer derivation (`derive_planning_layer.py`) bridges the gap between
 extracted catalog data and the derived planning files consumed by

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1234,8 +1234,11 @@ Pass `--extract-only` to re-run semantic extraction against an **existing** turn
 file without creating a new turn or modifying the raw transcript. Use it to
 re-extract already-ingested turns after a template or model change. The target
 turn is given via `--file` and must be an existing
-`transcript/turn-NNN-(player|dm).md` file; the turn id and speaker are read from
-the file name, and the transcript header line is stripped before extraction.
+`transcript/turn-NNN-(player|dm).md` file **inside the given `--session`'s
+`transcript/` directory**; pointing `--file` at a turn file from another session
+is rejected. The turn id and speaker are read from the file name, and the
+transcript header line is stripped before extraction. `--extract-only` cannot be
+combined with `--extract` (they are mutually exclusive).
 Like `--extract`, this mode re-runs semantic extraction and DM-profile analysis
 but does not re-run the structured-data merge.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1228,6 +1228,30 @@ python tools/ingest_turn.py \
 
 See [`docs/semantic-extraction-design.md`](semantic-extraction-design.md) for full pipeline design.
 
+#### Re-extraction (`--extract-only`)
+
+Pass `--extract-only` to re-run semantic extraction against an **existing** turn
+file without creating a new turn or modifying the raw transcript. Use it to
+re-extract already-ingested turns after a template or model change. The target
+turn is given via `--file` and must be an existing
+`transcript/turn-NNN-(player|dm).md` file; the turn id and speaker are read from
+the file name, and the transcript header line is stripped before extraction.
+Like `--extract`, this mode re-runs semantic extraction and DM-profile analysis
+but does not re-run the structured-data merge.
+
+```bash
+python tools/ingest_turn.py \
+  --session sessions/session-import \
+  --speaker dm \
+  --file sessions/session-import/transcript/turn-022-dm.md \
+  --extract-only \
+  --framework framework-local
+```
+
+`--extract-only` is read-only with respect to `raw/` and `transcript/` files: it
+never appends to `full-transcript.md`, creates a turn file, or updates
+`metadata.json`. To re-extract a whole session, loop over its turn files.
+
 ### Extraction Log
 
 During extraction (batch, segmented, or single-turn), the pipeline writes a per-turn log to `<framework-dir>/extraction-log.jsonl`. Each line is a JSON object recording:

--- a/tests/test_ingest_extract_only.py
+++ b/tests/test_ingest_extract_only.py
@@ -1,0 +1,217 @@
+"""Tests for the --extract-only re-extraction mode of ingest_turn.py (#71).
+
+Covers:
+- --extract-only runs semantic extraction against an existing turn file
+  WITHOUT creating a new turn file or modifying the raw transcript (Rule 1).
+- Clear errors when the target turn file is missing, has a bad name, or
+  --file is omitted.
+- Regression: the normal new-turn ingest flow still creates the turn file
+  and appends to the raw transcript.
+- Pure helpers parse_turn_filename() and strip_turn_header().
+
+All extraction is mocked — no real LLM/GPU is invoked.
+"""
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+import ingest_turn
+
+
+def _make_session(tmp_path):
+    """Create a minimal session dir with one existing DM turn."""
+    session = tmp_path / "session-test"
+    transcript = session / "transcript"
+    raw = session / "raw"
+    transcript.mkdir(parents=True)
+    raw.mkdir(parents=True)
+    turn_file = transcript / "turn-001-dm.md"
+    turn_file.write_text(
+        "# turn-001 — DM\n\nThe innkeeper looks up as you enter.\n",
+        encoding="utf-8",
+    )
+    transcript_md = raw / "full-transcript.md"
+    transcript_md.write_text(
+        "\n---\n\n## turn-001 [dm]\n\nThe innkeeper looks up as you enter.\n",
+        encoding="utf-8",
+    )
+    return session, turn_file, transcript_md
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_parse_turn_filename_dm(self):
+        assert ingest_turn.parse_turn_filename(
+            "sessions/s/transcript/turn-022-dm.md"
+        ) == ("turn-022", "dm")
+
+    def test_parse_turn_filename_player(self):
+        assert ingest_turn.parse_turn_filename("turn-007-player.md") == (
+            "turn-007",
+            "player",
+        )
+
+    def test_parse_turn_filename_rejects_non_turn(self):
+        assert ingest_turn.parse_turn_filename("notes.md") is None
+
+    def test_strip_turn_header_removes_header(self):
+        text = "# turn-001 — DM\n\nThe innkeeper looks up.\n"
+        assert ingest_turn.strip_turn_header(text) == "The innkeeper looks up."
+
+    def test_strip_turn_header_noop_without_header(self):
+        assert ingest_turn.strip_turn_header("Just narrative text.") == (
+            "Just narrative text."
+        )
+
+
+# ---------------------------------------------------------------------------
+# --extract-only behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestExtractOnly:
+    def test_runs_extraction_without_touching_files(self, tmp_path, monkeypatch):
+        session, turn_file, transcript_md = _make_session(tmp_path)
+        before_raw = transcript_md.read_text(encoding="utf-8")
+        before_files = sorted(os.listdir(session / "transcript"))
+
+        calls = []
+        monkeypatch.setattr(
+            ingest_turn,
+            "run_semantic_extraction",
+            lambda turn_id, speaker, text, session_dir, args: calls.append(
+                (turn_id, speaker, text, session_dir)
+            ),
+        )
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "ingest_turn.py",
+                "--session", str(session),
+                "--speaker", "dm",
+                "--file", str(turn_file),
+                "--extract-only",
+                "--framework", str(tmp_path / "framework-local"),
+            ],
+        )
+
+        ingest_turn.main()
+
+        # Extraction ran against the existing turn, header stripped.
+        assert len(calls) == 1
+        turn_id, speaker, text, session_dir = calls[0]
+        assert turn_id == "turn-001"
+        assert speaker == "dm"
+        assert text == "The innkeeper looks up as you enter."
+        assert session_dir == str(session)
+
+        # Rule 1: raw transcript and transcript dir are untouched.
+        assert transcript_md.read_text(encoding="utf-8") == before_raw
+        assert sorted(os.listdir(session / "transcript")) == before_files
+
+    def test_missing_file_errors(self, tmp_path, monkeypatch):
+        session, _turn_file, _transcript_md = _make_session(tmp_path)
+        monkeypatch.setattr(
+            ingest_turn, "run_semantic_extraction",
+            lambda *a, **k: pytest.fail("extraction should not run"),
+        )
+        monkeypatch.setattr(
+            sys, "argv",
+            [
+                "ingest_turn.py",
+                "--session", str(session),
+                "--speaker", "dm",
+                "--file", str(session / "transcript" / "turn-999-dm.md"),
+                "--extract-only",
+            ],
+        )
+        with pytest.raises(SystemExit) as exc:
+            ingest_turn.main()
+        assert exc.value.code == 1
+
+    def test_bad_filename_errors(self, tmp_path, monkeypatch):
+        session, _turn_file, _transcript_md = _make_session(tmp_path)
+        bad = session / "transcript" / "notes.md"
+        bad.write_text("not a turn", encoding="utf-8")
+        monkeypatch.setattr(
+            ingest_turn, "run_semantic_extraction",
+            lambda *a, **k: pytest.fail("extraction should not run"),
+        )
+        monkeypatch.setattr(
+            sys, "argv",
+            [
+                "ingest_turn.py",
+                "--session", str(session),
+                "--speaker", "dm",
+                "--file", str(bad),
+                "--extract-only",
+            ],
+        )
+        with pytest.raises(SystemExit) as exc:
+            ingest_turn.main()
+        assert exc.value.code == 1
+
+    def test_requires_file_not_text(self, tmp_path, monkeypatch):
+        session, _turn_file, _transcript_md = _make_session(tmp_path)
+        monkeypatch.setattr(
+            ingest_turn, "run_semantic_extraction",
+            lambda *a, **k: pytest.fail("extraction should not run"),
+        )
+        monkeypatch.setattr(
+            sys, "argv",
+            [
+                "ingest_turn.py",
+                "--session", str(session),
+                "--speaker", "dm",
+                "--text", "inline text",
+                "--extract-only",
+            ],
+        )
+        with pytest.raises(SystemExit) as exc:
+            ingest_turn.main()
+        assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Regression: normal new-turn ingest still works
+# ---------------------------------------------------------------------------
+
+
+class TestNormalIngestRegression:
+    def test_creates_turn_and_appends_transcript(self, tmp_path, monkeypatch):
+        session = tmp_path / "session-new"
+        session.mkdir()
+
+        # Stub the structured-data extraction the normal flow imports.
+        stub = types.ModuleType("extract_structured_data")
+        stub.extract_and_merge_single_turn = lambda *a, **k: None
+        monkeypatch.setitem(sys.modules, "extract_structured_data", stub)
+
+        monkeypatch.setattr(
+            sys, "argv",
+            [
+                "ingest_turn.py",
+                "--session", str(session),
+                "--speaker", "dm",
+                "--text", "A new turn appears.",
+            ],
+        )
+
+        ingest_turn.main()
+
+        turn_file = session / "transcript" / "turn-001-dm.md"
+        assert turn_file.is_file()
+        assert "A new turn appears." in turn_file.read_text(encoding="utf-8")
+
+        raw = (session / "raw" / "full-transcript.md").read_text(encoding="utf-8")
+        assert "turn-001 [dm]" in raw
+        assert "A new turn appears." in raw

--- a/tests/test_ingest_extract_only.py
+++ b/tests/test_ingest_extract_only.py
@@ -180,6 +180,54 @@ class TestExtractOnly:
             ingest_turn.main()
         assert exc.value.code == 1
 
+    def test_conflicting_extract_flag_errors(self, tmp_path, monkeypatch):
+        session, turn_file, _transcript_md = _make_session(tmp_path)
+        monkeypatch.setattr(
+            ingest_turn, "run_semantic_extraction",
+            lambda *a, **k: pytest.fail("extraction should not run"),
+        )
+        monkeypatch.setattr(
+            sys, "argv",
+            [
+                "ingest_turn.py",
+                "--session", str(session),
+                "--speaker", "dm",
+                "--file", str(turn_file),
+                "--extract-only",
+                "--extract",
+            ],
+        )
+        with pytest.raises(SystemExit) as exc:
+            ingest_turn.main()
+        assert exc.value.code == 1
+
+    def test_file_outside_session_transcript_errors(self, tmp_path, monkeypatch):
+        session, _turn_file, _transcript_md = _make_session(tmp_path)
+        # A correctly-named turn file but belonging to a DIFFERENT session.
+        other = tmp_path / "session-other" / "transcript"
+        other.mkdir(parents=True)
+        foreign = other / "turn-001-dm.md"
+        foreign.write_text(
+            "# turn-001 — DM\n\nForeign session content.\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(
+            ingest_turn, "run_semantic_extraction",
+            lambda *a, **k: pytest.fail("extraction should not run"),
+        )
+        monkeypatch.setattr(
+            sys, "argv",
+            [
+                "ingest_turn.py",
+                "--session", str(session),
+                "--speaker", "dm",
+                "--file", str(foreign),
+                "--extract-only",
+            ],
+        )
+        with pytest.raises(SystemExit) as exc:
+            ingest_turn.main()
+        assert exc.value.code == 1
+
 
 # ---------------------------------------------------------------------------
 # Regression: normal new-turn ingest still works

--- a/tools/ingest_turn.py
+++ b/tools/ingest_turn.py
@@ -215,6 +215,14 @@ def main() -> None:
     # --extract-only: re-run semantic extraction against an EXISTING turn file
     # without creating a new turn or modifying any raw/transcript file (#71).
     if args.extract_only:
+        if args.extract:
+            print(
+                "ERROR: --extract-only and --extract are mutually exclusive; "
+                "--extract-only re-extracts an existing turn without ingesting, "
+                "so it cannot be combined with --extract.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         if not args.file:
             print(
                 "ERROR: --extract-only requires --file pointing to an existing "
@@ -224,6 +232,19 @@ def main() -> None:
             sys.exit(1)
         if not os.path.isfile(args.file):
             print(f"ERROR: Turn file not found: {args.file}", file=sys.stderr)
+            sys.exit(1)
+        # Guard against pointing --file at a turn file outside this session's
+        # transcript/ directory, which would pollute the wrong session's
+        # framework outputs. The file must live in <session>/transcript/.
+        expected_dir = os.path.realpath(os.path.join(session_dir, "transcript"))
+        actual_dir = os.path.realpath(os.path.dirname(args.file))
+        if actual_dir != expected_dir:
+            print(
+                "ERROR: --extract-only --file must be a turn file inside this "
+                f"session's transcript directory ({expected_dir}); got "
+                f"{os.path.realpath(args.file)}.",
+                file=sys.stderr,
+            )
             sys.exit(1)
         parsed = parse_turn_filename(args.file)
         if parsed is None:

--- a/tools/ingest_turn.py
+++ b/tools/ingest_turn.py
@@ -69,7 +69,95 @@ def update_metadata(session_dir: str, turn_count: int) -> None:
         f.write("\n")
 
 
-def main() -> None:
+_TURN_FILE_RE = re.compile(r"^turn-(\d+)-(player|dm)\.md$")
+
+
+def parse_turn_filename(path: str):
+    """Return (turn_id, speaker) parsed from an existing turn file name.
+
+    Returns None if the basename does not match the turn-NNN-(player|dm).md
+    convention used by write_turn_file().
+    """
+    m = _TURN_FILE_RE.match(os.path.basename(path))
+    if not m:
+        return None
+    return f"turn-{int(m.group(1)):03d}", m.group(2)
+
+
+def strip_turn_header(text: str) -> str:
+    """Drop the leading "# turn-NNN — SPEAKER" header line if present.
+
+    Turn files written by write_turn_file() begin with a markdown header that
+    is not part of the narrative text; remove it before extraction so the LLM
+    sees the same content as a freshly ingested turn.
+    """
+    lines = text.lstrip("\n").splitlines()
+    if lines and lines[0].lstrip().startswith("# turn-"):
+        return "\n".join(lines[1:]).strip()
+    return text.strip()
+
+
+def run_semantic_extraction(turn_id, speaker, text, session_dir, args) -> None:
+    """Run LLM-based semantic extraction (and DM profile analysis) for a turn.
+
+    Shared by the normal --extract flow and the --extract-only flow so both
+    use exactly the same extraction code path.
+    """
+    try:
+        from semantic_extraction import extract_semantic_single
+
+        llm_overrides = {}
+        if args.model:
+            llm_overrides["model"] = args.model
+        if args.base_url:
+            llm_overrides["base_url"] = args.base_url
+
+        extract_semantic_single(
+            turn_id, speaker, text, session_dir, framework_dir=args.framework,
+            overrides=llm_overrides or None,
+        )
+    except ModuleNotFoundError as exc:
+        if exc.name == "semantic_extraction":
+            print(
+                "WARNING: Semantic extraction skipped because "
+                "'semantic_extraction' is not available.",
+                file=sys.stderr,
+            )
+        else:
+            raise
+    except Exception as exc:
+        print(f"WARNING: Semantic extraction failed: {exc}", file=sys.stderr)
+
+    # DM profile analysis — update behavioral profile from DM turns (#260)
+    if speaker == "dm":
+        try:
+            from dm_profile_analyzer import analyze_single_turn
+
+            llm_overrides = {}
+            if args.model:
+                llm_overrides["model"] = args.model
+            if args.base_url:
+                llm_overrides["base_url"] = args.base_url
+
+            analyze_single_turn(
+                turn_id, speaker, text,
+                framework_dir=args.framework,
+                overrides=llm_overrides or None,
+            )
+        except ModuleNotFoundError as exc:
+            if exc.name == "dm_profile_analyzer":
+                print(
+                    "WARNING: DM profile analysis skipped because "
+                    "'dm_profile_analyzer' is not available.",
+                    file=sys.stderr,
+                )
+            else:
+                raise
+        except Exception as exc:
+            print(f"WARNING: DM profile analysis failed: {exc}", file=sys.stderr)
+
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Ingest a new turn into a session.")
     parser.add_argument("--session", required=True, help="Path to the session directory.")
     parser.add_argument(
@@ -88,6 +176,14 @@ def main() -> None:
         help="Run LLM-based semantic extraction after ingesting the turn.",
     )
     parser.add_argument(
+        "--extract-only",
+        action="store_true",
+        default=False,
+        help="Re-run semantic extraction against an EXISTING turn file "
+             "(given via --file) without creating a new turn file or "
+             "modifying the transcript. Requires --file.",
+    )
+    parser.add_argument(
         "--framework",
         default="framework",
         help="Path to the framework directory for catalog output "
@@ -104,12 +200,57 @@ def main() -> None:
         default=None,
         help="Override the LLM API base URL from config/llm.json for this run.",
     )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
     args = parser.parse_args()
 
     session_dir = args.session
     if not os.path.isdir(session_dir):
         print(f"ERROR: Session directory not found: {session_dir}", file=sys.stderr)
         sys.exit(1)
+
+    # --extract-only: re-run semantic extraction against an EXISTING turn file
+    # without creating a new turn or modifying any raw/transcript file (#71).
+    if args.extract_only:
+        if not args.file:
+            print(
+                "ERROR: --extract-only requires --file pointing to an existing "
+                "turn file (e.g. transcript/turn-022-dm.md).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not os.path.isfile(args.file):
+            print(f"ERROR: Turn file not found: {args.file}", file=sys.stderr)
+            sys.exit(1)
+        parsed = parse_turn_filename(args.file)
+        if parsed is None:
+            print(
+                "ERROR: --file must be a turn file named like "
+                "'turn-NNN-(player|dm).md' for --extract-only; got "
+                f"{os.path.basename(args.file)}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        turn_id, file_speaker = parsed
+        if file_speaker != args.speaker:
+            print(
+                f"WARNING: --speaker {args.speaker} does not match the turn file "
+                f"speaker '{file_speaker}'; using '{file_speaker}' from the file.",
+                file=sys.stderr,
+            )
+        speaker = file_speaker
+        with open(args.file, "r", encoding="utf-8") as f:
+            text = strip_turn_header(f.read())
+        if not text:
+            print(f"ERROR: Turn file is empty: {args.file}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"Re-extracting {turn_id} ({speaker}) from {args.file}")
+        run_semantic_extraction(turn_id, speaker, text, session_dir, args)
+        return
 
     transcript_dir = os.path.join(session_dir, "transcript")
     raw_dir = os.path.join(session_dir, "raw")
@@ -156,58 +297,7 @@ def main() -> None:
 
     # Semantic extraction — LLM-based entity/relationship/event extraction (#43)
     if args.extract:
-        try:
-            from semantic_extraction import extract_semantic_single
-
-            llm_overrides = {}
-            if args.model:
-                llm_overrides["model"] = args.model
-            if args.base_url:
-                llm_overrides["base_url"] = args.base_url
-
-            extract_semantic_single(
-                turn_id, args.speaker, text, session_dir, framework_dir=args.framework,
-                overrides=llm_overrides or None,
-            )
-        except ModuleNotFoundError as exc:
-            if exc.name == "semantic_extraction":
-                print(
-                    "WARNING: Semantic extraction skipped because "
-                    "'semantic_extraction' is not available.",
-                    file=sys.stderr,
-                )
-            else:
-                raise
-        except Exception as exc:
-            print(f"WARNING: Semantic extraction failed: {exc}", file=sys.stderr)
-
-        # DM profile analysis — update behavioral profile from DM turns (#260)
-        if args.speaker == "dm":
-            try:
-                from dm_profile_analyzer import analyze_single_turn
-
-                llm_overrides = {}
-                if args.model:
-                    llm_overrides["model"] = args.model
-                if args.base_url:
-                    llm_overrides["base_url"] = args.base_url
-
-                analyze_single_turn(
-                    turn_id, args.speaker, text,
-                    framework_dir=args.framework,
-                    overrides=llm_overrides or None,
-                )
-            except ModuleNotFoundError as exc:
-                if exc.name == "dm_profile_analyzer":
-                    print(
-                        "WARNING: DM profile analysis skipped because "
-                        "'dm_profile_analyzer' is not available.",
-                        file=sys.stderr,
-                    )
-                else:
-                    raise
-            except Exception as exc:
-                print(f"WARNING: DM profile analysis failed: {exc}", file=sys.stderr)
+        run_semantic_extraction(turn_id, args.speaker, text, session_dir, args)
 
     print()
     print("Next steps:")


### PR DESCRIPTION
## Summary

Adds an `--extract-only` mode to `tools/ingest_turn.py` that re-runs semantic
extraction against an **existing** turn file without creating a new turn or
modifying the raw transcript. This makes it easy to re-extract already-ingested
turns after a prompt-template or model change.

Closes #71

## Changes

- **New `--extract-only` flag**: re-runs extraction against an existing
  `transcript/turn-NNN-(player|dm).md` file supplied via `--file`. The turn id
  and speaker are parsed from the file name, and the transcript header line is
  stripped before extraction.
- **Shared helper**: both the normal `--extract` flow and the new
  `--extract-only` flow route through `run_semantic_extraction()`, so they use
  exactly the same semantic-extraction and DM-profile-analysis code path.
- **Validation**: the target file must exist and match the expected
  `turn-NNN-(player|dm).md` naming pattern.
- **Tests**: 10 new tests in `tests/test_ingest_extract_only.py` covering flag
  parsing, file-name validation, header stripping, read-only guarantees, and the
  shared helper path.
- **Docs**: updated `docs/usage.md` (new "Re-extraction" subsection) and
  `docs/architecture.md`.

## Testing

- `pytest -k ingest` — 10 new tests pass.
- `python tools/validate.py --all` — 27/27 pass.

## Rule 1 note

`--extract-only` is read-only with respect to `raw/` and `transcript/` files: it
never appends to `full-transcript.md`, creates a turn file, or updates
`metadata.json`. It only reads the existing turn file and writes derived
extraction outputs.
