### PR TITLE
fix: make ingest_turn --extract-only exit non-zero on extraction failure

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,8 +67,11 @@ transcript, for re-extraction after a template or model change. In this mode the
 process exits non-zero when extraction actually **errors** for the turn — the LLM
 client is unavailable, `extract_and_merge` raises, or a phase reports an
 unrecoverable failure (an LLM/parse error, or an exception in the
-discovery / detail / relationship / event / **temporal** phases). These are
-failures that a re-extraction could fix, so automated/incremental callers can
+discovery / detail / relationship / event / **temporal** phases). It also exits
+non-zero when the optional `semantic_extraction` module or its LLM dependencies
+are unavailable (the extraction entry point returns failure), so callers without
+the optional deps get a clear failure signal. These are failures that a
+re-extraction could fix, so automated/incremental callers can
 detect them instead of silently advancing past an un-extracted turn.
 
 The exit code deliberately stays **zero** for the pipeline's intentional

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,25 @@ or via the `--extract` flag on `ingest_turn.py` (incremental). It requires an LL
 endpoint configured in `config/llm.json` and gracefully degrades if unavailable.
 The `--extract-only` flag on `ingest_turn.py` re-runs extraction against an existing
 turn file (given via `--file`) without creating a new turn or modifying the raw
-transcript, for re-extraction after a template or model change.
+transcript, for re-extraction after a template or model change. In this mode the
+process exits non-zero when extraction actually **errors** for the turn — the LLM
+client is unavailable, `extract_and_merge` raises, or a phase reports an
+unrecoverable failure (an LLM/parse error, or an exception in the
+discovery / detail / relationship / event / **temporal** phases). These are
+failures that a re-extraction could fix, so automated/incremental callers can
+detect them instead of silently advancing past an un-extracted turn.
+
+The exit code deliberately stays **zero** for the pipeline's intentional
+best-effort behaviour: an `entity_detail` completion that fails schema validation
+and cannot be repaired is dropped (the entity still merges from discovery; only
+the malformed enrichment is lost), and that drop is recorded in the per-turn log's
+`validation_failures` (auditable, not silent). Failing the turn there would stall
+re-extraction forever, since the deterministic extractor would reproduce the same
+invalid output. A turn that legitimately yields zero entities or no temporal
+signals also exits 0. PC-extraction failures are tracked separately (`pc_ok` /
+`pc_error`) and do not drive the exit code. The new-entity detail-validation-drop
+case (a NEW entity lost from the catalog when its detail is unrepairable; exit 0,
+recorded in `validation_failures`) is a known limitation tracked in issue #528.
 
 Planning layer derivation (`derive_planning_layer.py`) bridges the gap between
 extracted catalog data and the derived planning files consumed by

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1341,6 +1341,11 @@ re-extraction could fix, so automated or incremental callers (e.g. those using
 `subprocess` with `check=True`) can detect them instead of silently advancing past
 an un-extracted turn.
 
+If the optional `semantic_extraction` module or its LLM dependencies are not
+installed, `--extract-only` also exits **non-zero** (the extraction entry point
+returns failure), so callers running without the optional deps get a clear
+failure signal rather than a silent no-op.
+
 The command stays at exit **0** for the pipeline's intentional best-effort
 behaviour and for legitimately empty turns:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1332,6 +1332,33 @@ python tools/ingest_turn.py \
 never appends to `full-transcript.md`, creates a turn file, or updates
 `metadata.json`. To re-extract a whole session, loop over its turn files.
 
+Unlike the normal `--extract` flow (which warns and continues on extraction
+problems), `--extract-only` exits **non-zero** when semantic extraction actually
+**errors** for the turn — the LLM client is unavailable, extraction raises, or a
+phase reports an unrecoverable failure (an LLM/parse error, or an exception in the
+discovery, detail, relationship, event, or temporal phase). These are failures a
+re-extraction could fix, so automated or incremental callers (e.g. those using
+`subprocess` with `check=True`) can detect them instead of silently advancing past
+an un-extracted turn.
+
+The command stays at exit **0** for the pipeline's intentional best-effort
+behaviour and for legitimately empty turns:
+
+- An `entity_detail` completion that fails schema validation and cannot be
+  repaired is **dropped** — the entity still merges from discovery, only the
+  malformed enrichment is lost. The drop is recorded in the per-turn
+  extraction-log `validation_failures` field (auditable, not silent), so it does
+  **not** fail the turn. Failing it would stall re-extraction permanently, because
+  the deterministic extractor would reproduce the same invalid output.
+- A turn that legitimately yields zero entities, or no temporal signals, exits 0.
+- PC-character extraction failures are tracked separately (`pc_ok` / `pc_error`)
+  and do not affect the exit code.
+
+Known limitation (issue #528): when the dropped detail belongs to a **new**
+entity, that entity is lost from the catalog (it remains only in
+`discovery_proposals`). This is the best-effort drop case above (exit 0, recorded
+in `validation_failures`); promoting a schema-valid stub instead is tracked there.
+
 ### Extraction Log
 
 During extraction (batch, segmented, or single-turn), the pipeline writes a per-turn log to `<framework-dir>/extraction-log.jsonl`. Each line is a JSON object recording:

--- a/tests/test_ingest_extract_only.py
+++ b/tests/test_ingest_extract_only.py
@@ -84,12 +84,13 @@ class TestExtractOnly:
         before_files = sorted(os.listdir(session / "transcript"))
 
         calls = []
+        def _fake_extract(turn_id, speaker, text, session_dir, args):
+            calls.append((turn_id, speaker, text, session_dir))
+            return True
         monkeypatch.setattr(
             ingest_turn,
             "run_semantic_extraction",
-            lambda turn_id, speaker, text, session_dir, args: calls.append(
-                (turn_id, speaker, text, session_dir)
-            ),
+            _fake_extract,
         )
         monkeypatch.setattr(
             sys,
@@ -263,3 +264,311 @@ class TestNormalIngestRegression:
         raw = (session / "raw" / "full-transcript.md").read_text(encoding="utf-8")
         assert "turn-001 [dm]" in raw
         assert "A new turn appears." in raw
+
+
+# ---------------------------------------------------------------------------
+# --extract-only exit code is honest about extraction failure
+# ---------------------------------------------------------------------------
+
+
+import semantic_extraction  # noqa: E402
+
+
+def _patch_extraction_internals(
+    monkeypatch, *, llm_raises=False, merge_raises=False, turn_failed=False
+):
+    """Patch the module-level dependencies of extract_semantic_single so the
+    REAL function runs end-to-end without any LLM/GPU or file side effects.
+
+    The three failure modes mirror the production swallow sites:
+    - llm_raises   -> (a) LLMClient unavailable.
+    - merge_raises -> (b) extract_and_merge raises.
+    - turn_failed  -> (c) extract_and_merge returns turn_failed=True.
+    """
+    if llm_raises:
+        def _bad_client(*a, **k):
+            raise semantic_extraction.LLMExtractionError("no LLM available")
+        monkeypatch.setattr(semantic_extraction, "LLMClient", _bad_client)
+    else:
+        class _DummyClient:
+            def __init__(self, *a, **k):
+                self.config = {}
+
+            def enable_raw_io_capture(self, *a, **k):
+                pass
+        monkeypatch.setattr(semantic_extraction, "LLMClient", _DummyClient)
+
+    monkeypatch.setattr(semantic_extraction, "_reset_pc_failure_tracking", lambda: None)
+    monkeypatch.setattr(semantic_extraction, "_raw_io_capture_enabled", lambda cfg: False)
+    monkeypatch.setattr(semantic_extraction, "load_catalogs", lambda d: {})
+    monkeypatch.setattr(semantic_extraction, "load_events", lambda d: [])
+    monkeypatch.setattr(semantic_extraction, "load_timeline", lambda d: [])
+    monkeypatch.setattr(semantic_extraction, "_ensure_player_character", lambda c, t: None)
+    monkeypatch.setattr(semantic_extraction, "_write_extraction_log", lambda p, r: None)
+    monkeypatch.setattr(semantic_extraction, "mark_dormant_relationships", lambda c, t: 0)
+    monkeypatch.setattr(semantic_extraction, "save_catalogs", lambda d, c: None)
+    monkeypatch.setattr(semantic_extraction, "save_events", lambda d, e: None)
+    monkeypatch.setattr(semantic_extraction, "save_timeline", lambda d, t: None)
+
+    if merge_raises:
+        def _bad_merge(*a, **k):
+            raise RuntimeError("merge boom")
+        monkeypatch.setattr(semantic_extraction, "extract_and_merge", _bad_merge)
+    else:
+        def _ok_merge(turn, catalogs, events_list, llm, min_confidence, **k):
+            return catalogs, events_list, turn_failed, {"turn_id": turn["turn_id"]}
+        monkeypatch.setattr(semantic_extraction, "extract_and_merge", _ok_merge)
+
+
+def _stub_dm_profile(monkeypatch):
+    """Prevent DM-profile analysis from touching a real LLM."""
+    stub = types.ModuleType("dm_profile_analyzer")
+    stub.analyze_single_turn = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "dm_profile_analyzer", stub)
+
+
+def _extract_only_argv(session, turn_file, tmp_path):
+    return [
+        "ingest_turn.py",
+        "--session", str(session),
+        "--speaker", "dm",
+        "--file", str(turn_file),
+        "--extract-only",
+        "--framework", str(tmp_path / "framework-local"),
+    ]
+
+
+class TestExtractOnlyExitCode:
+    """--extract-only must exit non-zero when extraction actually fails so a
+    caller using subprocess check=True can detect it (companion to private
+    advisor Fix A)."""
+
+    def test_success_exits_zero(self, tmp_path, monkeypatch):
+        session, turn_file, _md = _make_session(tmp_path)
+        _patch_extraction_internals(monkeypatch)
+        _stub_dm_profile(monkeypatch)
+        monkeypatch.setattr(sys, "argv", _extract_only_argv(session, turn_file, tmp_path))
+        # Returns normally (no SystemExit) on success.
+        ingest_turn.main()
+
+    def test_zero_entities_no_failure_exits_zero(self, tmp_path, monkeypatch):
+        # A legitimately entity-free turn (empty catalogs, turn_failed=False)
+        # must NOT be treated as a failure.
+        session, turn_file, _md = _make_session(tmp_path)
+        _patch_extraction_internals(monkeypatch, turn_failed=False)
+        _stub_dm_profile(monkeypatch)
+        monkeypatch.setattr(sys, "argv", _extract_only_argv(session, turn_file, tmp_path))
+        ingest_turn.main()
+
+    def test_llm_unavailable_exits_nonzero(self, tmp_path, monkeypatch):
+        # Case (a): LLMClient init fails.
+        session, turn_file, _md = _make_session(tmp_path)
+        _patch_extraction_internals(monkeypatch, llm_raises=True)
+        _stub_dm_profile(monkeypatch)
+        monkeypatch.setattr(sys, "argv", _extract_only_argv(session, turn_file, tmp_path))
+        with pytest.raises(SystemExit) as exc:
+            ingest_turn.main()
+        assert exc.value.code == 1
+
+    def test_merge_raises_exits_nonzero(self, tmp_path, monkeypatch):
+        # Case (b): extract_and_merge raises.
+        session, turn_file, _md = _make_session(tmp_path)
+        _patch_extraction_internals(monkeypatch, merge_raises=True)
+        _stub_dm_profile(monkeypatch)
+        monkeypatch.setattr(sys, "argv", _extract_only_argv(session, turn_file, tmp_path))
+        with pytest.raises(SystemExit) as exc:
+            ingest_turn.main()
+        assert exc.value.code == 1
+
+    def test_turn_failed_exits_nonzero(self, tmp_path, monkeypatch):
+        # Case (c): per-phase failure (turn_failed=True) with NO exception.
+        # This is the previously-undetectable common case.
+        session, turn_file, _md = _make_session(tmp_path)
+        _patch_extraction_internals(monkeypatch, turn_failed=True)
+        _stub_dm_profile(monkeypatch)
+        monkeypatch.setattr(sys, "argv", _extract_only_argv(session, turn_file, tmp_path))
+        with pytest.raises(SystemExit) as exc:
+            ingest_turn.main()
+        assert exc.value.code == 1
+
+
+class TestExtractSemanticSingleReturn:
+    """Unit-level: extract_semantic_single returns an honest success bool."""
+
+    def _run(self, tmp_path, monkeypatch, **kw):
+        _patch_extraction_internals(monkeypatch, **kw)
+        return semantic_extraction.extract_semantic_single(
+            "turn-001", "dm", "The innkeeper looks up.",
+            str(tmp_path / "session"),
+            framework_dir=str(tmp_path / "framework-local"),
+        )
+
+    def test_returns_true_on_success(self, tmp_path, monkeypatch):
+        assert self._run(tmp_path, monkeypatch) is True
+
+    def test_returns_false_when_llm_unavailable(self, tmp_path, monkeypatch):
+        assert self._run(tmp_path, monkeypatch, llm_raises=True) is False
+
+    def test_returns_false_when_merge_raises(self, tmp_path, monkeypatch):
+        assert self._run(tmp_path, monkeypatch, merge_raises=True) is False
+
+    def test_returns_false_when_turn_failed(self, tmp_path, monkeypatch):
+        assert self._run(tmp_path, monkeypatch, turn_failed=True) is False
+
+
+# ---------------------------------------------------------------------------
+# extract_and_merge: which phase outcomes flip turn_failed (the exit-code
+# source).  These exercise the REAL extract_and_merge (LLM stubbed, no GPU) and
+# chain with TestExtractOnlyExitCode above: a phase that flips turn_failed=True
+# propagates to a non-zero --extract-only exit, while an intentional best-effort
+# drop keeps turn_failed=False (exit 0) yet stays auditable in the log.
+# ---------------------------------------------------------------------------
+
+
+def _phase_stub_llm(*, discovery_entities=None, detail_for=None):
+    """Stub LLM driving the real extract_and_merge.
+
+    discovery_entities: list of discovery proposal dicts (default empty).
+    detail_for: optional ``{entity_marker: entity_dict}`` mapping; when a
+        detail user-prompt mentions ``entity_marker`` the mapped entity is
+        returned (used to feed a schema-invalid detail for a discovered
+        entity).  The always-on char-player detail returns a valid PC.
+    """
+    from unittest.mock import MagicMock
+
+    discovery_entities = discovery_entities or []
+    detail_for = detail_for or {}
+    llm = MagicMock()
+    llm.default_timeout = 10
+    llm.pc_max_tokens = 4096
+    llm.delay = MagicMock()
+    llm.config = {"checkpoint_interval": 100}
+
+    _good_pc = {
+        "id": "char-player",
+        "name": "Player Character",
+        "type": "character",
+        "identity": "The player character.",
+        "first_seen_turn": "turn-001",
+        "last_updated_turn": "turn-001",
+    }
+
+    def _extract_json(system_prompt, user_prompt, timeout=None, max_tokens=None,
+                      schema=None, temperature=None, capture=None):
+        sp = system_prompt.lower()
+        if "discover" in sp or "discovery" in sp:
+            return {"entities": list(discovery_entities)}
+        if "detail" in sp:
+            for marker, entity in detail_for.items():
+                if marker in user_prompt:
+                    return {"entity": entity}
+            return {"entity": _good_pc}
+        if "relationship" in sp:
+            return {"relationships": []}
+        if "event" in sp:
+            return {"events": []}
+        return {}
+
+    llm.extract_json = MagicMock(side_effect=_extract_json)
+    return llm
+
+
+class TestPhaseOutcomeDrivesExitCode:
+    """extract_and_merge sets turn_failed for phase ERRORS (exceptions /
+    unrecoverable phase failures) but NOT for intentional best-effort drops."""
+
+    def _fresh_catalogs(self):
+        return {fn: [] for fn in semantic_extraction.CATALOG_KEYS}
+
+    def test_temporal_exception_sets_turn_failed(self, monkeypatch):
+        """A RAISED temporal-extraction error -> turn_failed=True (so
+        --extract-only exits non-zero and the turn is re-extractable)."""
+        monkeypatch.setattr(semantic_extraction, "load_template",
+                            lambda name: f"{name} template")
+        semantic_extraction._reset_pc_failure_tracking()
+
+        def _boom(*a, **k):
+            raise RuntimeError("temporal boom")
+        monkeypatch.setattr(semantic_extraction, "extract_temporal_signals", _boom)
+
+        llm = _phase_stub_llm()
+        turn = {"turn_id": "turn-001", "speaker": "dm", "text": "Time passes."}
+        _c, _e, failed, log = semantic_extraction.extract_and_merge(
+            turn, self._fresh_catalogs(), [], llm, min_confidence=0.6, timeline=[],
+        )
+        assert failed is True
+        assert log["temporal_ok"] is False
+        assert "temporal boom" in (log["temporal_error"] or "")
+
+    def test_temporal_no_signals_is_success(self, monkeypatch):
+        """Legitimate 'no temporal signals' is NOT a failure (exit 0)."""
+        monkeypatch.setattr(semantic_extraction, "load_template",
+                            lambda name: f"{name} template")
+        semantic_extraction._reset_pc_failure_tracking()
+        monkeypatch.setattr(semantic_extraction, "extract_temporal_signals",
+                            lambda *a, **k: [])
+
+        llm = _phase_stub_llm()
+        turn = {"turn_id": "turn-001", "speaker": "dm", "text": "Nothing temporal."}
+        _c, _e, failed, log = semantic_extraction.extract_and_merge(
+            turn, self._fresh_catalogs(), [], llm, min_confidence=0.6, timeline=[],
+        )
+        assert failed is False
+        assert log["temporal_ok"] is True
+
+    def test_zero_entity_turn_is_success(self, monkeypatch):
+        """An empty/sparse turn (no discoveries, no signals) exits 0 — no false
+        stall."""
+        monkeypatch.setattr(semantic_extraction, "load_template",
+                            lambda name: f"{name} template")
+        semantic_extraction._reset_pc_failure_tracking()
+        llm = _phase_stub_llm(discovery_entities=[])
+        turn = {"turn_id": "turn-001", "speaker": "dm", "text": "A quiet moment."}
+        _c, _e, failed, _log = semantic_extraction.extract_and_merge(
+            turn, self._fresh_catalogs(), [], llm, min_confidence=0.6,
+        )
+        assert failed is False
+
+    def test_entity_detail_validation_drop_is_best_effort(self, monkeypatch):
+        """CONTRACT: an unrepairable entity_detail validation failure for a
+        DISCOVERED entity is an intentional best-effort drop — turn_failed stays
+        False (exit 0) so the deterministic extractor does not stall — but the
+        drop is RECORDED in the extraction log's validation_failures (NOT
+        silent)."""
+        monkeypatch.setattr(semantic_extraction, "load_template",
+                            lambda name: f"{name} template")
+        semantic_extraction._reset_pc_failure_tracking()
+        semantic_extraction._drain_validation_failures()  # clean buffer
+
+        # identity must be a string; 123 is an unrepairable schema violation.
+        bad_detail = {
+            "id": "char-elder",
+            "name": "Elder",
+            "type": "character",
+            "identity": 123,
+            "first_seen_turn": "turn-001",
+            "last_updated_turn": "turn-001",
+        }
+        discovery = [{
+            "name": "Elder", "is_new": True, "proposed_id": "char-elder",
+            "type": "character", "confidence": 0.9, "source_turn": "turn-001",
+        }]
+        llm = _phase_stub_llm(
+            discovery_entities=discovery,
+            detail_for={"char-elder": bad_detail, "Elder": bad_detail},
+        )
+        turn = {"turn_id": "turn-001", "speaker": "dm",
+                "text": "The elder watches the road."}
+        _c, _e, failed, log = semantic_extraction.extract_and_merge(
+            turn, self._fresh_catalogs(), [], llm, min_confidence=0.6,
+        )
+        # Best-effort: the malformed detail is dropped but the turn is NOT failed.
+        assert failed is False
+        # NOT silent: the drop is recorded in the per-turn log.
+        failures = log.get("validation_failures", [])
+        assert any(
+            f.get("entity_id") == "char-elder" and f.get("phase") == "entity_detail"
+            for f in failures
+        ), f"validation drop not recorded: {failures!r}"
+
+

--- a/tests/test_turn_failure_tracking.py
+++ b/tests/test_turn_failure_tracking.py
@@ -258,3 +258,49 @@ class TestResumeRetry:
 
         assert "failed_turns" not in progress
         assert progress["completed"] is True
+
+
+# --- extract_semantic_single persists timeline on failure (#529 Copilot) ---
+
+class TestSingleExtractTimelinePersistedOnFailure:
+    """When extract_and_merge raises after mutating the in-memory timeline,
+    extract_semantic_single should still persist timeline.json alongside
+    catalogs/events so temporal progress is not lost."""
+
+    def test_timeline_saved_when_extract_and_merge_raises(self, monkeypatch, tmp_path):
+        framework_dir = str(tmp_path / "framework")
+        catalog_dir = os.path.join(framework_dir, "catalogs")
+        os.makedirs(catalog_dir, exist_ok=True)
+        session_dir = str(tmp_path / "session")
+        os.makedirs(session_dir, exist_ok=True)
+
+        llm = MagicMock()
+        llm.config = {}
+        monkeypatch.setattr(se, "LLMClient", lambda *a, **kw: llm)
+
+        mutated_entry = {"id": "time-001", "source_turn": "turn-001"}
+
+        def _raise_after_mutation(turn, catalogs, events_list, llm_, min_confidence,
+                                  catalog_dir=None, timeline=None, framework_dir=None):
+            # Simulate a temporal-phase mutation before the failure.
+            timeline.append(mutated_entry)
+            raise RuntimeError("boom during extraction")
+
+        monkeypatch.setattr(se, "extract_and_merge", _raise_after_mutation)
+
+        ok = se.extract_semantic_single(
+            "turn-001", "dm", "The DM describes the scene.",
+            session_dir, framework_dir=framework_dir,
+        )
+
+        assert ok is False
+
+        timeline_path = os.path.join(catalog_dir, "timeline.json")
+        assert os.path.exists(timeline_path), "timeline.json must be persisted on failure"
+        with open(timeline_path, "r", encoding="utf-8-sig") as f:
+            saved_timeline = json.load(f)
+        assert mutated_entry in saved_timeline
+
+        # Catalogs and events are also persisted (existing behaviour).
+        assert os.path.isdir(os.path.join(catalog_dir, "characters"))
+        assert os.path.exists(os.path.join(catalog_dir, "events.json"))

--- a/tools/ingest_turn.py
+++ b/tools/ingest_turn.py
@@ -97,12 +97,23 @@ def strip_turn_header(text: str) -> str:
     return text.strip()
 
 
-def run_semantic_extraction(turn_id, speaker, text, session_dir, args) -> None:
+def run_semantic_extraction(turn_id, speaker, text, session_dir, args) -> bool:
     """Run LLM-based semantic extraction (and DM profile analysis) for a turn.
 
     Shared by the normal --extract flow and the --extract-only flow so both
     use exactly the same extraction code path.
+
+    Returns:
+        ``True`` when semantic extraction completed successfully for the turn,
+        ``False`` when it could not run or reported a failure (LLM client
+        unavailable, the ``semantic_extraction`` module missing, a per-phase
+        extraction failure, or an unexpected error). Callers that need to
+        surface failure via the process exit code (e.g. ``--extract-only``)
+        can act on this; the normal ``--extract`` flow ignores it, preserving
+        existing behaviour. DM profile analysis failures do not affect the
+        returned extraction status.
     """
+    extraction_succeeded = False
     try:
         from semantic_extraction import extract_semantic_single
 
@@ -112,10 +123,10 @@ def run_semantic_extraction(turn_id, speaker, text, session_dir, args) -> None:
         if args.base_url:
             llm_overrides["base_url"] = args.base_url
 
-        extract_semantic_single(
+        extraction_succeeded = bool(extract_semantic_single(
             turn_id, speaker, text, session_dir, framework_dir=args.framework,
             overrides=llm_overrides or None,
-        )
+        ))
     except ModuleNotFoundError as exc:
         if exc.name == "semantic_extraction":
             print(
@@ -155,6 +166,8 @@ def run_semantic_extraction(turn_id, speaker, text, session_dir, args) -> None:
                 raise
         except Exception as exc:
             print(f"WARNING: DM profile analysis failed: {exc}", file=sys.stderr)
+
+    return extraction_succeeded
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -270,7 +283,15 @@ def main() -> None:
             sys.exit(1)
 
         print(f"Re-extracting {turn_id} ({speaker}) from {args.file}")
-        run_semantic_extraction(turn_id, speaker, text, session_dir, args)
+        extraction_succeeded = run_semantic_extraction(
+            turn_id, speaker, text, session_dir, args)
+        if not extraction_succeeded:
+            print(
+                f"ERROR: Semantic extraction failed for {turn_id}; "
+                "the turn was not re-extracted successfully.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         return
 
     transcript_dir = os.path.join(session_dir, "transcript")

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -4455,6 +4455,16 @@ def _extract_single_entity_detail(
     ):
         _filter_pc_attributes(entity_data)
         return entity_ref, entity_data, None
+    # Best-effort drop (#503): unrepairable, schema-invalid detail is discarded
+    # by returning ``(entity_ref, None, None)`` — a None error so the merge loop
+    # does NOT set turn_failed (unlike the ``str(e)`` LLM-error return above).
+    # The drop is recorded via ``validation_failures`` (auditable, not silent).
+    # We do not fail the turn here because the deterministic extractor would
+    # reproduce the same invalid detail on re-extraction -> a permanent
+    # ``--extract-only`` stall.  Mirrors the sequential path's best-effort drop.
+    # Known limitation (#528): for a NEW entity this drop loses the catalog
+    # record entirely (it stays only in discovery_proposals) — promoting a
+    # schema-valid stub is tracked there.
     return entity_ref, None, None
 
 
@@ -5829,6 +5839,20 @@ def extract_and_merge(
                 )
             if entity_data and not _filter_concept_prefix_from_items(entity_data):
                 continue
+            # Best-effort drop (#503): if entity_detail validation fails on
+            # unrepairable, schema-invalid LLM output, the malformed detail is
+            # discarded (this merge is skipped) but the turn is NOT failed.  The
+            # drop is recorded in the per-turn extraction log via
+            # ``validation_failures`` (drained at the end of extract_and_merge),
+            # so it is auditable, NOT silent.  We deliberately do not set
+            # turn_failed here: the extractor is deterministic, so re-extracting
+            # would reproduce the identical invalid detail -> a permanent
+            # ``--extract-only`` stall (and runaway refresh cost) on a turn the
+            # LLM cannot get right.  For existing entities the base record stays
+            # in the catalog (only enrichment is lost); a new entity's discovery
+            # is still recorded in ``discovery_proposals``.  Known limitation
+            # (#528): a NEW entity is lost from the catalog in this case —
+            # promoting a schema-valid stub is tracked there.
             if entity_data and _validate_entity_detail(
                 entity_data, turn=turn_id, entity_id=entity_id,
                 phase="entity_detail",
@@ -6121,7 +6145,14 @@ def extract_and_merge(
             else:
                 _phase_log["temporal_ok"] = True  # No signals is not an error
         except Exception as e:
+            # A RAISED error in this phase is a genuine extraction failure
+            # (consistent with the detail/relationship/event exception sites
+            # above, which all set turn_failed).  Flagging it lets
+            # ``--extract-only`` report a non-zero exit so the turn can be
+            # re-extracted.  The legitimate "no temporal signals" branch above
+            # is a success and must NOT set turn_failed.
             print(f"  WARNING: Temporal extraction failed for {turn_id}: {e}", file=sys.stderr)
+            turn_failed = True
             _phase_log["temporal_ok"] = False
             _phase_log["temporal_error"] = str(e)
 
@@ -9069,7 +9100,7 @@ def extract_semantic_single(
     config_path: str = "config/llm.json",
     min_confidence: float = DEFAULT_MIN_CONFIDENCE,
     overrides: dict | None = None,
-) -> None:
+) -> bool:
     """Run semantic extraction for a single new turn.
 
     Called from ingest_turn.py after writing the turn file.
@@ -9084,6 +9115,15 @@ def extract_semantic_single(
         min_confidence: Minimum confidence to catalog an entity.
         overrides: Optional dictionary of config key/value overrides passed to
             ``LLMClient`` to override settings loaded from ``config_path``.
+
+    Returns:
+        ``True`` when extraction completed successfully for the turn.
+        ``False`` when extraction could not run or reported a failure:
+        (a) the LLM client was unavailable, (b) ``extract_and_merge`` raised,
+        or (c) a per-phase extraction failure was reported
+        (``turn_failed=True``). Callers that need to detect failure (e.g.
+        ``ingest_turn.py --extract-only``) can use this to set the process
+        exit code; callers that ignore the return value are unaffected.
     """
     _reset_pc_failure_tracking()
 
@@ -9091,7 +9131,7 @@ def extract_semantic_single(
         llm = LLMClient(config_path, overrides=overrides)
     except (ImportError, LLMExtractionError, FileNotFoundError) as e:
         print(f"  WARNING: Semantic extraction not available: {e}", file=sys.stderr)
-        return
+        return False
 
     catalog_dir = os.path.join(framework_dir, "catalogs")
     extraction_log_path = os.path.join(framework_dir, "extraction-log.jsonl")
@@ -9136,7 +9176,7 @@ def extract_semantic_single(
         print(f"  ERROR at {turn_id}: {e}", file=sys.stderr)
         save_catalogs(catalog_dir, catalogs)
         save_events(catalog_dir, events_list)
-        return
+        return False
 
     _write_extraction_log(extraction_log_path, _turn_log)
 
@@ -9151,6 +9191,19 @@ def extract_semantic_single(
     save_catalogs(catalog_dir, catalogs)
     save_events(catalog_dir, events_list)
     save_timeline(catalog_dir, timeline)
+
+    # A per-phase extraction failure (turn_failed=True) means an LLM/parse
+    # phase failed and results may be zero/partial. The catalogs above are
+    # still saved (existing behaviour), but report failure so callers such as
+    # ``ingest_turn.py --extract-only`` can detect it via the exit code.
+    if _turn_failed:
+        print(
+            f"  WARNING: extraction reported a per-phase failure for {turn_id}; "
+            "results may be partial",
+            file=sys.stderr,
+        )
+        return False
+    return True
 
 
 def _save_progress(

--- a/tools/semantic_extraction.py
+++ b/tools/semantic_extraction.py
@@ -9174,8 +9174,13 @@ def extract_semantic_single(
         }
         _write_extraction_log(extraction_log_path, _turn_log)
         print(f"  ERROR at {turn_id}: {e}", file=sys.stderr)
+        # Preserve partial progress: persist catalogs, events, AND timeline.
+        # ``extract_and_merge`` may have mutated the in-memory timeline before
+        # raising; save it here so temporal signals are not lost and framework
+        # outputs stay consistent with the happy path (which saves all three).
         save_catalogs(catalog_dir, catalogs)
         save_events(catalog_dir, events_list)
+        save_timeline(catalog_dir, timeline)
         return False
 
     _write_extraction_log(extraction_log_path, _turn_log)


### PR DESCRIPTION
## Summary

Make `ingest_turn.py --extract-only` **honest about extraction failure** via its
process exit code, so automated / incremental callers (e.g. the private advisor's
incremental-extraction, Fix A — using `subprocess` with `check=True`) can detect a
failed re-extraction instead of silently advancing past an un-extracted turn.

## Exit-code contract

`--extract-only` now exits **non-zero (1)** when extraction actually **errors**
for the turn:

- the `LLMClient` is unavailable,
- `extract_and_merge` raises, or
- any non-PC phase reports an unrecoverable failure (an LLM/parse error, or an
  exception in the discovery / detail / relationship / event / **temporal**
  phase).

These are failures a re-extraction could fix.

It stays at exit **0** for the pipeline's intentional best-effort behaviour and
for legitimately empty turns:

- An unrepairable `entity_detail` schema-validation drop keeps `turn_failed=False`
  — the entity still merges from discovery, only the malformed enrichment is lost,
  and the drop is recorded in the per-turn log's `validation_failures` (auditable,
  not silent). Failing it would stall re-extraction permanently, since the
  deterministic extractor would reproduce the same invalid output.
- A turn that legitimately yields zero entities or no temporal signals exits 0.
- PC-extraction failures stay tracked separately (`pc_ok` / `pc_error`) and do not
  drive the exit code.

## Temporal-exception fix

A **raised** error in the temporal phase previously did **not** set
`turn_failed` (inconsistent with the detail/relationship/event exception sites).
It now sets `turn_failed=True`, so a temporal extraction error is reportable via
the non-zero exit and the turn is re-extractable. The legitimate "no temporal
signals" branch remains a success (exit 0).

## Batch path unchanged

`extract_semantic_batch` is **not** affected — it still continues past a per-turn
failure (its bulk-resume semantics are intentional).

## Testing

- Full suite: **~2283 passed** (no regressions).
- New tests in `tests/test_ingest_extract_only.py`:
  - `--extract-only` exits 0 on success / zero-entity turns; exits non-zero when
    the LLM is unavailable, `extract_and_merge` raises, or `turn_failed=True`.
  - `extract_semantic_single` returns an honest success bool for each case.
  - `extract_and_merge` flips `turn_failed` for a raised temporal error but not
    for "no temporal signals", a zero-entity turn, or a best-effort
    `entity_detail` validation-drop (which stays `turn_failed=False` yet is
    recorded in `validation_failures`).

## Adversarial review

Cleared a multi-round GPT-5.5 adversarial review. The one remaining block — the
**new-entity** detail-validation-drop (a NEW entity lost from the catalog when its
detail is unrepairable) — is triaged as a **low-priority backlog item, #528**:
measured **0 occurrences** in the real 189-turn Aurexara run (the #503/#504
instrumentation was live), so it is latent and does not currently affect the game.
Docs and the drop-site code comment reference #528 as a known limitation.

## Dependency note

This is a dependency for the private advisor's incremental-extraction (Fix A),
which relies on the `--extract-only` exit code to detect a failed re-extraction.

Refs #528 (backlog; intentionally left open — not closed by this PR).
