### PR TITLE
chore: gitignore local agent memory store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,8 @@ framework-eval-*/
 error.log
 setup_pg.sh
 *.task-prompt.md
+
+# Local agent memory store — never commit. Holds local-only operational notes
+# and secret-access hints; gitignoring it ensures a secret written there can
+# never be committed.
+memories/


### PR DESCRIPTION
## Summary

Add `memories/` to `.gitignore` so the local agent memory store is never committed.

The memory store is local-only and may hold operational notes and secret-access hints.
Gitignoring the directory guarantees that a secret accidentally written into a memory
file can never be committed to the repo.

## Changes

- `.gitignore`: add a `memories/` ignore rule with an explanatory comment.

## Notes

- No memory files were previously tracked (`git ls-files memories/` returned 0), so no
  untracking (`git rm --cached`) was needed; this is a pure additive ignore rule.
- Verified `git check-ignore memories/` matches the new rule after the change.

Trivial config change.
