### PR TITLE
fix: clarify dropped-turn wording and verdict label in paired A/B scorer (PR #488 follow-up)

### DIFF
--- a/docs/ab-test-checklist.md
+++ b/docs/ab-test-checklist.md
@@ -153,7 +153,7 @@ python tools/validate_extraction.py \
 ## PR Report
 
 - [ ] A/B Test Results posted as a PR comment (see template in `docs/ab-test-standard.md` §5.1)
-- [ ] Multi-run paired token-metric score reported: matched-call turn count, weighted Δ, effect-size-vs-noise-floor, and SEPARABLE / WITHIN-NOISE verdict (standard §0)
+- [ ] Multi-run paired token-metric score reported: matched-call turn count, weighted Δ, effect-size-vs-noise-floor, and SEPARABLE / NOT SEPARABLE verdict (standard §0)
 - [ ] Noise Floor (A-vs-A) table included in PR comment (§5.1)
 - [ ] All tables filled with mean ± σ values
 - [ ] Zero BLOCK statuses

--- a/tools/ab_paired_score.py
+++ b/tools/ab_paired_score.py
@@ -441,7 +441,8 @@ def format_report(
     lines.append(
         f"  runs: A={n_a}  B={n_b}   "
         f"matched-call-COUNT turns: {matched}/{population_total} "
-        f"({pct:.1f}%); {dropped} dropped due to call-count divergence"
+        f"({pct:.1f}%); {dropped} dropped (missing from a run, "
+        f"zero {phase} calls, or divergent call count)"
     )
     lines.append(
         "  NOTE: matched turns are a SURVIVOR subset (matching conditions on a "
@@ -459,8 +460,9 @@ def format_report(
         )
     if matched == 0:
         lines.append(
-            "  No matched-call-COUNT turns: every common turn had a divergent "
-            "entity_detail call count across runs. Nothing to score."
+            "  No matched-call-COUNT turns: every common turn was excluded "
+            f"(missing from a run, zero {phase} calls, or a divergent "
+            f"{phase} call count across runs). Nothing to score."
         )
         return "\n".join(lines)
     nf = summary["noise_floor"]


### PR DESCRIPTION
## Summary

Follow-up to PR #488 (already merged). The paired multi-run A/B scorer landed with three unresolved Copilot review threads that were never addressed before merge. This PR fixes them on `main`.

## Changes

- **`tools/ab_paired_score.py`** — The report line `"N dropped due to call-count divergence"` was misleading: `matched_call_turns()` also excludes turns that are missing from a run or have zero phase calls (the drop count is `population_total − matched`, and `population_total` is the union across runs). Reworded to list all exclusion reasons.
- **`tools/ab_paired_score.py`** — The zero-match message (`"every common turn had a divergent entity_detail call count"`) had the same overstatement; reworded to reflect all exclusion reasons and parameterized on `phase`.
- **`docs/ab-test-checklist.md`** — Fixed the verdict label `SEPARABLE / WITHIN-NOISE` → `SEPARABLE / NOT SEPARABLE` to match the canonical wording used by the tool and the standard.

## Testing

- `python3 -m pytest tests/test_ab_paired_score.py -q` → 35 passed
- `ruff check tools/ab_paired_score.py` → clean

## References

Addresses Copilot review comments on PR #488:
- `tools/ab_paired_score.py` line 445 (dropped-turn wording)
- `tools/ab_paired_score.py` line 464 (zero-match message)
- `docs/ab-test-checklist.md` line 156 (verdict label)
