### PR TITLE
fix: clarify A/B paired-score drop reasons and align checklist verdict terms

### DIFF
--- a/docs/ab-test-checklist.md
+++ b/docs/ab-test-checklist.md
@@ -153,7 +153,7 @@ python tools/validate_extraction.py \
 ## PR Report
 
 - [ ] A/B Test Results posted as a PR comment (see template in `docs/ab-test-standard.md` §5.1)
-- [ ] Multi-run paired token-metric score reported: matched-call turn count, weighted Δ, effect-size-vs-noise-floor, and SEPARABLE / WITHIN-NOISE verdict (standard §0)
+- [ ] Multi-run paired token-metric score reported: matched-call turn count, weighted Δ, effect-size-vs-noise-floor, and SEPARABLE / NOT SEPARABLE verdict (standard §0)
 - [ ] Noise Floor (A-vs-A) table included in PR comment (§5.1)
 - [ ] All tables filled with mean ± σ values
 - [ ] Zero BLOCK statuses

--- a/tools/ab_paired_score.py
+++ b/tools/ab_paired_score.py
@@ -461,8 +461,8 @@ def format_report(
     if matched == 0:
         lines.append(
             "  No matched-call-COUNT turns: every turn was missing from a run, "
-            "had zero entity_detail phase-calls, or had a divergent "
-            "entity_detail call count across runs. Nothing to score."
+            f"had zero {phase} phase-calls, or had a divergent "
+            f"{phase} call count across runs. Nothing to score."
         )
         return "\n".join(lines)
     nf = summary["noise_floor"]

--- a/tools/ab_paired_score.py
+++ b/tools/ab_paired_score.py
@@ -441,7 +441,8 @@ def format_report(
     lines.append(
         f"  runs: A={n_a}  B={n_b}   "
         f"matched-call-COUNT turns: {matched}/{population_total} "
-        f"({pct:.1f}%); {dropped} dropped due to call-count divergence"
+        f"({pct:.1f}%); {dropped} dropped (missing from a run, "
+        f"zero phase-calls, or divergent call count)"
     )
     lines.append(
         "  NOTE: matched turns are a SURVIVOR subset (matching conditions on a "
@@ -459,7 +460,8 @@ def format_report(
         )
     if matched == 0:
         lines.append(
-            "  No matched-call-COUNT turns: every common turn had a divergent "
+            "  No matched-call-COUNT turns: every turn was missing from a run, "
+            "had zero entity_detail phase-calls, or had a divergent "
             "entity_detail call count across runs. Nothing to score."
         )
         return "\n".join(lines)

--- a/tools/ab_paired_score.py
+++ b/tools/ab_paired_score.py
@@ -442,7 +442,7 @@ def format_report(
         f"  runs: A={n_a}  B={n_b}   "
         f"matched-call-COUNT turns: {matched}/{population_total} "
         f"({pct:.1f}%); {dropped} dropped (missing from a run, "
-        f"zero phase-calls, or divergent call count)"
+        f"zero {phase} calls, or divergent {phase} call count)"
     )
     lines.append(
         "  NOTE: matched turns are a SURVIVOR subset (matching conditions on a "


### PR DESCRIPTION
## Summary

Addresses trivial, wording-only Copilot nits raised on #488 (which
merged the paired multi-run A/B scoring on the `entity_detail` token
metric, from #487). No logic changes.

**Consolidation note:** This PR supersedes and consolidates the duplicate
#489 (the autonomous fix-pr488 follow-up), which was opened independently
for the same nits. #490 is now a strict superset: it includes #489's
unique phase-parameterization of the drop-summary line and resolves the
remaining Copilot review nits that #489 surfaced. #489 has been closed in
favor of this consolidated PR.

## Nit 1 — drop-reason summary line (`tools/ab_paired_score.py`)

The report summary said `N dropped due to call-count divergence`, but
`matched_call_turns()` drops a turn for any of three reasons: it is
missing from at least one run, it has zero/no `entity_detail` phase-calls
in some run, or its call counts diverge across runs. Reworded to:
`N dropped (missing from a run, zero {phase} calls, or divergent {phase} call count)`.
The reasons are now phase-parameterized, so the report names which
phase's calls diverged for any `--phase` (ported from #489 plus the two
remaining Copilot nits resolved).

## Nit 2 — 0-matched message (`tools/ab_paired_score.py`)

The "no matched turns" message claimed `every common turn had a divergent
entity_detail call count`, which has the same inaccuracy. Reworded to
cover missing turns and zero-phase-call turns as well, and parameterized
on `phase`. It avoids the word "common" so it does not contradict the
"missing from a run" reason.

## Nit 3 — checklist verdict terminology (`docs/ab-test-checklist.md`)

The PR-report checklist referred to a `SEPARABLE / WITHIN-NOISE` verdict,
but the tool (`format_report`) and `docs/ab-test-standard.md` both use
`SEPARABLE / NOT SEPARABLE`. Aligned the checklist with the tool.

## Testing

- `pytest tests/test_ab_paired_score.py` → 35 passed.

Closes nothing on its own; follow-up to #488 / #487. Consolidates #489.
